### PR TITLE
Integrate PoW into Node Service Layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6336,6 +6336,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-reward"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-consensus-pow",
+ "sp-io",
+ "sp-keyring",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-session"
 version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10202,6 +10217,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "pallet-balances",
+ "pallet-reward",
  "pallet-sudo",
  "pallet-template",
  "pallet-timestamp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6213,23 +6213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-aura"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7f6e0f4710b9ce1bfa7473624987365550b718eef6b7ab2f8daf807a08d38f"
-dependencies = [
- "frame-support",
- "frame-system",
- "log",
- "pallet-timestamp",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto",
- "sp-consensus-aura",
- "sp-runtime",
-]
-
-[[package]]
 name = "pallet-authority-discovery"
 version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6317,29 +6300,6 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-runtime",
-]
-
-[[package]]
-name = "pallet-grandpa"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3546e596001808dd1c371b5237a0f11a85679a98a861535de04f9d486a95722f"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "pallet-authorship",
- "pallet-session",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-session",
- "sp-staking",
 ]
 
 [[package]]
@@ -8588,38 +8548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-consensus-aura"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbfd63937c546d873785b7fa311bc5a032bcd1593e6fb8af97ee6d545fec2e7"
-dependencies = [
- "async-trait",
- "fork-tree",
- "futures",
- "log",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "sc-block-builder",
- "sc-client-api",
- "sc-consensus",
- "sc-consensus-slots",
- "sc-telemetry",
- "sp-api",
- "sp-application-crypto",
- "sp-block-builder",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-aura",
- "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-keystore",
- "sp-runtime",
- "substrate-prometheus-endpoint",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "sc-consensus-babe"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8672,56 +8600,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-consensus-grandpa"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f8b9bab63814a10053d5eef9e349b198f69977442b61f8ad70c58dee1d66343"
-dependencies = [
- "ahash 0.8.12",
- "array-bytes 6.2.3",
- "async-trait",
- "dyn-clone",
- "finality-grandpa",
- "fork-tree",
- "futures",
- "futures-timer",
- "log",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "rand 0.8.5",
- "sc-block-builder",
- "sc-chain-spec",
- "sc-client-api",
- "sc-client-db",
- "sc-consensus",
- "sc-network",
- "sc-network-common",
- "sc-network-gossip",
- "sc-network-sync",
- "sc-network-types",
- "sc-telemetry",
- "sc-transaction-pool-api",
- "sc-utils",
- "serde_json",
- "sp-api",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-crypto-hashing",
- "sp-keystore",
- "sp-runtime",
- "substrate-prometheus-endpoint",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "sc-consensus-pow"
 version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed80ba9e74323ce627ae7791436a4e633796b9143175b16078b70d3364636fe6"
 dependencies = [
  "async-trait",
  "futures",
@@ -8956,26 +8836,6 @@ dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
  "sp-runtime",
-]
-
-[[package]]
-name = "sc-network-gossip"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9951cebee17b8e27ad61b2fbdc4c379297868e49a67d004a33c91c9898d8c68"
-dependencies = [
- "ahash 0.8.12",
- "futures",
- "futures-timer",
- "log",
- "sc-network",
- "sc-network-common",
- "sc-network-sync",
- "sc-network-types",
- "schnellru",
- "sp-runtime",
- "substrate-prometheus-endpoint",
- "tracing",
 ]
 
 [[package]]
@@ -10016,6 +9876,7 @@ dependencies = [
  "sc-consensus-pow",
  "sha2 0.11.0",
  "sp-api",
+ "sp-blockchain",
  "sp-consensus-pow",
  "sp-core",
  "sp-runtime",
@@ -10297,12 +10158,12 @@ dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc",
+ "parity-scale-codec",
  "sc-basic-authorship",
  "sc-cli",
  "sc-client-api",
  "sc-consensus",
- "sc-consensus-aura",
- "sc-consensus-grandpa",
+ "sc-consensus-pow",
  "sc-executor",
  "sc-network",
  "sc-offchain",
@@ -10316,7 +10177,7 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-consensus-aura",
+ "sp-consensus-pow",
  "sp-core",
  "sp-genesis-builder",
  "sp-inherents",
@@ -10340,9 +10201,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "pallet-aura",
  "pallet-balances",
- "pallet-grandpa",
  "pallet-sudo",
  "pallet-template",
  "pallet-timestamp",
@@ -10354,8 +10213,6 @@ dependencies = [
  "sha256pow",
  "sp-api",
  "sp-block-builder",
- "sp-consensus-aura",
- "sp-consensus-grandpa",
  "sp-consensus-pow",
  "sp-core",
  "sp-genesis-builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "consensus/sc-consensus-pow",
     "consensus/sha256pow",
     "node",
+    "pallets/reward",
     "pallets/template",
     "runtime",
 ]
@@ -18,6 +19,7 @@ resolver = "2"
 [workspace.dependencies]
 solochain-template-runtime = { path = "./runtime", default-features = false }
 sha256pow = { path = "./consensus/sha256pow", default-features = false }
+pallet-reward = { path = "./pallets/reward", default-features = false }
 pallet-template = { path = "./pallets/template", default-features = false }
 clap = { version = "4.6.0" }
 futures = { version = "0.3.32" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [workspace]
 members = [
+    "consensus/sc-consensus-pow",
     "consensus/sha256pow",
     "node",
     "pallets/template",
@@ -20,8 +21,13 @@ sha256pow = { path = "./consensus/sha256pow", default-features = false }
 pallet-template = { path = "./pallets/template", default-features = false }
 clap = { version = "4.6.0" }
 futures = { version = "0.3.32" }
+futures-timer = { version = "3.0.3" }
 jsonrpsee = { version = "0.24.3" }
 sha2 = { version = "0.11.0", default-features = false }
+async-trait = { version = "0.1.88" }
+log = { version = "0.4.27" }
+parking_lot = { version = "0.12.3" }
+thiserror = { version = "1.0.69" }
 frame-benchmarking-cli = { version = "54.0.0", default-features = false }
 frame-metadata-hash-extension = { version = "0.14.0", default-features = false }
 frame-system = { version = "46.0.0", default-features = false }
@@ -33,7 +39,7 @@ sc-client-api = { version = "45.0.0", default-features = false }
 sc-consensus = { version = "0.55.0", default-features = false }
 sc-consensus-aura = { version = "0.56.0", default-features = false }
 sc-consensus-grandpa = { version = "0.41.0", default-features = false }
-sc-consensus-pow = { version = "0.55.0", default-features = false }
+sc-consensus-pow = { path = "./consensus/sc-consensus-pow", default-features = false }
 sc-executor = { version = "0.48.0", default-features = false }
 sc-network = { version = "0.56.0", default-features = false }
 sc-offchain = { version = "51.0.0", default-features = false }
@@ -44,6 +50,7 @@ sc-transaction-pool-api = { version = "44.0.0", default-features = false }
 sp-api = { version = "41.0.0", default-features = false }
 sp-block-builder = { version = "41.0.0", default-features = false }
 sp-blockchain = { version = "44.0.0", default-features = false }
+sp-consensus = { version = "0.47.0", default-features = false }
 sp-consensus-aura = { version = "0.47.0", default-features = false }
 sp-core = { version = "40.0.0", default-features = false }
 sp-genesis-builder = { version = "0.22.0", default-features = false }
@@ -54,6 +61,7 @@ sp-runtime = { version = "46.0.0", default-features = false }
 sp-timestamp = { version = "41.0.0", default-features = false }
 substrate-frame-rpc-system = { version = "50.0.0", default-features = false }
 substrate-build-script-utils = { version = "11.0.0", default-features = false }
+substrate-prometheus-endpoint = { version = "0.17.7", default-features = false }
 codec = { version = "3.7.4", default-features = false, package = "parity-scale-codec" }
 frame-benchmarking = { version = "46.0.0", default-features = false }
 frame-executive = { version = "46.0.0", default-features = false }

--- a/consensus/sc-consensus-pow/Cargo.toml
+++ b/consensus/sc-consensus-pow/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "sc-consensus-pow"
+version = "0.55.0"
+description = "PoW consensus algorithm for substrate (vendored for sp-runtime 46 compatibility)"
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+async-trait.workspace = true
+codec = { features = ["derive"], workspace = true }
+futures.workspace = true
+futures-timer.workspace = true
+log.workspace = true
+parking_lot.workspace = true
+substrate-prometheus-endpoint.default-features = true
+substrate-prometheus-endpoint.workspace = true
+sc-client-api.default-features = true
+sc-client-api.workspace = true
+sc-consensus.default-features = true
+sc-consensus.workspace = true
+sp-api.default-features = true
+sp-api.workspace = true
+sp-block-builder.default-features = true
+sp-block-builder.workspace = true
+sp-blockchain.default-features = true
+sp-blockchain.workspace = true
+sp-consensus.default-features = true
+sp-consensus.workspace = true
+sp-consensus-pow.default-features = true
+sp-consensus-pow.workspace = true
+sp-core.default-features = true
+sp-core.workspace = true
+sp-inherents.default-features = true
+sp-inherents.workspace = true
+sp-runtime.default-features = true
+sp-runtime.workspace = true
+thiserror.workspace = true

--- a/consensus/sc-consensus-pow/src/lib.rs
+++ b/consensus/sc-consensus-pow/src/lib.rs
@@ -1,0 +1,683 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Proof of work consensus for Substrate.
+//!
+//! To use this engine, you can need to have a struct that implements
+//! [`PowAlgorithm`]. After that, pass an instance of the struct, along
+//! with other necessary client references to [`import_queue`] to setup
+//! the queue.
+//!
+//! This library also comes with an async mining worker, which can be
+//! started via the [`start_mining_worker`] function. It returns a worker
+//! handle together with a future. The future must be pulled. Through
+//! the worker handle, you can pull the metadata needed to start the
+//! mining process via [`MiningHandle::metadata`], and then do the actual
+//! mining on a standalone thread. Finally, when a seal is found, call
+//! [`MiningHandle::submit`] to build the block.
+//!
+//! The auxiliary storage for PoW engine only stores the total difficulty.
+//! For other storage requirements for particular PoW algorithm (such as
+//! the actual difficulty for each particular blocks), you can take a client
+//! reference in your [`PowAlgorithm`] implementation, and use a separate prefix
+//! for the auxiliary storage. It is also possible to just use the runtime
+//! as the storage, but it is not recommended as it won't work well with light
+//! clients.
+
+mod worker;
+
+pub use crate::worker::{MiningBuild, MiningHandle, MiningMetadata};
+
+use crate::worker::UntilImportedOrTimeout;
+use codec::{Decode, Encode};
+use futures::{Future, StreamExt};
+use log::*;
+use substrate_prometheus_endpoint::Registry;
+use sc_client_api::{self, backend::AuxStore, BlockOf, BlockchainEvents};
+use sc_consensus::{
+	BasicQueue, BlockCheckParams, BlockImport, BlockImportParams, BoxBlockImport,
+	BoxJustificationImport, ForkChoiceStrategy, ImportResult, Verifier,
+};
+use sp_api::ProvideRuntimeApi;
+use sp_block_builder::BlockBuilder as BlockBuilderApi;
+use sp_blockchain::HeaderBackend;
+use sp_consensus::{
+	Environment, Error as ConsensusError, ProposeArgs, Proposer, SelectChain, SyncOracle,
+};
+use sp_consensus_pow::{Seal, TotalDifficulty, POW_ENGINE_ID};
+use sp_inherents::{CreateInherentDataProviders, InherentDataProvider};
+use sp_runtime::{
+	generic::{BlockId, Digest, DigestItem},
+	traits::{Block as BlockT, Header as HeaderT},
+};
+use std::{cmp::Ordering, marker::PhantomData, sync::Arc, time::Duration};
+
+const LOG_TARGET: &str = "pow";
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error<B: BlockT> {
+	#[error("Header uses the wrong engine {0:?}")]
+	WrongEngine([u8; 4]),
+	#[error("Header {0:?} is unsealed")]
+	HeaderUnsealed(B::Hash),
+	#[error("PoW validation error: invalid seal")]
+	InvalidSeal,
+	#[error("PoW validation error: preliminary verification failed")]
+	FailedPreliminaryVerify,
+	#[error("Rejecting block too far in future")]
+	TooFarInFuture,
+	#[error("Fetching best header failed using select chain: {0}")]
+	BestHeaderSelectChain(ConsensusError),
+	#[error("Fetching best header failed: {0}")]
+	BestHeader(sp_blockchain::Error),
+	#[error("Best header does not exist")]
+	NoBestHeader,
+	#[error("Block proposing error: {0}")]
+	BlockProposingError(String),
+	#[error("Fetch best hash failed via select chain: {0}")]
+	BestHashSelectChain(ConsensusError),
+	#[error("Error with block built on {0:?}: {1}")]
+	BlockBuiltError(B::Hash, ConsensusError),
+	#[error("Creating inherents failed: {0}")]
+	CreateInherents(sp_inherents::Error),
+	#[error("Checking inherents failed: {0}")]
+	CheckInherents(sp_inherents::Error),
+	#[error(
+		"Checking inherents unknown error for identifier: {}",
+		String::from_utf8_lossy(.0)
+	)]
+	CheckInherentsUnknownError(sp_inherents::InherentIdentifier),
+	#[error("Multiple pre-runtime digests")]
+	MultiplePreRuntimeDigests,
+	#[error(transparent)]
+	Client(sp_blockchain::Error),
+	#[error(transparent)]
+	Codec(codec::Error),
+	#[error("{0}")]
+	Environment(String),
+	#[error("{0}")]
+	Runtime(String),
+	#[error("{0}")]
+	Other(String),
+}
+
+impl<B: BlockT> From<Error<B>> for String {
+	fn from(error: Error<B>) -> String {
+		error.to_string()
+	}
+}
+
+impl<B: BlockT> From<Error<B>> for ConsensusError {
+	fn from(error: Error<B>) -> ConsensusError {
+		ConsensusError::ClientImport(error.to_string())
+	}
+}
+
+/// Auxiliary storage prefix for PoW engine.
+pub const POW_AUX_PREFIX: [u8; 4] = *b"PoW:";
+
+/// Get the auxiliary storage key used by engine to store total difficulty.
+fn aux_key<T: AsRef<[u8]>>(hash: &T) -> Vec<u8> {
+	POW_AUX_PREFIX.iter().chain(hash.as_ref()).copied().collect()
+}
+
+/// Intermediate value passed to block importer.
+#[derive(Encode, Decode, Clone, Debug, Default)]
+pub struct PowIntermediate<Difficulty> {
+	/// Difficulty of the block, if known.
+	pub difficulty: Option<Difficulty>,
+}
+
+/// Intermediate key for PoW engine.
+pub static INTERMEDIATE_KEY: &[u8] = b"pow1";
+
+/// Auxiliary storage data for PoW.
+#[derive(Encode, Decode, Clone, Debug, Default)]
+pub struct PowAux<Difficulty> {
+	/// Difficulty of the current block.
+	pub difficulty: Difficulty,
+	/// Total difficulty up to current block.
+	pub total_difficulty: Difficulty,
+}
+
+impl<Difficulty> PowAux<Difficulty>
+where
+	Difficulty: Decode + Default,
+{
+	/// Read the auxiliary from client.
+	pub fn read<C: AuxStore, B: BlockT>(client: &C, hash: &B::Hash) -> Result<Self, Error<B>> {
+		let key = aux_key(&hash);
+
+		match client.get_aux(&key).map_err(Error::Client)? {
+			Some(bytes) => Self::decode(&mut &bytes[..]).map_err(Error::Codec),
+			None => Ok(Self::default()),
+		}
+	}
+}
+
+/// Algorithm used for proof of work.
+pub trait PowAlgorithm<B: BlockT> {
+	/// Difficulty for the algorithm.
+	type Difficulty: TotalDifficulty + Default + Encode + Decode + Ord + Clone + Copy;
+
+	/// Get the next block's difficulty.
+	///
+	/// This function will be called twice during the import process, so the implementation
+	/// should be properly cached.
+	fn difficulty(&self, parent: B::Hash) -> Result<Self::Difficulty, Error<B>>;
+	/// Verify that the seal is valid against given pre hash when parent block is not yet imported.
+	///
+	/// None means that preliminary verify is not available for this algorithm.
+	fn preliminary_verify(
+		&self,
+		_pre_hash: &B::Hash,
+		_seal: &Seal,
+	) -> Result<Option<bool>, Error<B>> {
+		Ok(None)
+	}
+	/// Break a fork choice tie.
+	///
+	/// By default this chooses the earliest block seen. Using uniform tie
+	/// breaking algorithms will help to protect against selfish mining.
+	///
+	/// Returns if the new seal should be considered best block.
+	fn break_tie(&self, _own_seal: &Seal, _new_seal: &Seal) -> bool {
+		false
+	}
+	/// Verify that the difficulty is valid against given seal.
+	fn verify(
+		&self,
+		parent: &BlockId<B>,
+		pre_hash: &B::Hash,
+		pre_digest: Option<&[u8]>,
+		seal: &Seal,
+		difficulty: Self::Difficulty,
+	) -> Result<bool, Error<B>>;
+}
+
+/// A block importer for PoW.
+pub struct PowBlockImport<B: BlockT, I, C, S, Algorithm, CIDP> {
+	algorithm: Algorithm,
+	inner: I,
+	select_chain: S,
+	client: Arc<C>,
+	create_inherent_data_providers: Arc<CIDP>,
+	check_inherents_after: <<B as BlockT>::Header as HeaderT>::Number,
+}
+
+impl<B: BlockT, I: Clone, C, S: Clone, Algorithm: Clone, CIDP> Clone
+	for PowBlockImport<B, I, C, S, Algorithm, CIDP>
+{
+	fn clone(&self) -> Self {
+		Self {
+			algorithm: self.algorithm.clone(),
+			inner: self.inner.clone(),
+			select_chain: self.select_chain.clone(),
+			client: self.client.clone(),
+			create_inherent_data_providers: self.create_inherent_data_providers.clone(),
+			check_inherents_after: self.check_inherents_after,
+		}
+	}
+}
+
+impl<B, I, C, S, Algorithm, CIDP> PowBlockImport<B, I, C, S, Algorithm, CIDP>
+where
+	B: BlockT,
+	I: BlockImport<B> + Send + Sync,
+	I::Error: Into<ConsensusError>,
+	C: ProvideRuntimeApi<B> + Send + Sync + HeaderBackend<B> + AuxStore + BlockOf,
+	C::Api: BlockBuilderApi<B>,
+	Algorithm: PowAlgorithm<B>,
+	CIDP: CreateInherentDataProviders<B, ()>,
+{
+	/// Create a new block import suitable to be used in PoW
+	pub fn new(
+		inner: I,
+		client: Arc<C>,
+		algorithm: Algorithm,
+		check_inherents_after: <<B as BlockT>::Header as HeaderT>::Number,
+		select_chain: S,
+		create_inherent_data_providers: CIDP,
+	) -> Self {
+		Self {
+			inner,
+			client,
+			algorithm,
+			check_inherents_after,
+			select_chain,
+			create_inherent_data_providers: Arc::new(create_inherent_data_providers),
+		}
+	}
+
+	async fn check_inherents(
+		&self,
+		block: B,
+		at_hash: B::Hash,
+		inherent_data_providers: CIDP::InherentDataProviders,
+	) -> Result<(), Error<B>> {
+		use sp_block_builder::CheckInherentsError;
+
+		if *block.header().number() < self.check_inherents_after {
+			return Ok(());
+		}
+
+		sp_block_builder::check_inherents(
+			self.client.clone(),
+			at_hash,
+			block,
+			&inherent_data_providers,
+		)
+		.await
+		.map_err(|e| match e {
+			CheckInherentsError::CreateInherentData(e) => Error::CreateInherents(e),
+			CheckInherentsError::Client(e) => Error::Client(e.into()),
+			CheckInherentsError::CheckInherents(e) => Error::CheckInherents(e),
+			CheckInherentsError::CheckInherentsUnknownError(id) => {
+				Error::CheckInherentsUnknownError(id)
+			},
+		})?;
+
+		Ok(())
+	}
+}
+
+#[async_trait::async_trait]
+impl<B, I, C, S, Algorithm, CIDP> BlockImport<B> for PowBlockImport<B, I, C, S, Algorithm, CIDP>
+where
+	B: BlockT,
+	I: BlockImport<B> + Send + Sync,
+	I::Error: Into<ConsensusError>,
+	S: SelectChain<B>,
+	C: ProvideRuntimeApi<B> + Send + Sync + HeaderBackend<B> + AuxStore + BlockOf,
+	C::Api: BlockBuilderApi<B>,
+	Algorithm: PowAlgorithm<B> + Send + Sync,
+	Algorithm::Difficulty: 'static + Send,
+	CIDP: CreateInherentDataProviders<B, ()> + Send + Sync,
+{
+	type Error = ConsensusError;
+
+	async fn check_block(&self, block: BlockCheckParams<B>) -> Result<ImportResult, Self::Error> {
+		self.inner.check_block(block).await.map_err(Into::into)
+	}
+
+	async fn import_block(
+		&self,
+		mut block: BlockImportParams<B>,
+	) -> Result<ImportResult, Self::Error> {
+		let best_header = self
+			.select_chain
+			.best_chain()
+			.await
+			.map_err(|e| format!("Fetch best chain failed via select chain: {}", e))
+			.map_err(ConsensusError::ChainLookup)?;
+		let best_hash = best_header.hash();
+
+		let parent_hash = *block.header.parent_hash();
+		let best_aux = PowAux::read::<_, B>(self.client.as_ref(), &best_hash)?;
+		let mut aux = PowAux::read::<_, B>(self.client.as_ref(), &parent_hash)?;
+
+		if let Some(inner_body) = block.body.take() {
+			let check_block = B::new(block.header.clone(), inner_body);
+
+			if !block.state_action.skip_execution_checks() {
+				self.check_inherents(
+					check_block.clone(),
+					parent_hash,
+					self.create_inherent_data_providers
+						.create_inherent_data_providers(parent_hash, ())
+						.await?,
+				)
+				.await?;
+			}
+
+			block.body = Some(check_block.deconstruct().1);
+		}
+
+		let inner_seal = fetch_seal::<B>(block.post_digests.last(), block.header.hash())?;
+
+		let intermediate = block
+			.remove_intermediate::<PowIntermediate<Algorithm::Difficulty>>(INTERMEDIATE_KEY)?;
+
+		let difficulty = match intermediate.difficulty {
+			Some(difficulty) => difficulty,
+			None => self.algorithm.difficulty(parent_hash)?,
+		};
+
+		let pre_hash = block.header.hash();
+		let pre_digest = find_pre_digest::<B>(&block.header)?;
+		if !self.algorithm.verify(
+			&BlockId::hash(parent_hash),
+			&pre_hash,
+			pre_digest.as_ref().map(|v| &v[..]),
+			&inner_seal,
+			difficulty,
+		)? {
+			return Err(Error::<B>::InvalidSeal.into());
+		}
+
+		aux.difficulty = difficulty;
+		aux.total_difficulty.increment(difficulty);
+
+		let key = aux_key(&block.post_hash());
+		block.auxiliary.push((key, Some(aux.encode())));
+		if block.fork_choice.is_none() {
+			block.fork_choice = Some(ForkChoiceStrategy::Custom(
+				match aux.total_difficulty.cmp(&best_aux.total_difficulty) {
+					Ordering::Less => false,
+					Ordering::Greater => true,
+					Ordering::Equal => {
+						let best_inner_seal =
+							fetch_seal::<B>(best_header.digest().logs.last(), best_hash)?;
+
+						self.algorithm.break_tie(&best_inner_seal, &inner_seal)
+					},
+				},
+			));
+		}
+
+		self.inner.import_block(block).await.map_err(Into::into)
+	}
+}
+
+/// A verifier for PoW blocks.
+pub struct PowVerifier<B: BlockT, Algorithm> {
+	algorithm: Algorithm,
+	_marker: PhantomData<B>,
+}
+
+impl<B: BlockT, Algorithm> PowVerifier<B, Algorithm> {
+	pub fn new(algorithm: Algorithm) -> Self {
+		Self { algorithm, _marker: PhantomData }
+	}
+
+	fn check_header(&self, mut header: B::Header) -> Result<(B::Header, DigestItem), Error<B>>
+	where
+		Algorithm: PowAlgorithm<B>,
+	{
+		let hash = header.hash();
+
+		let (seal, inner_seal) = match header.digest_mut().pop() {
+			Some(DigestItem::Seal(id, seal)) => {
+				if id == POW_ENGINE_ID {
+					(DigestItem::Seal(id, seal.clone()), seal)
+				} else {
+					return Err(Error::WrongEngine(id));
+				}
+			},
+			_ => return Err(Error::HeaderUnsealed(hash)),
+		};
+
+		let pre_hash = header.hash();
+
+		if !self.algorithm.preliminary_verify(&pre_hash, &inner_seal)?.unwrap_or(true) {
+			return Err(Error::FailedPreliminaryVerify);
+		}
+
+		Ok((header, seal))
+	}
+}
+
+#[async_trait::async_trait]
+impl<B: BlockT, Algorithm> Verifier<B> for PowVerifier<B, Algorithm>
+where
+	Algorithm: PowAlgorithm<B> + Send + Sync,
+	Algorithm::Difficulty: 'static + Send,
+{
+	async fn verify(
+		&self,
+		mut block: BlockImportParams<B>,
+	) -> Result<BlockImportParams<B>, String> {
+		let hash = block.header.hash();
+		let (checked_header, seal) = self.check_header(block.header)?;
+
+		let intermediate = PowIntermediate::<Algorithm::Difficulty> { difficulty: None };
+		block.header = checked_header;
+		block.post_digests.push(seal);
+		block.insert_intermediate(INTERMEDIATE_KEY, intermediate);
+		block.post_hash = Some(hash);
+
+		Ok(block)
+	}
+}
+
+/// The PoW import queue type.
+pub type PowImportQueue<B> = BasicQueue<B>;
+
+/// Import queue for PoW engine.
+pub fn import_queue<B, Algorithm>(
+	block_import: BoxBlockImport<B>,
+	justification_import: Option<BoxJustificationImport<B>>,
+	algorithm: Algorithm,
+	spawner: &impl sp_core::traits::SpawnEssentialNamed,
+	registry: Option<&Registry>,
+) -> Result<PowImportQueue<B>, sp_consensus::Error>
+where
+	B: BlockT,
+	Algorithm: PowAlgorithm<B> + Clone + Send + Sync + 'static,
+	Algorithm::Difficulty: Send,
+{
+	let verifier = PowVerifier::new(algorithm);
+
+	Ok(BasicQueue::new(verifier, block_import, justification_import, spawner, registry))
+}
+
+/// Start the mining worker for PoW. This function provides the necessary helper functions that can
+/// be used to implement a miner. However, it does not do the CPU-intensive mining itself.
+///
+/// Two values are returned -- a worker, which contains functions that allows querying the current
+/// mining metadata and submitting mined blocks, and a future, which must be polled to fill in
+/// information in the worker.
+///
+/// `pre_runtime` is a parameter that allows a custom additional pre-runtime digest to be inserted
+/// for blocks being built. This can encode authorship information, or just be a graffiti.
+pub fn start_mining_worker<Block, C, S, Algorithm, E, SO, L, CIDP>(
+	block_import: BoxBlockImport<Block>,
+	client: Arc<C>,
+	select_chain: S,
+	algorithm: Algorithm,
+	mut env: E,
+	sync_oracle: SO,
+	justification_sync_link: L,
+	pre_runtime: Option<Vec<u8>>,
+	create_inherent_data_providers: CIDP,
+	timeout: Duration,
+	build_time: Duration,
+) -> (MiningHandle<Block, Algorithm, L>, impl Future<Output = ()>)
+where
+	Block: BlockT,
+	C: BlockchainEvents<Block> + 'static,
+	S: SelectChain<Block> + 'static,
+	Algorithm: PowAlgorithm<Block> + Clone,
+	Algorithm::Difficulty: Send + 'static,
+	E: Environment<Block> + Send + Sync + 'static,
+	E::Error: std::fmt::Debug,
+	E::Proposer: Proposer<Block>,
+	SO: SyncOracle + Clone + Send + Sync + 'static,
+	L: sc_consensus::JustificationSyncLink<Block>,
+	CIDP: CreateInherentDataProviders<Block, ()>,
+{
+	let mut timer = UntilImportedOrTimeout::new(client.import_notification_stream(), timeout);
+	let worker = MiningHandle::new(algorithm.clone(), block_import, justification_sync_link);
+	let worker_ret = worker.clone();
+
+	let task = async move {
+		loop {
+			if timer.next().await.is_none() {
+				break;
+			}
+
+			if sync_oracle.is_major_syncing() {
+				debug!(target: LOG_TARGET, "Skipping proposal due to sync.");
+				worker.on_major_syncing();
+				continue;
+			}
+
+			let best_header = match select_chain.best_chain().await {
+				Ok(x) => x,
+				Err(err) => {
+					warn!(
+						target: LOG_TARGET,
+						"Unable to pull new block for authoring. \
+						 Select best chain error: {}",
+						err
+					);
+					continue;
+				},
+			};
+			let best_hash = best_header.hash();
+
+			if worker.best_hash() == Some(best_hash) {
+				continue;
+			}
+
+			// The worker is locked for the duration of the whole proposing period. Within this
+			// period, the mining target is outdated and useless anyway.
+
+			let difficulty = match algorithm.difficulty(best_hash) {
+				Ok(x) => x,
+				Err(err) => {
+					warn!(
+						target: LOG_TARGET,
+						"Unable to propose new block for authoring. \
+						 Fetch difficulty failed: {}",
+						err,
+					);
+					continue;
+				},
+			};
+
+			let inherent_data_providers = match create_inherent_data_providers
+				.create_inherent_data_providers(best_hash, ())
+				.await
+			{
+				Ok(x) => x,
+				Err(err) => {
+					warn!(
+						target: LOG_TARGET,
+						"Unable to propose new block for authoring. \
+						 Creating inherent data providers failed: {}",
+						err,
+					);
+					continue;
+				},
+			};
+
+			let inherent_data = match inherent_data_providers.create_inherent_data().await {
+				Ok(r) => r,
+				Err(e) => {
+					warn!(
+						target: LOG_TARGET,
+						"Unable to propose new block for authoring. \
+						 Creating inherent data failed: {}",
+						e,
+					);
+					continue;
+				},
+			};
+
+			let mut inherent_digests = Digest::default();
+			if let Some(pre_runtime) = &pre_runtime {
+				inherent_digests.push(DigestItem::PreRuntime(POW_ENGINE_ID, pre_runtime.to_vec()));
+			}
+
+			let pre_runtime = pre_runtime.clone();
+
+			let proposer = match env.init(&best_header).await {
+				Ok(x) => x,
+				Err(err) => {
+					warn!(
+						target: LOG_TARGET,
+						"Unable to propose new block for authoring. \
+						 Creating proposer failed: {:?}",
+						err,
+					);
+					continue;
+				},
+			};
+
+			let propose_args = ProposeArgs {
+				inherent_data,
+				inherent_digests,
+				max_duration: build_time,
+				block_size_limit: None,
+				storage_proof_recorder: None,
+				extra_extensions: Default::default(),
+			};
+
+			let proposal = match proposer.propose(propose_args).await {
+				Ok(x) => x,
+				Err(err) => {
+					warn!(
+						target: LOG_TARGET,
+						"Unable to propose new block for authoring. \
+						 Creating proposal failed: {}",
+						err,
+					);
+					continue;
+				},
+			};
+
+			let build = MiningBuild::<Block, Algorithm> {
+				metadata: MiningMetadata {
+					best_hash,
+					pre_hash: proposal.block.header().hash(),
+					pre_runtime: pre_runtime.clone(),
+					difficulty,
+				},
+				proposal,
+			};
+
+			worker.on_build(build);
+		}
+	};
+
+	(worker_ret, task)
+}
+
+/// Find PoW pre-runtime.
+fn find_pre_digest<B: BlockT>(header: &B::Header) -> Result<Option<Vec<u8>>, Error<B>> {
+	let mut pre_digest: Option<_> = None;
+	for log in header.digest().logs() {
+		trace!(target: LOG_TARGET, "Checking log {:?}, looking for pre runtime digest", log);
+		match (log, pre_digest.is_some()) {
+			(DigestItem::PreRuntime(POW_ENGINE_ID, _), true) => {
+				return Err(Error::MultiplePreRuntimeDigests)
+			},
+			(DigestItem::PreRuntime(POW_ENGINE_ID, v), false) => {
+				pre_digest = Some(v.clone());
+			},
+			(_, _) => trace!(target: LOG_TARGET, "Ignoring digest not meant for us"),
+		}
+	}
+
+	Ok(pre_digest)
+}
+
+/// Fetch PoW seal.
+fn fetch_seal<B: BlockT>(digest: Option<&DigestItem>, hash: B::Hash) -> Result<Vec<u8>, Error<B>> {
+	match digest {
+		Some(DigestItem::Seal(id, seal)) => {
+			if id == &POW_ENGINE_ID {
+				Ok(seal.clone())
+			} else {
+				Err(Error::<B>::WrongEngine(*id))
+			}
+		},
+		_ => Err(Error::<B>::HeaderUnsealed(hash)),
+	}
+}

--- a/consensus/sc-consensus-pow/src/worker.rs
+++ b/consensus/sc-consensus-pow/src/worker.rs
@@ -1,0 +1,282 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use futures::{
+	prelude::*,
+	task::{Context, Poll},
+};
+use futures_timer::Delay;
+use log::*;
+use parking_lot::Mutex;
+use sc_client_api::ImportNotifications;
+use sc_consensus::{BlockImportParams, BoxBlockImport, StateAction, StorageChanges};
+use sp_consensus::{BlockOrigin, Proposal};
+use sp_runtime::{
+	generic::BlockId,
+	traits::{Block as BlockT, Header as HeaderT},
+	DigestItem,
+};
+use std::{
+	pin::Pin,
+	sync::{
+		atomic::{AtomicUsize, Ordering},
+		Arc,
+	},
+	time::Duration,
+};
+
+use crate::{PowAlgorithm, PowIntermediate, Seal, INTERMEDIATE_KEY, LOG_TARGET, POW_ENGINE_ID};
+
+/// Mining metadata. This is the information needed to start an actual mining loop.
+#[derive(Clone, Eq, PartialEq)]
+pub struct MiningMetadata<H, D> {
+	/// Currently known best hash which the pre-hash is built on.
+	pub best_hash: H,
+	/// Mining pre-hash.
+	pub pre_hash: H,
+	/// Pre-runtime digest item.
+	pub pre_runtime: Option<Vec<u8>>,
+	/// Mining target difficulty.
+	pub difficulty: D,
+}
+
+/// A build of mining, containing the metadata and the block proposal.
+pub struct MiningBuild<Block: BlockT, Algorithm: PowAlgorithm<Block>> {
+	/// Mining metadata.
+	pub metadata: MiningMetadata<Block::Hash, Algorithm::Difficulty>,
+	/// Mining proposal.
+	pub proposal: Proposal<Block>,
+}
+
+/// Version of the mining worker.
+#[derive(Eq, PartialEq, Clone, Copy)]
+pub struct Version(usize);
+
+/// Mining worker that exposes structs to query the current mining build and submit mined blocks.
+pub struct MiningHandle<
+	Block: BlockT,
+	Algorithm: PowAlgorithm<Block>,
+	L: sc_consensus::JustificationSyncLink<Block>,
+> {
+	version: Arc<AtomicUsize>,
+	algorithm: Arc<Algorithm>,
+	justification_sync_link: Arc<L>,
+	build: Arc<Mutex<Option<MiningBuild<Block, Algorithm>>>>,
+	block_import: Arc<Mutex<BoxBlockImport<Block>>>,
+}
+
+impl<Block, Algorithm, L> MiningHandle<Block, Algorithm, L>
+where
+	Block: BlockT,
+	Algorithm: PowAlgorithm<Block>,
+	Algorithm::Difficulty: 'static + Send,
+	L: sc_consensus::JustificationSyncLink<Block>,
+{
+	fn increment_version(&self) {
+		self.version.fetch_add(1, Ordering::SeqCst);
+	}
+
+	pub(crate) fn new(
+		algorithm: Algorithm,
+		block_import: BoxBlockImport<Block>,
+		justification_sync_link: L,
+	) -> Self {
+		Self {
+			version: Arc::new(AtomicUsize::new(0)),
+			algorithm: Arc::new(algorithm),
+			justification_sync_link: Arc::new(justification_sync_link),
+			build: Arc::new(Mutex::new(None)),
+			block_import: Arc::new(Mutex::new(block_import)),
+		}
+	}
+
+	pub(crate) fn on_major_syncing(&self) {
+		let mut build = self.build.lock();
+		*build = None;
+		self.increment_version();
+	}
+
+	pub(crate) fn on_build(&self, value: MiningBuild<Block, Algorithm>) {
+		let mut build = self.build.lock();
+		*build = Some(value);
+		self.increment_version();
+	}
+
+	/// Get the version of the mining worker.
+	///
+	/// This returns type `Version` which can only compare equality. If `Version` is unchanged, then
+	/// it can be certain that `best_hash` and `metadata` were not changed.
+	pub fn version(&self) -> Version {
+		Version(self.version.load(Ordering::SeqCst))
+	}
+
+	/// Get the current best hash. `None` if the worker has just started or the client is doing
+	/// major syncing.
+	pub fn best_hash(&self) -> Option<Block::Hash> {
+		self.build.lock().as_ref().map(|b| b.metadata.best_hash)
+	}
+
+	/// Get a copy of the current mining metadata, if available.
+	pub fn metadata(&self) -> Option<MiningMetadata<Block::Hash, Algorithm::Difficulty>> {
+		self.build.lock().as_ref().map(|b| b.metadata.clone())
+	}
+
+	/// Submit a mined seal. The seal will be validated again. Returns true if the submission is
+	/// successful.
+	pub async fn submit(&self, seal: Seal) -> bool {
+		if let Some(metadata) = self.metadata() {
+			match self.algorithm.verify(
+				&BlockId::Hash(metadata.best_hash),
+				&metadata.pre_hash,
+				metadata.pre_runtime.as_ref().map(|v| &v[..]),
+				&seal,
+				metadata.difficulty,
+			) {
+				Ok(true) => (),
+				Ok(false) => {
+					warn!(target: LOG_TARGET, "Unable to import mined block: seal is invalid",);
+					return false;
+				},
+				Err(err) => {
+					warn!(target: LOG_TARGET, "Unable to import mined block: {}", err,);
+					return false;
+				},
+			}
+		} else {
+			warn!(target: LOG_TARGET, "Unable to import mined block: metadata does not exist",);
+			return false;
+		}
+
+		let build = if let Some(build) = {
+			let mut build = self.build.lock();
+			let value = build.take();
+			if value.is_some() {
+				self.increment_version();
+			}
+			value
+		} {
+			build
+		} else {
+			warn!(target: LOG_TARGET, "Unable to import mined block: build does not exist",);
+			return false;
+		};
+
+		let seal = DigestItem::Seal(POW_ENGINE_ID, seal);
+		let (header, body) = build.proposal.block.deconstruct();
+
+		let mut import_block = BlockImportParams::new(BlockOrigin::Own, header);
+		import_block.post_digests.push(seal);
+		import_block.body = Some(body);
+		import_block.state_action =
+			StateAction::ApplyChanges(StorageChanges::Changes(build.proposal.storage_changes));
+
+		let intermediate = PowIntermediate::<Algorithm::Difficulty> {
+			difficulty: Some(build.metadata.difficulty),
+		};
+		import_block.insert_intermediate(INTERMEDIATE_KEY, intermediate);
+
+		let header = import_block.post_header();
+		let block_import = self.block_import.lock();
+
+		match block_import.import_block(import_block).await {
+			Ok(res) => {
+				res.handle_justification(
+					&header.hash(),
+					*header.number(),
+					&self.justification_sync_link,
+				);
+
+				info!(
+					target: LOG_TARGET,
+					"✅ Successfully mined block on top of: {}", build.metadata.best_hash
+				);
+				true
+			},
+			Err(err) => {
+				warn!(target: LOG_TARGET, "Unable to import mined block: {}", err,);
+				false
+			},
+		}
+	}
+}
+
+impl<Block, Algorithm, L> Clone for MiningHandle<Block, Algorithm, L>
+where
+	Block: BlockT,
+	Algorithm: PowAlgorithm<Block>,
+	L: sc_consensus::JustificationSyncLink<Block>,
+{
+	fn clone(&self) -> Self {
+		Self {
+			version: self.version.clone(),
+			algorithm: self.algorithm.clone(),
+			justification_sync_link: self.justification_sync_link.clone(),
+			build: self.build.clone(),
+			block_import: self.block_import.clone(),
+		}
+	}
+}
+
+/// A stream that waits for a block import or timeout.
+pub struct UntilImportedOrTimeout<Block: BlockT> {
+	import_notifications: ImportNotifications<Block>,
+	timeout: Duration,
+	inner_delay: Option<Delay>,
+}
+
+impl<Block: BlockT> UntilImportedOrTimeout<Block> {
+	/// Create a new stream using the given import notification and timeout duration.
+	pub fn new(import_notifications: ImportNotifications<Block>, timeout: Duration) -> Self {
+		Self { import_notifications, timeout, inner_delay: None }
+	}
+}
+
+impl<Block: BlockT> Stream for UntilImportedOrTimeout<Block> {
+	type Item = ();
+
+	fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<()>> {
+		let mut fire = false;
+
+		loop {
+			match Stream::poll_next(Pin::new(&mut self.import_notifications), cx) {
+				Poll::Pending => break,
+				Poll::Ready(Some(_)) => {
+					fire = true;
+				},
+				Poll::Ready(None) => return Poll::Ready(None),
+			}
+		}
+
+		let timeout = self.timeout;
+		let inner_delay = self.inner_delay.get_or_insert_with(|| Delay::new(timeout));
+
+		match Future::poll(Pin::new(inner_delay), cx) {
+			Poll::Pending => (),
+			Poll::Ready(()) => {
+				fire = true;
+			},
+		}
+
+		if fire {
+			self.inner_delay = None;
+			Poll::Ready(Some(()))
+		} else {
+			Poll::Pending
+		}
+	}
+}

--- a/consensus/sha256pow/Cargo.toml
+++ b/consensus/sha256pow/Cargo.toml
@@ -18,6 +18,7 @@ sp-core.workspace = true
 
 # std-only dependencies
 sc-consensus-pow = { workspace = true, default-features = true, optional = true }
+sp-blockchain = { workspace = true, default-features = true, optional = true }
 sp-runtime = { workspace = true, default-features = true, optional = true }
 
 [features]
@@ -28,5 +29,6 @@ std = [
 	"sp-consensus-pow/std",
 	"sp-core/std",
 	"sc-consensus-pow",
+	"sp-blockchain",
 	"sp-runtime/std",
 ]

--- a/consensus/sha256pow/src/lib.rs
+++ b/consensus/sha256pow/src/lib.rs
@@ -268,4 +268,96 @@ mod tests {
 		let recomputed = Compute { pre_hash, nonce: seal.nonce }.work();
 		assert_ne!(recomputed, seal.work, "tampered nonce should produce different work");
 	}
+
+	#[test]
+	fn verify_seal_accepts_valid_seal() {
+		let pre_hash = H256::from_low_u64_be(12345);
+		let difficulty = U256::from(10);
+
+		let mut nonce = U256::zero();
+		let seal = loop {
+			let compute = Compute { pre_hash, nonce };
+			let work = compute.work();
+			if hash_meets_difficulty(&work, difficulty) {
+				break compute.seal(difficulty);
+			}
+			nonce = nonce.saturating_add(U256::one());
+			assert!(nonce < U256::from(1_000_000));
+		};
+
+		let encoded = seal.encode();
+		assert_eq!(verify_seal(pre_hash, &encoded, difficulty), Ok(true));
+	}
+
+	#[test]
+	fn verify_seal_rejects_insufficient_difficulty() {
+		let pre_hash = H256::from_low_u64_be(12345);
+		let easy_difficulty = U256::from(2);
+
+		let mut nonce = U256::zero();
+		let seal = loop {
+			let compute = Compute { pre_hash, nonce };
+			let work = compute.work();
+			if hash_meets_difficulty(&work, easy_difficulty) {
+				break compute.seal(easy_difficulty);
+			}
+			nonce = nonce.saturating_add(U256::one());
+			assert!(nonce < U256::from(1_000_000));
+		};
+
+		let encoded = seal.encode();
+		// Valid at easy difficulty
+		assert_eq!(verify_seal(pre_hash, &encoded, easy_difficulty), Ok(true));
+		// Rejected at much harder difficulty
+		assert_eq!(verify_seal(pre_hash, &encoded, U256::MAX), Ok(false));
+	}
+
+	#[test]
+	fn verify_seal_rejects_tampered_work() {
+		let pre_hash = H256::from_low_u64_be(12345);
+		let difficulty = U256::from(10);
+
+		let mut nonce = U256::zero();
+		let mut seal = loop {
+			let compute = Compute { pre_hash, nonce };
+			let work = compute.work();
+			if hash_meets_difficulty(&work, difficulty) {
+				break compute.seal(difficulty);
+			}
+			nonce = nonce.saturating_add(U256::one());
+			assert!(nonce < U256::from(1_000_000));
+		};
+
+		// Tamper with the nonce (work hash no longer matches)
+		seal.nonce = seal.nonce.saturating_add(U256::one());
+		let encoded = seal.encode();
+		assert_eq!(verify_seal(pre_hash, &encoded, difficulty), Ok(false));
+	}
+
+	#[test]
+	fn verify_seal_rejects_wrong_pre_hash() {
+		let pre_hash = H256::from_low_u64_be(12345);
+		let difficulty = U256::from(10);
+
+		let mut nonce = U256::zero();
+		let seal = loop {
+			let compute = Compute { pre_hash, nonce };
+			let work = compute.work();
+			if hash_meets_difficulty(&work, difficulty) {
+				break compute.seal(difficulty);
+			}
+			nonce = nonce.saturating_add(U256::one());
+			assert!(nonce < U256::from(1_000_000));
+		};
+
+		let encoded = seal.encode();
+		let wrong_pre_hash = H256::from_low_u64_be(99999);
+		assert_eq!(verify_seal(wrong_pre_hash, &encoded, difficulty), Ok(false));
+	}
+
+	#[test]
+	fn verify_seal_rejects_malformed_bytes() {
+		let garbage = vec![0xDE, 0xAD];
+		assert!(verify_seal(H256::zero(), &garbage, U256::from(1)).is_err());
+	}
 }

--- a/consensus/sha256pow/src/lib.rs
+++ b/consensus/sha256pow/src/lib.rs
@@ -18,6 +18,8 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use codec::{Decode, Encode};
+#[cfg(feature = "std")]
+use sc_consensus_pow::{Error as PowError, PowAlgorithm};
 use sha2::{Digest, Sha256};
 use sp_core::{H256, U256};
 
@@ -110,8 +112,6 @@ sp_api::decl_runtime_apis! {
 // ── PowAlgorithm implementation (std only) ──────────────────────────
 
 #[cfg(feature = "std")]
-use sc_consensus_pow::{Error, PowAlgorithm};
-#[cfg(feature = "std")]
 use sp_api::ProvideRuntimeApi;
 #[cfg(feature = "std")]
 use sp_consensus_pow::DifficultyApi;
@@ -150,16 +150,18 @@ impl<B: BlockT, C> Clone for Sha256DoubleHashAlgorithm<B, C> {
 impl<B, C> PowAlgorithm<B> for Sha256DoubleHashAlgorithm<B, C>
 where
 	B: BlockT<Hash = H256>,
-	C: ProvideRuntimeApi<B> + Send + Sync,
+	C: ProvideRuntimeApi<B> + sp_blockchain::HeaderBackend<B> + Send + Sync,
 	C::Api: DifficultyApi<B, U256> + PowVerifyApi<B>,
 {
 	type Difficulty = U256;
 
-	fn difficulty(&self, parent: B::Hash) -> Result<U256, Error<B>> {
+	fn difficulty(&self, parent: B::Hash) -> Result<U256, PowError<B>> {
 		self.client
 			.runtime_api()
 			.difficulty(parent)
-			.map_err(|err| Error::Other(format!("Fetching difficulty from runtime failed: {err:?}")))
+			.map_err(|err| PowError::Environment(format!(
+				"Fetching difficulty from runtime failed: {err:?}"
+			)))
 	}
 
 	fn verify(
@@ -169,18 +171,20 @@ where
 		_pre_digest: Option<&[u8]>,
 		seal: &sp_consensus_pow::Seal,
 		difficulty: U256,
-	) -> Result<bool, Error<B>> {
+	) -> Result<bool, PowError<B>> {
 		let parent_hash = match parent {
 			BlockId::Hash(h) => *h,
 			BlockId::Number(_) => {
-				return Err(Error::Other("BlockId::Number not supported for verify".into()));
+				return Err(PowError::Environment(
+					"BlockId::Number not supported for verify".into(),
+				));
 			},
 		};
 
 		self.client
 			.runtime_api()
 			.verify_seal(parent_hash, *pre_hash, seal.clone(), difficulty)
-			.map_err(|err| Error::Runtime(format!("Runtime verify_seal failed: {err:?}")))
+			.map_err(|err| PowError::Runtime(format!("Runtime verify_seal failed: {err:?}")))
 	}
 }
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 clap = { features = ["derive"], workspace = true }
+codec.workspace = true
 frame-benchmarking-cli.default-features = true
 frame-benchmarking-cli.workspace = true
 frame-metadata-hash-extension.default-features = true
@@ -34,12 +35,10 @@ sc-cli.default-features = true
 sc-cli.workspace = true
 sc-client-api.default-features = true
 sc-client-api.workspace = true
-sc-consensus-aura.default-features = true
-sc-consensus-aura.workspace = true
-sc-consensus-grandpa.default-features = true
-sc-consensus-grandpa.workspace = true
 sc-consensus.default-features = true
 sc-consensus.workspace = true
+sc-consensus-pow.default-features = true
+sc-consensus-pow.workspace = true
 sc-executor.default-features = true
 sc-executor.workspace = true
 sc-network.default-features = true
@@ -63,8 +62,8 @@ sp-block-builder.default-features = true
 sp-block-builder.workspace = true
 sp-blockchain.default-features = true
 sp-blockchain.workspace = true
-sp-consensus-aura.default-features = true
-sp-consensus-aura.workspace = true
+sp-consensus-pow.default-features = true
+sp-consensus-pow.workspace = true
 sp-core.default-features = true
 sp-core.workspace = true
 sp-genesis-builder.default-features = true

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -7,6 +7,10 @@ pub struct Cli {
 
 	#[clap(flatten)]
 	pub run: RunCmd,
+
+	/// Enable PoW block mining. Without this flag the node only syncs.
+	#[arg(long)]
+	pub miner: bool,
 }
 
 #[derive(Debug, clap::Subcommand)]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -172,6 +172,7 @@ pub fn run() -> sc_cli::Result<()> {
 			runner.sync_run(|config| cmd.run::<Block>(&config))
 		},
 		None => {
+			let mine = cli.miner;
 			let runner = cli.create_runner(&cli.run)?;
 			runner.run_node_until_exit(|config| async move {
 				match config.network.network_backend {
@@ -180,10 +181,10 @@ pub fn run() -> sc_cli::Result<()> {
 							solochain_template_runtime::opaque::Block,
 							<solochain_template_runtime::opaque::Block as sp_runtime::traits::Block>::Hash,
 						>,
-					>(config)
+					>(config, mine)
 					.map_err(sc_cli::Error::Service),
 					sc_network::config::NetworkBackendType::Litep2p =>
-						service::new_full::<sc_network::Litep2pNetworkBackend>(config)
+						service::new_full::<sc_network::Litep2pNetworkBackend>(config, mine)
 							.map_err(sc_cli::Error::Service),
 				}
 			})

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -94,11 +94,7 @@ pub fn run() -> sc_cli::Result<()> {
 			runner.async_run(|config| {
 				let PartialComponents { client, task_manager, backend, .. } =
 					service::new_partial(&config)?;
-				let aux_revert = Box::new(|client, _, blocks| {
-					sc_consensus_grandpa::revert(client, blocks)?;
-					Ok(())
-				});
-				Ok((cmd.run(client, backend, Some(aux_revert)), task_manager))
+				Ok((cmd.run(client, backend, None), task_manager))
 			})
 		},
 		Some(Subcommand::Benchmark(cmd)) => {

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -1,14 +1,15 @@
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 
 use futures::FutureExt;
-use sc_client_api::{Backend, BlockBackend};
-use sc_consensus_aura::{ImportQueueParams, SlotProportion, StartAuraParams};
-use sc_consensus_grandpa::SharedVoterState;
-use sc_service::{error::Error as ServiceError, Configuration, TaskManager, WarpSyncConfig};
+use sc_client_api::Backend;
+use sc_consensus::LongestChain;
+use sc_consensus_pow::PowBlockImport;
+use sc_service::{error::Error as ServiceError, Configuration, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryWorker};
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
+use sha256pow::Sha256DoubleHashAlgorithm;
 use solochain_template_runtime::{self, apis::RuntimeApi, opaque::Block};
-use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
+use sp_core::U256;
 use std::{sync::Arc, time::Duration};
 
 pub(crate) type FullClient = sc_service::TFullClient<
@@ -17,11 +18,7 @@ pub(crate) type FullClient = sc_service::TFullClient<
 	sc_executor::WasmExecutor<sp_io::SubstrateHostFunctions>,
 >;
 type FullBackend = sc_service::TFullBackend<Block>;
-type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
-
-/// The minimum period of blocks on which justifications will be
-/// imported and generated.
-const GRANDPA_JUSTIFICATION_PERIOD: u32 = 512;
+type FullSelectChain = LongestChain<FullBackend, Block>;
 
 pub type Service = sc_service::PartialComponents<
 	FullClient,
@@ -29,11 +26,7 @@ pub type Service = sc_service::PartialComponents<
 	FullSelectChain,
 	sc_consensus::DefaultImportQueue<Block>,
 	sc_transaction_pool::TransactionPoolHandle<Block, FullClient>,
-	(
-		sc_consensus_grandpa::GrandpaBlockImport<FullBackend, Block, FullClient, FullSelectChain>,
-		sc_consensus_grandpa::LinkHalf<Block, FullClient, FullSelectChain>,
-		Option<Telemetry>,
-	),
+	Option<Telemetry>,
 >;
 
 pub fn new_partial(config: &Configuration) -> Result<Service, ServiceError> {
@@ -63,7 +56,7 @@ pub fn new_partial(config: &Configuration) -> Result<Service, ServiceError> {
 		telemetry
 	});
 
-	let select_chain = sc_consensus::LongestChain::new(backend.clone());
+	let select_chain = LongestChain::new(backend.clone());
 
 	let transaction_pool = Arc::from(
 		sc_transaction_pool::Builder::new(
@@ -76,44 +69,24 @@ pub fn new_partial(config: &Configuration) -> Result<Service, ServiceError> {
 		.build(),
 	);
 
-	let (grandpa_block_import, grandpa_link) = sc_consensus_grandpa::block_import(
+	let algorithm = Sha256DoubleHashAlgorithm::new(client.clone());
+
+	let pow_block_import = PowBlockImport::new(
 		client.clone(),
-		GRANDPA_JUSTIFICATION_PERIOD,
-		&client,
+		client.clone(),
+		algorithm.clone(),
+		0u32.into(),
 		select_chain.clone(),
-		telemetry.as_ref().map(|x| x.handle()),
+		move |_, ()| async { Ok(sp_timestamp::InherentDataProvider::from_system_time()) },
+	);
+
+	let import_queue = sc_consensus_pow::import_queue(
+		Box::new(pow_block_import),
+		None,
+		algorithm,
+		&task_manager.spawn_essential_handle(),
+		config.prometheus_registry(),
 	)?;
-
-	let cidp_client = client.clone();
-	let import_queue =
-		sc_consensus_aura::import_queue::<AuraPair, _, _, _, _, _>(ImportQueueParams {
-			block_import: grandpa_block_import.clone(),
-			justification_import: Some(Box::new(grandpa_block_import.clone())),
-			client: client.clone(),
-			create_inherent_data_providers: move |parent_hash, _| {
-				let cidp_client = cidp_client.clone();
-				async move {
-					let slot_duration = sc_consensus_aura::standalone::slot_duration_at(
-						&*cidp_client,
-						parent_hash,
-					)?;
-					let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
-
-					let slot =
-						sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
-							*timestamp,
-							slot_duration,
-						);
-
-					Ok((slot, timestamp))
-				}
-			},
-			spawner: &task_manager.spawn_essential_handle(),
-			registry: config.prometheus_registry(),
-			check_for_equivocation: Default::default(),
-			telemetry: telemetry.as_ref().map(|x| x.handle()),
-			compatibility_mode: Default::default(),
-		})?;
 
 	Ok(sc_service::PartialComponents {
 		client,
@@ -123,7 +96,7 @@ pub fn new_partial(config: &Configuration) -> Result<Service, ServiceError> {
 		keystore_container,
 		select_chain,
 		transaction_pool,
-		other: (grandpa_block_import, grandpa_link, telemetry),
+		other: telemetry,
 	})
 }
 
@@ -141,34 +114,15 @@ pub fn new_full<
 		keystore_container,
 		select_chain,
 		transaction_pool,
-		other: (block_import, grandpa_link, mut telemetry),
+		other: mut telemetry,
 	} = new_partial(&config)?;
 
-	let mut net_config = sc_network::config::FullNetworkConfiguration::<
+	let net_config = sc_network::config::FullNetworkConfiguration::<
 		Block,
 		<Block as sp_runtime::traits::Block>::Hash,
 		N,
 	>::new(&config.network, config.prometheus_registry().cloned());
 	let metrics = N::register_notification_metrics(config.prometheus_registry());
-
-	let peer_store_handle = net_config.peer_store_handle();
-	let grandpa_protocol_name = sc_consensus_grandpa::protocol_standard_name(
-		&client.block_hash(0).ok().flatten().expect("Genesis block exists; qed"),
-		&config.chain_spec,
-	);
-	let (grandpa_protocol_config, grandpa_notification_service) =
-		sc_consensus_grandpa::grandpa_peers_set_config::<_, N>(
-			grandpa_protocol_name.clone(),
-			metrics.clone(),
-			peer_store_handle,
-		);
-	net_config.add_notification_protocol(grandpa_protocol_config);
-
-	let warp_sync = Arc::new(sc_consensus_grandpa::warp_proof::NetworkProvider::new(
-		backend.clone(),
-		grandpa_link.shared_authority_set().clone(),
-		Vec::default(),
-	));
 
 	let (network, system_rpc_tx, tx_handler_controller, sync_service) =
 		sc_service::build_network(sc_service::BuildNetworkParams {
@@ -180,7 +134,7 @@ pub fn new_full<
 			spawn_essential_handle: task_manager.spawn_essential_handle(),
 			import_queue,
 			block_announce_validator_builder: None,
-			warp_sync_config: Some(WarpSyncConfig::WithProvider(warp_sync)),
+			warp_sync_config: None,
 			block_relay: None,
 			metrics,
 		})?;
@@ -207,10 +161,6 @@ pub fn new_full<
 	}
 
 	let role = config.role;
-	let force_authoring = config.force_authoring;
-	let backoff_authoring_blocks: Option<()> = None;
-	let name = config.network.node_name.clone();
-	let enable_grandpa = !config.disable_grandpa;
 	let prometheus_registry = config.prometheus_registry().cloned();
 
 	let rpc_extensions_builder = {
@@ -248,88 +198,76 @@ pub fn new_full<
 			telemetry.as_ref().map(|x| x.handle()),
 		);
 
-		let slot_duration = sc_consensus_aura::slot_duration(&*client)?;
+		let algorithm = Sha256DoubleHashAlgorithm::new(client.clone());
 
-		let aura = sc_consensus_aura::start_aura::<AuraPair, _, _, _, _, _, _, _, _, _, _>(
-			StartAuraParams {
-				slot_duration,
+		let pow_block_import = PowBlockImport::new(
+			client.clone(),
+			client.clone(),
+			algorithm.clone(),
+			0u32.into(),
+			select_chain.clone(),
+			move |_, ()| async { Ok(sp_timestamp::InherentDataProvider::from_system_time()) },
+		);
+
+		let (mining_handle, mining_worker) =
+			sc_consensus_pow::start_mining_worker(
+				Box::new(pow_block_import),
 				client,
 				select_chain,
-				block_import,
+				algorithm,
 				proposer_factory,
-				create_inherent_data_providers: move |_, ()| async move {
-					let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+				sync_service.clone(),
+				sync_service,
+				None,
+				move |_, ()| async { Ok(sp_timestamp::InherentDataProvider::from_system_time()) },
+				Duration::from_secs(5),
+				Duration::from_secs(2),
+			);
 
-					let slot =
-						sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
-							*timestamp,
-							slot_duration,
-						);
-
-					Ok((slot, timestamp))
-				},
-				force_authoring,
-				backoff_authoring_blocks,
-				keystore: keystore_container.keystore(),
-				sync_oracle: sync_service.clone(),
-				justification_sync_link: sync_service.clone(),
-				block_proposal_slot_portion: SlotProportion::new(2f32 / 3f32),
-				max_block_proposal_slot_portion: None,
-				telemetry: telemetry.as_ref().map(|x| x.handle()),
-				compatibility_mode: Default::default(),
-			},
-		)?;
-
-		// the AURA authoring task is considered essential, i.e. if it
-		// fails we take down the service with it.
-		task_manager
-			.spawn_essential_handle()
-			.spawn_blocking("aura", Some("block-authoring"), aura);
-	}
-
-	if enable_grandpa {
-		// if the node isn't actively participating in consensus then it doesn't
-		// need a keystore, regardless of which protocol we use below.
-		let keystore = if role.is_authority() { Some(keystore_container.keystore()) } else { None };
-
-		let grandpa_config = sc_consensus_grandpa::Config {
-			// FIXME #1578 make this available through chainspec
-			gossip_duration: Duration::from_millis(333),
-			justification_generation_period: GRANDPA_JUSTIFICATION_PERIOD,
-			name: Some(name),
-			observer_enabled: false,
-			keystore,
-			local_role: role,
-			telemetry: telemetry.as_ref().map(|x| x.handle()),
-			protocol_name: grandpa_protocol_name,
-		};
-
-		// start the full GRANDPA voter
-		// NOTE: non-authorities could run the GRANDPA observer protocol, but at
-		// this point the full voter should provide better guarantees of block
-		// and vote data availability than the observer. The observer has not
-		// been tested extensively yet and having most nodes in a network run it
-		// could lead to finality stalls.
-		let grandpa_config = sc_consensus_grandpa::GrandpaParams {
-			config: grandpa_config,
-			link: grandpa_link,
-			network,
-			sync: Arc::new(sync_service),
-			notification_service: grandpa_notification_service,
-			voting_rule: sc_consensus_grandpa::VotingRulesBuilder::default().build(),
-			prometheus_registry,
-			shared_voter_state: SharedVoterState::empty(),
-			telemetry: telemetry.as_ref().map(|x| x.handle()),
-			offchain_tx_pool_factory: OffchainTransactionPoolFactory::new(transaction_pool),
-		};
-
-		// the GRANDPA voter task is considered infallible, i.e.
-		// if it fails we take down the service with it.
 		task_manager.spawn_essential_handle().spawn_blocking(
-			"grandpa-voter",
-			None,
-			sc_consensus_grandpa::run_grandpa_voter(grandpa_config)?,
+			"pow-mining-worker",
+			Some("block-authoring"),
+			mining_worker,
 		);
+
+		std::thread::spawn(move || {
+			loop {
+				let metadata = match mining_handle.metadata() {
+					Some(m) => m,
+					None => {
+						std::thread::sleep(Duration::from_millis(100));
+						continue;
+					}
+				};
+
+				let pre_hash = metadata.pre_hash;
+				let difficulty = metadata.difficulty;
+				let best_hash = metadata.best_hash;
+
+				let mut nonce = U256::zero();
+				loop {
+					let compute = sha256pow::Compute { pre_hash, nonce };
+					let work = compute.work();
+
+					if sha256pow::hash_meets_difficulty(&work, difficulty) {
+						let seal = compute.seal(difficulty);
+						let encoded_seal = codec::Encode::encode(&seal);
+						futures::executor::block_on(mining_handle.submit(encoded_seal));
+						break;
+					}
+
+					nonce = nonce.saturating_add(U256::one());
+
+					if nonce % 10_000 == U256::zero() {
+						if let Some(new_meta) = mining_handle.metadata() {
+							if new_meta.best_hash != best_hash {
+								break;
+							}
+						}
+					}
+				}
+			}
+		});
 	}
 
 	Ok(task_manager)

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -106,6 +106,7 @@ pub fn new_full<
 	N: sc_network::NetworkBackend<Block, <Block as sp_runtime::traits::Block>::Hash>,
 >(
 	config: Configuration,
+	mine: bool,
 ) -> Result<TaskManager, ServiceError> {
 	let sc_service::PartialComponents {
 		client,
@@ -161,7 +162,6 @@ pub fn new_full<
 		);
 	}
 
-	let role = config.role;
 	let prometheus_registry = config.prometheus_registry().cloned();
 
 	let rpc_extensions_builder = {
@@ -190,7 +190,7 @@ pub fn new_full<
 		tracing_execute_block: None,
 	})?;
 
-	if role.is_authority() {
+	if mine {
 		let proposer_factory = sc_basic_authorship::ProposerFactory::new(
 			task_manager.spawn_handle(),
 			client.clone(),

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -10,6 +10,7 @@ use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sha256pow::Sha256DoubleHashAlgorithm;
 use solochain_template_runtime::{self, apis::RuntimeApi, opaque::Block};
 use sp_core::U256;
+use sp_keyring::Sr25519Keyring;
 use std::{sync::Arc, time::Duration};
 
 pub(crate) type FullClient = sc_service::TFullClient<
@@ -209,6 +210,10 @@ pub fn new_full<
 			move |_, ()| async { Ok(sp_timestamp::InherentDataProvider::from_system_time()) },
 		);
 
+		// Default miner address: Alice (to be replaced by --miner-address CLI flag).
+		let miner_address = Sr25519Keyring::Alice.to_account_id();
+		let pre_runtime = codec::Encode::encode(&miner_address);
+
 		let (mining_handle, mining_worker) =
 			sc_consensus_pow::start_mining_worker(
 				Box::new(pow_block_import),
@@ -218,7 +223,7 @@ pub fn new_full<
 				proposer_factory,
 				sync_service.clone(),
 				sync_service,
-				None,
+				Some(pre_runtime),
 				move |_, ()| async { Ok(sp_timestamp::InherentDataProvider::from_system_time()) },
 				Duration::from_secs(5),
 				Duration::from_secs(2),

--- a/pallets/reward/Cargo.toml
+++ b/pallets/reward/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "pallet-reward"
+description = "block reward pallet"
+version = "0.1.0"
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+codec = { features = ["derive"], workspace = true }
+frame-support.workspace = true
+frame-system.workspace = true
+pallet-balances.workspace = true
+scale-info = { features = ["derive"], workspace = true }
+sp-consensus-pow.workspace = true
+sp-runtime.workspace = true
+
+[dev-dependencies]
+sp-io.default-features = true
+sp-io.workspace = true
+sp-keyring.default-features = true
+sp-keyring.workspace = true
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"pallet-balances/std",
+	"scale-info/std",
+	"sp-consensus-pow/std",
+	"sp-runtime/std",
+]
+runtime-benchmarks = [
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+]
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"pallet-balances/try-runtime",
+]

--- a/pallets/reward/src/lib.rs
+++ b/pallets/reward/src/lib.rs
@@ -66,3 +66,145 @@ pub mod pallet {
 		}
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use codec::Encode;
+	use frame_support::{
+		derive_impl, parameter_types,
+		traits::{ConstU128, Hooks},
+	};
+	use sp_consensus_pow::POW_ENGINE_ID;
+	use sp_keyring::Sr25519Keyring;
+	use sp_runtime::{AccountId32, BuildStorage, DigestItem, traits::IdentityLookup};
+
+	type Balance = u128;
+
+	#[frame_support::runtime]
+	mod test_runtime {
+		#[runtime::runtime]
+		#[runtime::derive(
+			RuntimeCall,
+			RuntimeEvent,
+			RuntimeError,
+			RuntimeOrigin,
+			RuntimeFreezeReason,
+			RuntimeHoldReason,
+			RuntimeSlashReason,
+			RuntimeLockId,
+			RuntimeTask
+		)]
+		pub struct Test;
+
+		#[runtime::pallet_index(0)]
+		pub type System = frame_system;
+
+		#[runtime::pallet_index(1)]
+		pub type Balances = pallet_balances;
+
+		#[runtime::pallet_index(2)]
+		pub type BlockReward = crate::pallet;
+	}
+
+	#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+	impl frame_system::Config for Test {
+		type Block = frame_system::mocking::MockBlock<Test>;
+		type AccountId = AccountId32;
+		type Lookup = IdentityLookup<AccountId32>;
+		type AccountData = pallet_balances::AccountData<Balance>;
+	}
+
+	#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+	impl pallet_balances::Config for Test {
+		type AccountStore = System;
+		type Balance = Balance;
+		type ExistentialDeposit = ConstU128<1>;
+	}
+
+	parameter_types! {
+		pub const Reward: Balance = 50_000_000_000_000_000_000; // 50 UNIT (18 decimals)
+	}
+
+	impl crate::pallet::Config for Test {
+		type Currency = Balances;
+		type BlockReward = Reward;
+	}
+
+	fn new_test_ext() -> sp_io::TestExternalities {
+		let t = frame_system::GenesisConfig::<Test>::default()
+			.build_storage()
+			.unwrap();
+		t.into()
+	}
+
+	fn set_author_digest(author: &sp_runtime::AccountId32) {
+		let digest_item = DigestItem::PreRuntime(POW_ENGINE_ID, author.encode());
+		frame_system::Pallet::<Test>::deposit_log(digest_item);
+	}
+
+	#[test]
+	fn mints_reward_to_block_author() {
+		new_test_ext().execute_with(|| {
+			let miner = Sr25519Keyring::Alice.to_account_id();
+			set_author_digest(&miner);
+
+			crate::pallet::Pallet::<Test>::on_finalize(1);
+
+			assert_eq!(
+				pallet_balances::Pallet::<Test>::free_balance(miner),
+				50_000_000_000_000_000_000u128, // 50 UNIT
+			);
+		});
+	}
+
+	#[test]
+	fn no_reward_without_digest() {
+		new_test_ext().execute_with(|| {
+			let miner = Sr25519Keyring::Alice.to_account_id();
+			// No digest set
+			crate::pallet::Pallet::<Test>::on_finalize(1);
+
+			assert_eq!(
+				pallet_balances::Pallet::<Test>::free_balance(miner),
+				0,
+			);
+		});
+	}
+
+	#[test]
+	fn ignores_non_pow_digest() {
+		new_test_ext().execute_with(|| {
+			let miner = Sr25519Keyring::Alice.to_account_id();
+			// Use a different engine ID
+			let digest_item = DigestItem::PreRuntime(*b"aura", miner.encode());
+			frame_system::Pallet::<Test>::deposit_log(digest_item);
+
+			crate::pallet::Pallet::<Test>::on_finalize(1);
+
+			assert_eq!(
+				pallet_balances::Pallet::<Test>::free_balance(miner),
+				0,
+			);
+		});
+	}
+
+	#[test]
+	fn reward_accumulates_over_blocks() {
+		new_test_ext().execute_with(|| {
+			let miner = Sr25519Keyring::Alice.to_account_id();
+
+			// Block 1
+			set_author_digest(&miner);
+			crate::pallet::Pallet::<Test>::on_finalize(1);
+
+			// Block 2
+			set_author_digest(&miner);
+			crate::pallet::Pallet::<Test>::on_finalize(2);
+
+			assert_eq!(
+				pallet_balances::Pallet::<Test>::free_balance(miner),
+				100_000_000_000_000_000_000u128, // 100 UNIT
+			);
+		});
+	}
+}

