### PR TITLE
Implement PoW Placeholder Algorithm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "generic-array 0.14.7",
 ]
 
@@ -45,7 +45,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher 0.4.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1021,6 +1021,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,7 +1245,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher 0.4.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1294,7 +1303,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
  "zeroize",
 ]
@@ -1442,7 +1451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "hex",
  "proptest",
  "serde",
@@ -1453,6 +1462,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -1579,6 +1594,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1808,6 +1832,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,7 +2054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -2224,7 +2257,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -2379,9 +2412,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
- "crypto-common",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle 2.6.1",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -3960,6 +4004,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4667,7 +4720,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -7196,7 +7249,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug 0.3.1",
  "universal-hash",
 ]
@@ -7208,7 +7261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug 0.3.1",
  "universal-hash",
 ]
@@ -9897,7 +9950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -9909,7 +9962,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug 0.3.1",
 ]
@@ -9921,8 +9974,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
+]
+
+[[package]]
+name = "sha256pow"
+version = "0.1.0"
+dependencies = [
+ "parity-scale-codec",
+ "sha2 0.11.0",
+ "sp-api",
+ "sp-consensus-pow",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10215,6 +10291,7 @@ dependencies = [
  "sc-transaction-pool",
  "sc-transaction-pool-api",
  "serde_json",
+ "sha256pow",
  "solochain-template-runtime",
  "sp-api",
  "sp-block-builder",
@@ -10258,6 +10335,7 @@ dependencies = [
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-consensus-grandpa",
+ "sp-consensus-pow",
  "sp-core",
  "sp-genesis-builder",
  "sp-inherents",
@@ -10450,6 +10528,18 @@ dependencies = [
  "sp-application-crypto",
  "sp-core",
  "sp-keystore",
+ "sp-runtime",
+]
+
+[[package]]
+name = "sp-consensus-pow"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60cebed0db0c193b52b939c9088b24178d316f367b82d76d79b732ac2675377"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api",
+ "sp-core",
  "sp-runtime",
 ]
 
@@ -12260,7 +12350,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle 2.6.1",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,12 +1464,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2257,7 +2251,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "zeroize",
 ]
 
@@ -2412,7 +2406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
+ "const-oid",
  "crypto-common 0.1.6",
  "subtle 2.6.1",
 ]
@@ -2424,7 +2418,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid 0.10.2",
  "crypto-common 0.2.1",
 ]
 
@@ -10358,6 +10351,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
+ "sha256pow",
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -7548,8 +7548,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -7568,8 +7568,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -7601,7 +7601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7614,7 +7614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8719,6 +8719,32 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-keystore",
+ "sp-runtime",
+ "substrate-prometheus-endpoint",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "sc-consensus-pow"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed80ba9e74323ce627ae7791436a4e633796b9143175b16078b70d3364636fe6"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-timer",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sc-client-api",
+ "sc-consensus",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-pow",
+ "sp-core",
+ "sp-inherents",
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
@@ -9994,6 +10020,7 @@ name = "sha256pow"
 version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
+ "sc-consensus-pow",
  "sha2 0.11.0",
  "sp-api",
  "sp-consensus-pow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ resolver = "2"
 
 [workspace.dependencies]
 solochain-template-runtime = { path = "./runtime", default-features = false }
-sha256pow = { path = "./consensus/sha256pow" }
+sha256pow = { path = "./consensus/sha256pow", default-features = false }
 pallet-template = { path = "./pallets/template", default-features = false }
 clap = { version = "4.6.0" }
 futures = { version = "0.3.32" }
 jsonrpsee = { version = "0.24.3" }
