### PR TITLE
 Integrate pallet-difficulty into Runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,6 +6303,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-difficulty"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-message-queue"
 version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10217,6 +10231,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "pallet-balances",
+ "pallet-difficulty",
  "pallet-reward",
  "pallet-sudo",
  "pallet-template",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "consensus/sc-consensus-pow",
     "consensus/sha256pow",
     "node",
+    "pallets/difficulty",
     "pallets/reward",
     "pallets/template",
     "runtime",
@@ -19,6 +20,7 @@ resolver = "2"
 [workspace.dependencies]
 solochain-template-runtime = { path = "./runtime", default-features = false }
 sha256pow = { path = "./consensus/sha256pow", default-features = false }
+pallet-difficulty = { path = "./pallets/difficulty", default-features = false }
 pallet-reward = { path = "./pallets/reward", default-features = false }
 pallet-template = { path = "./pallets/template", default-features = false }
 clap = { version = "4.6.0" }

--- a/pallets/difficulty/Cargo.toml
+++ b/pallets/difficulty/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "pallet-difficulty"
+description = "ASERT difficulty adjustment pallet for PoW consensus."
+version = "0.1.0"
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+codec = { features = ["derive"], workspace = true }
+frame-support.workspace = true
+frame-system.workspace = true
+pallet-timestamp.workspace = true
+scale-info = { features = ["derive"], workspace = true }
+sp-core.workspace = true
+sp-runtime.workspace = true
+
+[dev-dependencies]
+sp-io.default-features = true
+sp-io.workspace = true
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"pallet-timestamp/std",
+	"scale-info/std",
+	"sp-core/std",
+	"sp-runtime/std",
+]
+runtime-benchmarks = [
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks",
+]
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"pallet-timestamp/try-runtime",
+]