--- a/pallets/reward/src/lib.rs
+++ b/pallets/reward/src/lib.rs
@@ -1,0 +1,68 @@
+//! Block reward pallet.
+//!
+//! Reads the PoW pre-runtime digest to identify the block author (miner),
+//! then mints a configurable reward to their account on each block.
+//!
+//! Orphan and uncle blocks receive no reward because their state changes
+//! are never applied to the canonical chain.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use codec::Decode;
+	use frame_support::{
+		pallet_prelude::*,
+		traits::Currency,
+	};
+	use frame_system::pallet_prelude::*;
+	use sp_consensus_pow::POW_ENGINE_ID;
+
+	type BalanceOf<T> =
+		<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// The currency used to mint block rewards.
+		type Currency: Currency<Self::AccountId>;
+
+		/// Fixed reward per block (in smallest units).
+		#[pallet::constant]
+		type BlockReward: Get<BalanceOf<Self>>;
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_finalize(_n: BlockNumberFor<T>) {
+			if let Some(author) = Self::find_author() {
+				let reward = T::BlockReward::get();
+				if !reward.is_zero() {
+					let _ = T::Currency::deposit_creating(&author, reward);
+				}
+			}
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		/// Extract the block author from the PoW pre-runtime digest.
+		///
+		/// The miner encodes their `AccountId` as the payload of a
+		/// `PreRuntime(POW_ENGINE_ID, _)` digest item.
+		fn find_author() -> Option<T::AccountId> {
+			let digest = frame_system::Pallet::<T>::digest();
+			for log in digest.logs.iter() {
+				if let sp_runtime::DigestItem::PreRuntime(engine, data) = log {
+					if *engine == POW_ENGINE_ID {
+						return T::AccountId::decode(&mut &data[..]).ok();
+					}
+				}
+			}
+			None
+		}
+	}
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -22,9 +22,7 @@ frame-system-benchmarking = { optional = true, workspace = true }
 frame-system-rpc-runtime-api.workspace = true
 frame-system.workspace = true
 frame-try-runtime = { optional = true, workspace = true }