-sha2 = { version = "0.11.0" }
+sha2 = { version = "0.11.0", default-features = false }
 frame-benchmarking-cli = { version = "54.0.0", default-features = false }
 frame-metadata-hash-extension = { version = "0.14.0", default-features = false }
 frame-system = { version = "46.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ sc-client-api = { version = "45.0.0", default-features = false }
 sc-consensus = { version = "0.55.0", default-features = false }
 sc-consensus-aura = { version = "0.56.0", default-features = false }
 sc-consensus-grandpa = { version = "0.41.0", default-features = false }
+sc-consensus-pow = { version = "0.55.0", default-features = false }
 sc-executor = { version = "0.48.0", default-features = false }
 sc-network = { version = "0.56.0", default-features = false }
 sc-offchain = { version = "51.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [workspace]
 members = [
+    "consensus/sha256pow",
     "node",
     "pallets/template",
     "runtime",
@@ -15,13 +16,15 @@ resolver = "2"
 
 [workspace.dependencies]
 solochain-template-runtime = { path = "./runtime", default-features = false }
+sha256pow = { path = "./consensus/sha256pow" }
 pallet-template = { path = "./pallets/template", default-features = false }
 clap = { version = "4.6.0" }
+futures = { version = "0.3.32" }
+jsonrpsee = { version = "0.24.3" }
+sha2 = { version = "0.11.0" }
 frame-benchmarking-cli = { version = "54.0.0", default-features = false }
 frame-metadata-hash-extension = { version = "0.14.0", default-features = false }
 frame-system = { version = "46.0.0", default-features = false }
-futures = { version = "0.3.32" }
-jsonrpsee = { version = "0.24.3" }
 pallet-transaction-payment = { version = "46.0.0", default-features = false }
 pallet-transaction-payment-rpc = { version = "49.0.0", default-features = false }
 sc-basic-authorship = { version = "0.54.0", default-features = false }
@@ -66,6 +69,7 @@ pallet-transaction-payment-rpc-runtime-api = { version = "46.0.0", default-featu
 scale-info = { version = "2.11.6", default-features = false }
 serde_json = { version = "1.0.149", default-features = false }
 sp-consensus-grandpa = { version = "28.0.0", default-features = false }
+sp-consensus-pow = { version = "0.47.0", default-features = false }
 sp-offchain = { version = "41.0.0", default-features = false }
 sp-session = { version = "43.0.0", default-features = false }
 sp-storage = { version = "23.0.0", default-features = false }

--- a/consensus/sha256pow/Cargo.toml
+++ b/consensus/sha256pow/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sha256pow"
+description = "SHA-256 double-hash PoW placeholder algorithm for the crypto chain."
+version = "0.1.0"
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+codec = { features = ["derive"], workspace = true }
+sha2.workspace = true
+sp-api.default-features = true
+sp-api.workspace = true
+sp-consensus-pow.default-features = true
+sp-consensus-pow.workspace = true
+sp-core.default-features = true
+sp-core.workspace = true
+sp-runtime.default-features = true
+sp-runtime.workspace = true

--- a/consensus/sha256pow/Cargo.toml
+++ b/consensus/sha256pow/Cargo.toml
@@ -11,6 +11,8 @@ publish = false
 
 [dependencies]
 codec = { features = ["derive"], workspace = true }
+sc-consensus-pow.default-features = true
+sc-consensus-pow.workspace = true
 sha2.workspace = true
 sp-api.default-features = true
 sp-api.workspace = true

--- a/consensus/sha256pow/Cargo.toml
+++ b/consensus/sha256pow/Cargo.toml
@@ -11,14 +11,22 @@ publish = false
 
 [dependencies]
 codec = { features = ["derive"], workspace = true }
-sc-consensus-pow.default-features = true
-sc-consensus-pow.workspace = true
 sha2.workspace = true
-sp-api.default-features = true
 sp-api.workspace = true
-sp-consensus-pow.default-features = true
 sp-consensus-pow.workspace = true
-sp-core.default-features = true
 sp-core.workspace = true
-sp-runtime.default-features = true
-sp-runtime.workspace = true
+
+# std-only dependencies
+sc-consensus-pow = { workspace = true, default-features = true, optional = true }
+sp-runtime = { workspace = true, default-features = true, optional = true }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"sp-api/std",
+	"sp-consensus-pow/std",
+	"sp-core/std",
+	"sc-consensus-pow",
+	"sp-runtime/std",
+]

--- a/consensus/sha256pow/src/lib.rs
+++ b/consensus/sha256pow/src/lib.rs
@@ -8,6 +8,7 @@
 //! scheme (see issue #38).
 
 use codec::{Decode, Encode};
+use sc_consensus_pow::{Error, PowAlgorithm};
 use sha2::{Digest, Sha256};
 use sp_api::ProvideRuntimeApi;
 use sp_consensus_pow::DifficultyApi;
@@ -69,9 +70,8 @@ pub fn hash_meets_difficulty(hash: &H256, difficulty: U256) -> bool {
 /// SHA-256 double-hash PoW algorithm backed by a runtime `DifficultyApi`.
 ///
 /// The struct carries a client reference so it can query the runtime for
-/// the current target difficulty.  Its public API mirrors
-/// `sc_consensus_pow::PowAlgorithm` and will be wired into the actual trait
-/// implementation when the service integration lands (issue #4).
+/// the current target difficulty.  Implements `sc_consensus_pow::PowAlgorithm`
+/// so it can be used directly with `sc-consensus-pow` block import and mining.
 pub struct Sha256DoubleHashAlgorithm<B: BlockT, C> {
 	client: Arc<C>,
 	_phantom: PhantomData<B>,
@@ -90,18 +90,19 @@ impl<B: BlockT, C> Clone for Sha256DoubleHashAlgorithm<B, C> {
 	}
 }
 
-impl<B, C> Sha256DoubleHashAlgorithm<B, C>
+impl<B, C> PowAlgorithm<B> for Sha256DoubleHashAlgorithm<B, C>
 where
 	B: BlockT<Hash = H256>,
-	C: ProvideRuntimeApi<B>,
+	C: ProvideRuntimeApi<B> + Send + Sync,
 	C::Api: DifficultyApi<B, U256>,
 {
-	/// Fetch the target difficulty for the block **after** `parent`.
-	pub fn difficulty(&self, parent: B::Hash) -> Result<U256, String> {
+	type Difficulty = U256;
+
+	fn difficulty(&self, parent: B::Hash) -> Result<U256, Error<B>> {
 		self.client
 			.runtime_api()
 			.difficulty(parent)
-			.map_err(|err| format!("Fetching difficulty from runtime failed: {err:?}"))
+			.map_err(|err| Error::Other(format!("Fetching difficulty from runtime failed: {err:?}")))
 	}
 
 	/// Verify a raw seal against `pre_hash` and `difficulty`.
@@ -110,16 +111,16 @@ where
 	///   1. The seal can be SCALE-decoded.
 	///   2. The contained `work` hash meets the difficulty target.
 	///   3. Re-computing the hash from `pre_hash` and `nonce` reproduces `work`.
-	pub fn verify(
+	fn verify(
 		&self,
 		_parent: &BlockId<B>,
 		pre_hash: &B::Hash,
 		_pre_digest: Option<&[u8]>,
-		seal: &[u8],
+		seal: &sp_consensus_pow::Seal,
 		difficulty: U256,
-	) -> Result<bool, String> {
+	) -> Result<bool, Error<B>> {
 		let seal = Seal::decode(&mut &seal[..])
-			.map_err(|e| format!("Malformed seal: {e}"))?;
+			.map_err(Error::Codec)?;
 
 		if !hash_meets_difficulty(&seal.work, difficulty) {
 			return Ok(false);

--- a/consensus/sha256pow/src/lib.rs
+++ b/consensus/sha256pow/src/lib.rs
@@ -6,15 +6,22 @@
 //!
 //! This is an interim algorithm and will be replaced by an ASIC-resistant
 //! scheme (see issue #38).
+//!
+//! The core types ([`Seal`], [`Compute`], [`hash_meets_difficulty`],
+//! [`verify_seal`]) are `no_std`-compatible so the runtime can perform
+//! seal verification, making the algorithm hot-swappable via runtime
+//! upgrade.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+use alloc::vec::Vec;
 
 use codec::{Decode, Encode};
-use sc_consensus_pow::{Error, PowAlgorithm};
 use sha2::{Digest, Sha256};
-use sp_api::ProvideRuntimeApi;
-use sp_consensus_pow::DifficultyApi;
 use sp_core::{H256, U256};
-use sp_runtime::{generic::BlockId, traits::Block as BlockT};
-use std::{marker::PhantomData, sync::Arc};
+
+// ── Core types (no_std) ─────────────────────────────────────────────
 
 /// Seal produced by the miner, encoded into `Vec<u8>` for the block digest.
 #[derive(Clone, PartialEq, Eq, Encode, Decode, Debug)]
@@ -67,16 +74,64 @@ pub fn hash_meets_difficulty(hash: &H256, difficulty: U256) -> bool {
 	!overflowed
 }
 
-/// SHA-256 double-hash PoW algorithm backed by a runtime `DifficultyApi`.
+/// Standalone seal verification usable from both runtime and node.
 ///
-/// The struct carries a client reference so it can query the runtime for
-/// the current target difficulty.  Implements `sc_consensus_pow::PowAlgorithm`
-/// so it can be used directly with `sc-consensus-pow` block import and mining.
+/// Returns `Ok(true)` only when:
+///   1. The seal can be SCALE-decoded.
+///   2. The contained `work` hash meets the difficulty target.
+///   3. Re-computing the hash from `pre_hash` and `nonce` reproduces `work`.
+pub fn verify_seal(pre_hash: H256, raw_seal: &[u8], difficulty: U256) -> Result<bool, codec::Error> {
+	let seal = Seal::decode(&mut &raw_seal[..])?;
+
+	if !hash_meets_difficulty(&seal.work, difficulty) {
+		return Ok(false);
+	}
+
+	let compute = Compute { pre_hash, nonce: seal.nonce };
+	if compute.work() != seal.work {
+		return Ok(false);
+	}
+
+	Ok(true)
+}
+
+// ── Runtime API declaration (no_std) ────────────────────────────────
+
+sp_api::decl_runtime_apis! {
+	/// Runtime-side seal verification API.
+	///
+	/// Implementing this in the runtime makes the PoW algorithm
+	/// hot-swappable via a runtime upgrade.
+	pub trait PowVerifyApi {
+		fn verify_seal(pre_hash: H256, seal: Vec<u8>, difficulty: U256) -> bool;
+	}
+}
+
+// ── PowAlgorithm implementation (std only) ──────────────────────────
+
+#[cfg(feature = "std")]
+use sc_consensus_pow::{Error, PowAlgorithm};
+#[cfg(feature = "std")]
+use sp_api::ProvideRuntimeApi;
+#[cfg(feature = "std")]
+use sp_consensus_pow::DifficultyApi;
+#[cfg(feature = "std")]
+use sp_runtime::{generic::BlockId, traits::Block as BlockT};
+#[cfg(feature = "std")]
+use std::{marker::PhantomData, sync::Arc};
+
+/// SHA-256 double-hash PoW algorithm backed by a runtime `DifficultyApi`
+/// and `PowVerifyApi`.
+///
+/// Verification is delegated to the runtime so that the algorithm can be
+/// replaced by a runtime upgrade without restarting the node.
+#[cfg(feature = "std")]
 pub struct Sha256DoubleHashAlgorithm<B: BlockT, C> {
 	client: Arc<C>,
 	_phantom: PhantomData<B>,
 }
 
+#[cfg(feature = "std")]
 impl<B: BlockT, C> Sha256DoubleHashAlgorithm<B, C> {
 	/// Create a new algorithm instance backed by the given client.
 	pub fn new(client: Arc<C>) -> Self {
@@ -84,17 +139,19 @@ impl<B: BlockT, C> Sha256DoubleHashAlgorithm<B, C> {
 	}
 }
 
+#[cfg(feature = "std")]
 impl<B: BlockT, C> Clone for Sha256DoubleHashAlgorithm<B, C> {
 	fn clone(&self) -> Self {
 		Self { client: self.client.clone(), _phantom: PhantomData }
 	}
 }
 
+#[cfg(feature = "std")]
 impl<B, C> PowAlgorithm<B> for Sha256DoubleHashAlgorithm<B, C>
 where
 	B: BlockT<Hash = H256>,
 	C: ProvideRuntimeApi<B> + Send + Sync,
-	C::Api: DifficultyApi<B, U256>,
+	C::Api: DifficultyApi<B, U256> + PowVerifyApi<B>,
 {
 	type Difficulty = U256;
 
@@ -105,33 +162,25 @@ where
 			.map_err(|err| Error::Other(format!("Fetching difficulty from runtime failed: {err:?}")))
 	}
 
-	/// Verify a raw seal against `pre_hash` and `difficulty`.
-	///
-	/// Returns `Ok(true)` only when:
-	///   1. The seal can be SCALE-decoded.
-	///   2. The contained `work` hash meets the difficulty target.
-	///   3. Re-computing the hash from `pre_hash` and `nonce` reproduces `work`.
 	fn verify(
 		&self,
-		_parent: &BlockId<B>,
+		parent: &BlockId<B>,
 		pre_hash: &B::Hash,
 		_pre_digest: Option<&[u8]>,
 		seal: &sp_consensus_pow::Seal,
 		difficulty: U256,
 	) -> Result<bool, Error<B>> {
-		let seal = Seal::decode(&mut &seal[..])
-			.map_err(Error::Codec)?;
+		let parent_hash = match parent {
+			BlockId::Hash(h) => *h,
+			BlockId::Number(_) => {
+				return Err(Error::Other("BlockId::Number not supported for verify".into()));
+			},
+		};
 
-		if !hash_meets_difficulty(&seal.work, difficulty) {
-			return Ok(false);
-		}
-
-		let compute = Compute { pre_hash: *pre_hash, nonce: seal.nonce };
-		if compute.work() != seal.work {
-			return Ok(false);
-		}
-
-		Ok(true)
+		self.client
+			.runtime_api()
+			.verify_seal(parent_hash, *pre_hash, seal.clone(), difficulty)
+			.map_err(|err| Error::Runtime(format!("Runtime verify_seal failed: {err:?}")))
 	}
 }
 

--- a/consensus/sha256pow/src/lib.rs
+++ b/consensus/sha256pow/src/lib.rs
@@ -1,0 +1,217 @@
+//! SHA-256 double hash PoW placeholder algorithm.
+//!
+//! Algorithm: `SHA-256(SHA-256(pre_hash || nonce))` — the resulting hash is
+//! compared against a difficulty target using the multiplication-overflow
+//! method.
+//!
+//! This is an interim algorithm and will be replaced by an ASIC-resistant
+//! scheme (see issue #38).
+
+use codec::{Decode, Encode};
+use sha2::{Digest, Sha256};
+use sp_api::ProvideRuntimeApi;
+use sp_consensus_pow::DifficultyApi;
+use sp_core::{H256, U256};
+use sp_runtime::{generic::BlockId, traits::Block as BlockT};
+use std::{marker::PhantomData, sync::Arc};
+
+/// Seal produced by the miner, encoded into `Vec<u8>` for the block digest.
+#[derive(Clone, PartialEq, Eq, Encode, Decode, Debug)]
+pub struct Seal {
+	/// Nonce that satisfies the difficulty target.
+	pub nonce: U256,
+	/// Difficulty at which this seal was mined.
+	pub difficulty: U256,
+	/// Resulting double SHA-256 hash.
+	pub work: H256,
+}
+
+/// An un-evaluated mining attempt.  Call [`Compute::work`] to obtain the hash.
+#[derive(Clone, PartialEq, Eq, Encode, Decode, Debug)]
+pub struct Compute {
+	/// Block pre-hash (header hash without the seal digest).
+	pub pre_hash: H256,
+	/// Candidate nonce.
+	pub nonce: U256,
+}
+
+impl Compute {
+	/// `SHA-256(SHA-256(pre_hash || nonce))`
+	pub fn work(&self) -> H256 {
+		let mut buf = Vec::with_capacity(64);
+		buf.extend_from_slice(self.pre_hash.as_bytes());
+		buf.extend_from_slice(&self.nonce.encode());
+
+		let first = Sha256::digest(&buf);
+		let second = Sha256::digest(&first);
+
+		H256::from_slice(&second)
+	}
+
+	/// Mine: compute the work hash and bundle it into a [`Seal`].
+	pub fn seal(self, difficulty: U256) -> Seal {
+		let work = self.work();
+		Seal { nonce: self.nonce, difficulty, work }
+	}
+}
+
+/// Returns `true` when `hash` satisfies `difficulty`.
+///
+/// The check multiplies the numeric value of the hash by the difficulty.
+/// If the product overflows `U256`, the hash is too large (i.e. the work was
+/// not sufficient).
+pub fn hash_meets_difficulty(hash: &H256, difficulty: U256) -> bool {
+	let num_hash = U256::from_big_endian(hash.as_bytes());
+	let (_, overflowed) = num_hash.overflowing_mul(difficulty);
+	!overflowed
+}
+
+/// SHA-256 double-hash PoW algorithm backed by a runtime `DifficultyApi`.
+///
+/// The struct carries a client reference so it can query the runtime for
+/// the current target difficulty.  Its public API mirrors
+/// `sc_consensus_pow::PowAlgorithm` and will be wired into the actual trait
+/// implementation when the service integration lands (issue #4).
+pub struct Sha256DoubleHashAlgorithm<B: BlockT, C> {
+	client: Arc<C>,
+	_phantom: PhantomData<B>,
+}
+
+impl<B: BlockT, C> Sha256DoubleHashAlgorithm<B, C> {
+	/// Create a new algorithm instance backed by the given client.
+	pub fn new(client: Arc<C>) -> Self {
+		Self { client, _phantom: PhantomData }
+	}
+}
+
+impl<B: BlockT, C> Clone for Sha256DoubleHashAlgorithm<B, C> {
+	fn clone(&self) -> Self {
+		Self { client: self.client.clone(), _phantom: PhantomData }
+	}
+}
+
+impl<B, C> Sha256DoubleHashAlgorithm<B, C>
+where
+	B: BlockT<Hash = H256>,
+	C: ProvideRuntimeApi<B>,
+	C::Api: DifficultyApi<B, U256>,
+{
+	/// Fetch the target difficulty for the block **after** `parent`.
+	pub fn difficulty(&self, parent: B::Hash) -> Result<U256, String> {
+		self.client
+			.runtime_api()
+			.difficulty(parent)
+			.map_err(|err| format!("Fetching difficulty from runtime failed: {err:?}"))
+	}
+
+	/// Verify a raw seal against `pre_hash` and `difficulty`.
+	///
+	/// Returns `Ok(true)` only when:
+	///   1. The seal can be SCALE-decoded.
+	///   2. The contained `work` hash meets the difficulty target.
+	///   3. Re-computing the hash from `pre_hash` and `nonce` reproduces `work`.
+	pub fn verify(
+		&self,
+		_parent: &BlockId<B>,
+		pre_hash: &B::Hash,
+		_pre_digest: Option<&[u8]>,
+		seal: &[u8],
+		difficulty: U256,
+	) -> Result<bool, String> {
+		let seal = Seal::decode(&mut &seal[..])
+			.map_err(|e| format!("Malformed seal: {e}"))?;
+
+		if !hash_meets_difficulty(&seal.work, difficulty) {
+			return Ok(false);
+		}
+
+		let compute = Compute { pre_hash: *pre_hash, nonce: seal.nonce };
+		if compute.work() != seal.work {
+			return Ok(false);
+		}
+
+		Ok(true)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn compute_produces_deterministic_work() {
+		let c1 = Compute { pre_hash: H256::from_low_u64_be(42), nonce: U256::from(1) };
+		let c2 = c1.clone();
+		assert_eq!(c1.work(), c2.work());
+	}
+
+	#[test]
+	fn seal_roundtrip() {
+		let compute = Compute { pre_hash: H256::from_low_u64_be(99), nonce: U256::from(7) };
+		let seal = compute.seal(U256::from(1));
+		let encoded = seal.encode();
+		let decoded = Seal::decode(&mut &encoded[..]).expect("should decode");
+		assert_eq!(decoded, seal);
+	}
+
+	#[test]
+	fn trivial_difficulty_always_met() {
+		let compute = Compute { pre_hash: H256::from_low_u64_be(0), nonce: U256::from(0) };
+		let work = compute.work();
+		assert!(hash_meets_difficulty(&work, U256::from(1)));
+	}
+
+	#[test]
+	fn impossible_difficulty_never_met() {
+		let compute = Compute { pre_hash: H256::from_low_u64_be(1), nonce: U256::from(1) };
+		let work = compute.work();
+		assert!(!hash_meets_difficulty(&work, U256::MAX));
+	}
+
+	#[test]
+	fn mining_finds_valid_seal() {
+		let pre_hash = H256::from_low_u64_be(12345);
+		let difficulty = U256::from(10);
+
+		let mut nonce = U256::zero();
+		let seal = loop {
+			let compute = Compute { pre_hash, nonce };
+			let work = compute.work();
+			if hash_meets_difficulty(&work, difficulty) {
+				break compute.seal(difficulty);
+			}
+			nonce = nonce.saturating_add(U256::one());
+			assert!(nonce < U256::from(1_000_000), "should find a seal within 1M attempts");
+		};
+
+		assert!(hash_meets_difficulty(&seal.work, difficulty));
+	}
+
+	#[test]
+	fn malformed_seal_returns_decode_error() {
+		let garbage = vec![0xDE, 0xAD];
+		let result = Seal::decode(&mut &garbage[..]);
+		assert!(result.is_err(), "malformed bytes must fail to decode");
+	}
+
+	#[test]
+	fn wrong_nonce_rejected() {
+		let pre_hash = H256::from_low_u64_be(12345);
+		let difficulty = U256::from(10);
+
+		let mut nonce = U256::zero();
+		let mut seal = loop {
+			let compute = Compute { pre_hash, nonce };
+			let work = compute.work();
+			if hash_meets_difficulty(&work, difficulty) {
+				break compute.seal(difficulty);
+			}
+			nonce = nonce.saturating_add(U256::one());
+			assert!(nonce < U256::from(1_000_000));
+		};
+
+		seal.nonce = seal.nonce.saturating_add(U256::one());
+		let recomputed = Compute { pre_hash, nonce: seal.nonce }.work();
+		assert_ne!(recomputed, seal.work, "tampered nonce should produce different work");
+	}
+}

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -81,6 +81,7 @@ sp-timestamp.default-features = true
 sp-timestamp.workspace = true
 substrate-frame-rpc-system.default-features = true
 substrate-frame-rpc-system.workspace = true
+sha256pow.workspace = true
 
 [build-dependencies]
 substrate-build-script-utils.default-features = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -36,6 +36,7 @@ sp-api.workspace = true
 sp-block-builder.workspace = true
 sp-consensus-aura = { features = ["serde"], workspace = true }
 sp-consensus-grandpa = { features = ["serde"], workspace = true }
+sp-consensus-pow.workspace = true
 sp-core = { features = ["serde"], workspace = true }
 sp-genesis-builder.workspace = true
 sp-inherents.workspace = true
@@ -76,6 +77,7 @@ std = [
 	"sp-block-builder/std",
 	"sp-consensus-aura/std",
 	"sp-consensus-grandpa/std",
+	"sp-consensus-pow/std",
 	"sp-core/std",
 	"sp-genesis-builder/std",
 	"sp-inherents/std",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -32,6 +32,7 @@ pallet-transaction-payment-rpc-runtime-api.workspace = true
 pallet-transaction-payment.workspace = true
 scale-info = { features = ["derive", "serde"], workspace = true }
 serde_json = { workspace = true, default-features = false, features = ["alloc"] }
+sha256pow.workspace = true
 sp-api.workspace = true
 sp-block-builder.workspace = true
 sp-consensus-aura = { features = ["serde"], workspace = true }
@@ -73,6 +74,7 @@ std = [
 	"pallet-transaction-payment/std",
 	"scale-info/std",
 	"serde_json/std",
+	"sha256pow/std",
 	"sp-api/std",
 	"sp-block-builder/std",
 	"sp-consensus-aura/std",

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -32,13 +32,17 @@ use frame_support::{
 use pallet_grandpa::AuthorityId as GrandpaId;
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
+use sp_core::{crypto::KeyTypeId, OpaqueMetadata, U256};
 use sp_runtime::{
 	traits::{Block as BlockT, NumberFor},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult,
 };
 use sp_version::RuntimeVersion;
+
+/// Initial fixed mining difficulty.
+/// This will be replaced by a dynamic adjustment algorithm later.
+const INITIAL_DIFFICULTY: u64 = 1_000_000;
 
 // Local module imports
 use super::{
@@ -285,6 +289,12 @@ impl_runtime_apis! {
 			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).expect("execute-block failed")
+		}
+	}
+
+	impl sp_consensus_pow::DifficultyApi<Block, U256> for Runtime {
+		fn difficulty() -> U256 {
+			U256::from(INITIAL_DIFFICULTY)
 		}
 	}
 

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -298,6 +298,12 @@ impl_runtime_apis! {
 		}
 	}
 
+	impl sha256pow::PowVerifyApi<Block> for Runtime {
+		fn verify_seal(pre_hash: sp_core::H256, seal: Vec<u8>, difficulty: U256) -> bool {
+			sha256pow::verify_seal(pre_hash, &seal, difficulty).unwrap_or(false)
+		}
+	}
+
 	impl sp_genesis_builder::GenesisBuilder<Block> for Runtime {
 		fn build_state(config: Vec<u8>) -> sp_genesis_builder::Result {
 			build_state::<RuntimeGenesisConfig>(config)


### PR DESCRIPTION
## Summary

Implement an initial PoW mining algorithm using SHA-256 double hashing, with runtime-side verification as a pluggable module.

### Changes

### Node

- New crate: `consensus/sha256pow` (`no_std` compatible)
- Core types: `Seal` (nonce, difficulty, work) and `Compute` (pre_hash, nonce) with SCALE codec
- SHA-256 double hash: `Compute::work()` computes `SHA-256(SHA-256(pre_hash || nonce))`
- Difficulty check: `hash_meets_difficulty()` using the multiplication-overflow method
- Standalone verify: `verify_seal()` decodes, checks difficulty, and recomputes hash; usable from both runtime and node
- Runtime API: `PowVerifyApi` declared via `decl_runtime_apis!` for runtime-side seal verification
- `PowAlgorithm` impl: `Sha256DoubleHashAlgorithm` implements `sc_consensus_pow::PowAlgorithm`, delegating verification to the runtime API

### Runtime

- Implement `DifficultyApi` with a fixed initial difficulty (1,000,000)
- Implement `PowVerifyApi` delegating to `sha256pow::verify_seal()`

### Workspace

- Add `sc-consensus-pow`, `sp-consensus-pow`, `sha2` workspace dependencies
- Add `sha256pow` as dependency to both `node` and `runtime`

Closes #11  