--- a/pallets/difficulty/src/lib.rs
+++ b/pallets/difficulty/src/lib.rs
@@ -1,0 +1,125 @@
+//! ASERT difficulty adjustment pallet.
+//!
+//! Stores the current mining difficulty and anchor block parameters used by
+//! the ASERT algorithm. The actual difficulty calculation logic (ASERT
+//! formula) is added in a follow-up issue; this pallet provides the
+//! scaffolding, storage, genesis configuration, and a public query method
+//! that the `DifficultyApi` runtime API delegates to.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use frame_support::pallet_prelude::*;
+	use sp_core::U256;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config<RuntimeEvent: From<Event>> + pallet_timestamp::Config {
+		/// Target block time in seconds (e.g. 20).
+		#[pallet::constant]
+		type TargetBlockTime: Get<u64>;
+
+		/// ASERT halflife in seconds (e.g. 1800 = 30 minutes).
+		#[pallet::constant]
+		type Halflife: Get<u64>;
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	// ── Storage ─────────────────────────────────────────────────────
+
+	/// Current mining difficulty (U256).
+	///
+	/// Updated each block once ASERT calculation is wired in (#023b).
+	/// Initially set via genesis config.
+	#[pallet::storage]
+	#[pallet::getter(fn current_difficulty)]
+	pub type CurrentDifficulty<T: Config> = StorageValue<_, U256, ValueQuery>;
+
+	/// Anchor block target value (inverse of difficulty).
+	///
+	/// `target = U256::MAX / difficulty`. Set at genesis.
+	#[pallet::storage]
+	#[pallet::getter(fn anchor_target)]
+	pub type AnchorTarget<T: Config> = StorageValue<_, U256, ValueQuery>;
+
+	/// Timestamp of the anchor block's parent (seconds since Unix epoch).
+	#[pallet::storage]
+	#[pallet::getter(fn anchor_timestamp)]
+	pub type AnchorTimestamp<T: Config> = StorageValue<_, u64, ValueQuery>;
+
+	/// Block height of the anchor block.
+	#[pallet::storage]
+	#[pallet::getter(fn anchor_height)]
+	pub type AnchorHeight<T: Config> = StorageValue<_, u32, ValueQuery>;
+
+	// ── Events ──────────────────────────────────────────────────────
+
+	#[pallet::event]
+	pub enum Event {
+		/// Difficulty was adjusted to a new value.
+		DifficultyAdjusted {
+			/// The new difficulty.
+			difficulty: U256,
+		},
+	}
+
+	// ── Errors ──────────────────────────────────────────────────────
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// The difficulty value overflowed or underflowed during calculation.
+		DifficultyOverflow,
+		/// Zero difficulty is not allowed.
+		ZeroDifficulty,
+	}
+
+	// ── Genesis ─────────────────────────────────────────────────────
+
+	#[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config> {
+		/// Initial mining difficulty.
+		pub initial_difficulty: U256,
+		/// Anchor target (U256::MAX / initial_difficulty). If zero, it is
+		/// computed automatically from `initial_difficulty`.
+		pub anchor_target: U256,
+		/// Anchor timestamp (seconds). Typically 0 for genesis.
+		pub anchor_timestamp: u64,
+		/// Anchor block height. Typically 0 for genesis.
+		pub anchor_height: u32,
+		#[serde(skip)]
+		pub _marker: core::marker::PhantomData<T>,
+	}
+
+	impl<T: Config> Default for GenesisConfig<T> {
+		fn default() -> Self {
+			Self {
+				initial_difficulty: Default::default(),
+				anchor_target: Default::default(),
+				anchor_timestamp: Default::default(),
+				anchor_height: Default::default(),
+				_marker: Default::default(),
+			}
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
+		fn build(&self) {
+			CurrentDifficulty::<T>::put(self.initial_difficulty);
+
+			// Compute anchor target if not explicitly set.
+			let target = if self.anchor_target == U256::zero() && self.initial_difficulty != U256::zero() {
+				U256::MAX / self.initial_difficulty
+			} else {
+				self.anchor_target
+			};
+			AnchorTarget::<T>::put(target);
+			AnchorTimestamp::<T>::put(self.anchor_timestamp);
+			AnchorHeight::<T>::put(self.anchor_height);
+		}
+	}
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -23,6 +23,7 @@ frame-system-rpc-runtime-api.workspace = true
 frame-system.workspace = true
 frame-try-runtime = { optional = true, workspace = true }
 pallet-balances.workspace = true
+pallet-difficulty.workspace = true
 pallet-reward.workspace = true
 pallet-sudo.workspace = true
 pallet-template.workspace = true
@@ -62,6 +63,7 @@ std = [
 	"frame-system/std",
 	"frame-try-runtime?/std",
 	"pallet-balances/std",
+	"pallet-difficulty/std",
 	"pallet-reward/std",
 	"pallet-sudo/std",
 	"pallet-template/std",
@@ -93,6 +95,7 @@ runtime-benchmarks = [
 	"frame-system-benchmarking/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
+	"pallet-difficulty/runtime-benchmarks",
 	"pallet-reward/runtime-benchmarks",
 	"pallet-sudo/runtime-benchmarks",
 	"pallet-template/runtime-benchmarks",
@@ -107,6 +110,7 @@ try-runtime = [
 	"frame-system/try-runtime",
 	"frame-try-runtime/try-runtime",
 	"pallet-balances/try-runtime",
+	"pallet-difficulty/try-runtime",
 	"pallet-reward/try-runtime",
 	"pallet-sudo/try-runtime",
 	"pallet-template/try-runtime",

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -38,10 +38,6 @@ use sp_runtime::{
 };
 use sp_version::RuntimeVersion;
 
-/// Initial fixed mining difficulty.
-/// This will be replaced by a dynamic adjustment algorithm later.
-const INITIAL_DIFFICULTY: u64 = 1_000_000;
-
 // Local module imports
 use super::{
 	AccountId, Balance, Block, Executive, InherentDataExt, Nonce, Runtime,
@@ -252,7 +248,7 @@ impl_runtime_apis! {
 
 	impl sp_consensus_pow::DifficultyApi<Block, U256> for Runtime {
 		fn difficulty() -> U256 {
-			U256::from(INITIAL_DIFFICULTY)
+			pallet_difficulty::Pallet::<Runtime>::current_difficulty()
 		}
 	}
 

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -166,3 +166,13 @@ impl pallet_sudo::Config for Runtime {
 impl pallet_template::Config for Runtime {
 	type WeightInfo = pallet_template::weights::SubstrateWeight<Runtime>;
 }
+
+parameter_types! {
+	pub const TargetBlockTime: u64 = 20;
+	pub const DifficultyHalflife: u64 = 1800;
+}
+
+impl pallet_difficulty::Config for Runtime {
+	type TargetBlockTime = TargetBlockTime;
+	type Halflife = DifficultyHalflife;
+}

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -15,10 +15,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{AccountId, BalancesConfig, RuntimeGenesisConfig, SudoConfig, UNIT};
+use crate::{AccountId, BalancesConfig, DifficultyConfig, RuntimeGenesisConfig, SudoConfig, UNIT};
 use alloc::{vec, vec::Vec};
 use frame_support::build_struct_json_patch;
 use serde_json::Value;
+use sp_core::U256;
 use sp_genesis_builder::{self, PresetId};
 use sp_keyring::Sr25519Keyring;
 
@@ -28,6 +29,7 @@ fn testnet_genesis(
 ) -> Value {
 	let total_supply: u128 = 1_000_000_000 * UNIT;
 	let balance_per_account = total_supply / endowed_accounts.len() as u128;
+	let initial_difficulty = U256::from(1_000_000u64);
 	build_struct_json_patch!(RuntimeGenesisConfig {
 		balances: BalancesConfig {
 			balances: endowed_accounts
@@ -37,6 +39,13 @@ fn testnet_genesis(
 				.collect::<Vec<_>>(),
 		},
 		sudo: SudoConfig { key: Some(root) },
+		difficulty: DifficultyConfig {
+			initial_difficulty,
+			anchor_target: U256::zero(),
+			anchor_timestamp: 0,
+			anchor_height: 0,
+			..Default::default()
+		},
 	})
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,4 +220,7 @@ mod runtime {
 
 	#[runtime::pallet_index(8)]
 	pub type BlockReward = pallet_reward;
+
+	#[runtime::pallet_index(9)]
+	pub type Difficulty = pallet_difficulty;
 }


### PR DESCRIPTION
## Summary

Integrates pallet-difficulty into the runtime, providing the scaffolding for the ASERT difficulty adjustment algorithm. The pallet stores mining difficulty and anchor block parameters, and the DifficultyApi now reads from pallet storage instead of a hardcoded constant.

## Changes

### Pallet

- Add `pallet-difficulty`
- Config trait with TargetBlockTime (20s) and Halflife (1800s) constants
- Storage items: CurrentDifficulty (U256), AnchorTarget (U256), AnchorTimestamp (u64), AnchorHeight (u32)
- build() writes initial difficulty and computes anchor target from genesis config

### Runtime

- Added to construct_runtime! as Difficulty
- pallet_difficulty::Config implemented in mod.rs
- DifficultyApi::difficulty() now delegates to pallet_difficulty::Pallet::<Runtime>::current_difficulty()
- Genesis presets in genesis_config_presets.rs set initial_difficulty: U256::from(1_000_000u64)

Closes #14