-pallet-aura.workspace = true
 pallet-balances.workspace = true
-pallet-grandpa.workspace = true
 pallet-sudo.workspace = true
 pallet-template.workspace = true
 pallet-timestamp.workspace = true
@@ -35,8 +33,6 @@ serde_json = { workspace = true, default-features = false, features = ["alloc"] 
 sha256pow.workspace = true
 sp-api.workspace = true
 sp-block-builder.workspace = true
-sp-consensus-aura = { features = ["serde"], workspace = true }
-sp-consensus-grandpa = { features = ["serde"], workspace = true }
 sp-consensus-pow.workspace = true
 sp-core = { features = ["serde"], workspace = true }
 sp-genesis-builder.workspace = true
@@ -64,9 +60,7 @@ std = [
 	"frame-system-rpc-runtime-api/std",
 	"frame-system/std",
 	"frame-try-runtime?/std",
-	"pallet-aura/std",
 	"pallet-balances/std",
-	"pallet-grandpa/std",
 	"pallet-sudo/std",
 	"pallet-template/std",
 	"pallet-timestamp/std",
@@ -77,8 +71,6 @@ std = [
 	"sha256pow/std",
 	"sp-api/std",
 	"sp-block-builder/std",
-	"sp-consensus-aura/std",
-	"sp-consensus-grandpa/std",
 	"sp-consensus-pow/std",
 	"sp-core/std",
 	"sp-genesis-builder/std",
@@ -99,7 +91,6 @@ runtime-benchmarks = [
 	"frame-system-benchmarking/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
-	"pallet-grandpa/runtime-benchmarks",
 	"pallet-sudo/runtime-benchmarks",
 	"pallet-template/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
@@ -112,9 +103,7 @@ try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"frame-try-runtime/try-runtime",
-	"pallet-aura/try-runtime",
 	"pallet-balances/try-runtime",
-	"pallet-grandpa/try-runtime",
 	"pallet-sudo/try-runtime",
 	"pallet-template/try-runtime",
 	"pallet-timestamp/try-runtime",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -23,6 +23,7 @@ frame-system-rpc-runtime-api.workspace = true
 frame-system.workspace = true
 frame-try-runtime = { optional = true, workspace = true }
 pallet-balances.workspace = true
+pallet-reward.workspace = true
 pallet-sudo.workspace = true
 pallet-template.workspace = true
 pallet-timestamp.workspace = true
@@ -61,6 +62,7 @@ std = [
 	"frame-system/std",
 	"frame-try-runtime?/std",
 	"pallet-balances/std",
+	"pallet-reward/std",
 	"pallet-sudo/std",
 	"pallet-template/std",
 	"pallet-timestamp/std",
@@ -91,6 +93,7 @@ runtime-benchmarks = [
 	"frame-system-benchmarking/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
+	"pallet-reward/runtime-benchmarks",
 	"pallet-sudo/runtime-benchmarks",
 	"pallet-template/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
@@ -104,6 +107,7 @@ try-runtime = [
 	"frame-system/try-runtime",
 	"frame-try-runtime/try-runtime",
 	"pallet-balances/try-runtime",
+	"pallet-reward/try-runtime",
 	"pallet-sudo/try-runtime",
 	"pallet-template/try-runtime",
 	"pallet-timestamp/try-runtime",

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -29,12 +29,10 @@ use frame_support::{
 	genesis_builder_helper::{build_state, get_preset},
 	weights::Weight,
 };
-use pallet_grandpa::AuthorityId as GrandpaId;
 use sp_api::impl_runtime_apis;
-use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata, U256};
 use sp_runtime::{
-	traits::{Block as BlockT, NumberFor},
+	traits::Block as BlockT,
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult,
 };
@@ -46,7 +44,7 @@ const INITIAL_DIFFICULTY: u64 = 1_000_000;
 
 // Local module imports
 use super::{
-	AccountId, Aura, Balance, Block, Executive, Grandpa, InherentDataExt, Nonce, Runtime,
+	AccountId, Balance, Block, Executive, InherentDataExt, Nonce, Runtime,
 	RuntimeCall, RuntimeGenesisConfig, SessionKeys, System, TransactionPayment, VERSION,
 };
 
@@ -122,16 +120,6 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {
-		fn slot_duration() -> sp_consensus_aura::SlotDuration {
-			sp_consensus_aura::SlotDuration::from_millis(Aura::slot_duration())
-		}
-
-		fn authorities() -> Vec<AuraId> {
-			pallet_aura::Authorities::<Runtime>::get().into_inner()
-		}
-	}
-
 	impl sp_session::SessionKeys<Block> for Runtime {
 		fn generate_session_keys(owner: Vec<u8>, seed: Option<Vec<u8>>) -> sp_session::OpaqueGeneratedSessionKeys {
 			SessionKeys::generate(&owner, seed).into()
@@ -141,36 +129,6 @@ impl_runtime_apis! {
 			encoded: Vec<u8>,
 		) -> Option<Vec<(Vec<u8>, KeyTypeId)>> {
 			SessionKeys::decode_into_raw_public_keys(&encoded)
-		}
-	}
-
-	impl sp_consensus_grandpa::GrandpaApi<Block> for Runtime {
-		fn grandpa_authorities() -> sp_consensus_grandpa::AuthorityList {
-			Grandpa::grandpa_authorities()
-		}
-
-		fn current_set_id() -> sp_consensus_grandpa::SetId {
-			Grandpa::current_set_id()
-		}
-
-		fn submit_report_equivocation_unsigned_extrinsic(
-			_equivocation_proof: sp_consensus_grandpa::EquivocationProof<
-				<Block as BlockT>::Hash,
-				NumberFor<Block>,
-			>,
-			_key_owner_proof: sp_consensus_grandpa::OpaqueKeyOwnershipProof,
-		) -> Option<()> {
-			None
-		}
-
-		fn generate_key_ownership_proof(
-			_set_id: sp_consensus_grandpa::SetId,
-			_authority_id: GrandpaId,
-		) -> Option<sp_consensus_grandpa::OpaqueKeyOwnershipProof> {
-			// NOTE: this is the only implementation possible since we've
-			// defined our key owner proof type as a bottom type (i.e. a type
-			// with no values).
-			None
 		}
 	}
 

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -122,6 +122,16 @@ impl pallet_balances::Config for Runtime {
 }
 
 parameter_types! {
+	/// Block reward: 50 UNIT per block to the miner.
+	pub const BlockReward: Balance = 50 * super::UNIT;
+}
+
+impl pallet_reward::Config for Runtime {
+	type Currency = Balances;
+	type BlockReward = BlockReward;
+}
+
+parameter_types! {
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
 	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(3, 100_000);
 	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000u128);

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -26,7 +26,7 @@
 // Substrate and Polkadot dependencies
 use frame_support::{
 	derive_impl, parameter_types,
-	traits::{ConstBool, ConstU128, ConstU32, ConstU64, ConstU8, VariantCountOf},
+	traits::{ConstU128, ConstU32, ConstU64, ConstU8, VariantCountOf},
 	weights::{
 		constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND},
 		IdentityFee, Weight,
@@ -34,13 +34,12 @@ use frame_support::{
 };
 use frame_system::limits::{BlockLength, BlockWeights};
 use pallet_transaction_payment::{FungibleAdapter, Multiplier, TargetedFeeAdjustment};
-use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_runtime::{FixedPointNumber, Perbill, Perquintill};
 use sp_version::RuntimeVersion;
 
 // Local module imports
 use super::{
-	AccountId, Aura, Balance, Balances, Block, BlockNumber, Hash, Nonce, PalletInfo, Runtime,
+	AccountId, Balance, Balances, Block, BlockNumber, Hash, Nonce, PalletInfo, Runtime,
 	RuntimeCall, RuntimeEvent, RuntimeFreezeReason, RuntimeHoldReason, RuntimeOrigin, RuntimeTask,
 	System, EXISTENTIAL_DEPOSIT, SLOT_DURATION, VERSION,
 };
@@ -96,30 +95,9 @@ impl frame_system::Config for Runtime {
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
-impl pallet_aura::Config for Runtime {
-	type AuthorityId = AuraId;
-	type DisabledValidators = ();
-	type MaxAuthorities = ConstU32<32>;
-	type AllowMultipleBlocksPerSlot = ConstBool<false>;
-	type SlotDuration = pallet_aura::MinimumPeriodTimesTwo<Runtime>;
-}
-
-impl pallet_grandpa::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-
-	type WeightInfo = ();
-	type MaxAuthorities = ConstU32<32>;
-	type MaxNominators = ConstU32<0>;
-	type MaxSetIdSessionEntries = ConstU64<0>;
-
-	type KeyOwnerProof = sp_core::Void;
-	type EquivocationReportSystem = ();
-}
-
 impl pallet_timestamp::Config for Runtime {
-	/// A timestamp: milliseconds since the unix epoch.
 	type Moment = u64;
-	type OnTimestampSet = Aura;
+	type OnTimestampSet = ();
 	type MinimumPeriod = ConstU64<{ SLOT_DURATION / 2 }>;
 	type WeightInfo = ();
 }

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -19,14 +19,10 @@ use crate::{AccountId, BalancesConfig, RuntimeGenesisConfig, SudoConfig, UNIT};
 use alloc::{vec, vec::Vec};
 use frame_support::build_struct_json_patch;
 use serde_json::Value;
-use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_consensus_grandpa::AuthorityId as GrandpaId;
 use sp_genesis_builder::{self, PresetId};
 use sp_keyring::Sr25519Keyring;
 
-// Total supply: 1,000,000,000 UNIT, evenly distributed among endowed accounts.
 fn testnet_genesis(
-	initial_authorities: Vec<(AuraId, GrandpaId)>,
 	endowed_accounts: Vec<AccountId>,
 	root: AccountId,
 ) -> Value {
@@ -40,46 +36,24 @@ fn testnet_genesis(
 				.map(|k| (k, balance_per_account))
 				.collect::<Vec<_>>(),
 		},
-		aura: pallet_aura::GenesisConfig {
-			authorities: initial_authorities.iter().map(|x| x.0.clone()).collect::<Vec<_>>(),
-		},
-		grandpa: pallet_grandpa::GenesisConfig {
-			authorities: initial_authorities.iter().map(|x| (x.1.clone(), 1)).collect::<Vec<_>>(),
-		},
 		sudo: SudoConfig { key: Some(root) },
 	})
 }
 
-/// Return the development genesis config.
 pub fn development_config_genesis() -> Value {
 	testnet_genesis(
-		vec![(
-			sp_keyring::Sr25519Keyring::Alice.public().into(),
-			sp_keyring::Ed25519Keyring::Alice.public().into(),
-		)],
 		vec![
 			Sr25519Keyring::Alice.to_account_id(),
 			Sr25519Keyring::Bob.to_account_id(),
 			Sr25519Keyring::AliceStash.to_account_id(),
 			Sr25519Keyring::BobStash.to_account_id(),
 		],
-		sp_keyring::Sr25519Keyring::Alice.to_account_id(),
+		Sr25519Keyring::Alice.to_account_id(),
 	)
 }
 
-/// Return the local genesis config preset.
 pub fn local_config_genesis() -> Value {
 	testnet_genesis(
-		vec![
-			(
-				sp_keyring::Sr25519Keyring::Alice.public().into(),
-				sp_keyring::Ed25519Keyring::Alice.public().into(),
-			),
-			(
-				sp_keyring::Sr25519Keyring::Bob.public().into(),
-				sp_keyring::Ed25519Keyring::Bob.public().into(),
-			),
-		],
 		Sr25519Keyring::iter()
 			.filter(|v| v != &Sr25519Keyring::One && v != &Sr25519Keyring::Two)
 			.map(|v| v.to_account_id())

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -217,4 +217,7 @@ mod runtime {
 	// Include the custom logic from the pallet-template in the runtime.
 	#[runtime::pallet_index(7)]
 	pub type Template = pallet_template;
+
+	#[runtime::pallet_index(8)]
+	pub type BlockReward = pallet_reward;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -51,10 +51,7 @@ pub mod opaque {
 }
 
 impl_opaque_keys! {
-	pub struct SessionKeys {
-		pub aura: Aura,
-		pub grandpa: Grandpa,
-	}
+	pub struct SessionKeys {}
 }
 
 // To learn more about runtime versioning, see:
@@ -207,12 +204,6 @@ mod runtime {
 
 	#[runtime::pallet_index(1)]
 	pub type Timestamp = pallet_timestamp;
-
-	#[runtime::pallet_index(2)]
-	pub type Aura = pallet_aura;
-
-	#[runtime::pallet_index(3)]
-	pub type Grandpa = pallet_grandpa;
 
 	#[runtime::pallet_index(4)]
 	pub type Balances = pallet_balances;


### PR DESCRIPTION
## Summary

Enable the node to produce PoW blocks by assembling the mining pipeline:
block construction, seal verification via runtime API, mining worker with
CPU thread, and block reward distribution.

## Changes

### Consensus
- Vendor `sc-consensus-pow` v0.55.0 locally for sp-runtime 46 compatibility
- Extend `sha256pow` with `PowAlgorithm` trait impl (runtime API delegation for verify)
- Add `#[cfg(feature = "std")]` gates for no_std compatibility

### Node
- Rewrite `service.rs`: replace Aura/GRANDPA pipeline with PoW (PowBlockImport + LongestChain + mining worker)
- Add `--miner` CLI flag to toggle mining
- Mining worker poll = 5s, build time limit = 2s
- Encode miner address as PreRuntime digest (default: Alice)

### Runtime
- Add `pallet-reward`: mints 50 UNIT to block author on finalize
- Orphan/uncle no reward: inherent via Substrate's canonical-only finalize
- Implement `DifficultyApi` and `PowVerifyApi` runtime APIs
- Remove Aura/GRANDPA configuration and genesis presets

### Tests

sha256pow (12 tests):
- verify accepts valid seal
- reject tampered work
- reject wrong pre-hash
- reject malformed bytes
- reject seal below difficulty

pallet-reward (6 tests):
- mint reward to block author
- no reward without digest
- ignore non-PoW digest
- reward accumulates over blocks

Closes #12