### PR TITLE
 Implement Block Timestamp Drift Validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10255,6 +10255,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-storage",
+ "sp-timestamp",
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -44,6 +44,7 @@ sp-offchain.workspace = true
 sp-runtime = { features = ["serde"], workspace = true }
 sp-session.workspace = true
 sp-storage.workspace = true
+sp-timestamp.workspace = true
 sp-transaction-pool.workspace = true
 sp-version = { features = ["serde"], workspace = true }
 
@@ -84,6 +85,7 @@ std = [
 	"sp-runtime/std",
 	"sp-session/std",
 	"sp-storage/std",
+	"sp-timestamp/std",
 	"sp-transaction-pool/std",
 	"sp-version/std",
 	"substrate-wasm-builder",

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -44,6 +44,34 @@ use super::{
 	RuntimeCall, RuntimeGenesisConfig, SessionKeys, System, TransactionPayment, VERSION,
 };
 
+/// Maximum allowed timestamp drift from the node's local clock (milliseconds).
+pub const MAX_TIMESTAMP_DRIFT_MS: u64 = 2_000;
+
+/// Validate block timestamp against drift limits.
+///
+/// Appends errors to `result` if the block timestamp exceeds the allowed
+/// drift or is earlier than the parent timestamp.
+pub fn check_timestamp_drift(
+	result: &mut sp_inherents::CheckInherentsResult,
+	block_ts_ms: u64,
+	node_ts_ms: u64,
+	parent_ts_ms: u64,
+) {
+	if block_ts_ms > node_ts_ms + MAX_TIMESTAMP_DRIFT_MS {
+		let _ = result.put_error(
+			sp_timestamp::INHERENT_IDENTIFIER,
+			&sp_timestamp::InherentError::TooFarInFuture,
+		);
+	}
+
+	if block_ts_ms < parent_ts_ms {
+		let _ = result.put_error(
+			sp_timestamp::INHERENT_IDENTIFIER,
+			&sp_timestamp::InherentError::TooEarly,
+		);
+	}
+}
+
 impl_runtime_apis! {
 	impl sp_api::Core<Block> for Runtime {
 		fn version() -> RuntimeVersion {
@@ -96,7 +124,35 @@ impl_runtime_apis! {
 			block: <Block as BlockT>::LazyBlock,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			use sp_runtime::traits::LazyBlock as _;
+			use sp_timestamp::TimestampInherentData;
+
+			let mut result = data.check_extrinsics(&block);
+
+			// Enforce 2-second max future timestamp drift (FR-DIFF-005).
+			// pallet_timestamp hardcodes 30s; we tighten it to 2s to prevent
+			// miners from gaming ASERT difficulty calculations.
+			if let Ok(Some(node_ts)) = data.timestamp_inherent_data() {
+				let node_ts_ms: u64 = *node_ts;
+				let parent_ts_ms: u64 = pallet_timestamp::Now::<Runtime>::get();
+
+				for ext_result in block.extrinsics() {
+					let Ok(ext) = ext_result else { continue };
+					if let RuntimeCall::Timestamp(pallet_timestamp::Call::set { now }) =
+						&ext.function
+					{
+						check_timestamp_drift(
+							&mut result,
+							*now,
+							node_ts_ms,
+							parent_ts_ms,
+						);
+						break;
+					}
+				}
+			}
+
+			result
 		}
 	}
 

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -42,35 +42,8 @@ use sp_version::RuntimeVersion;
 use super::{
 	AccountId, Balance, Block, Executive, InherentDataExt, Nonce, Runtime,
 	RuntimeCall, RuntimeGenesisConfig, SessionKeys, System, TransactionPayment, VERSION,
+	inherent_checks::check_timestamp_drift,
 };
-
-/// Maximum allowed timestamp drift from the node's local clock (milliseconds).
-pub const MAX_TIMESTAMP_DRIFT_MS: u64 = 2_000;
-
-/// Validate block timestamp against drift limits.
-///
-/// Appends errors to `result` if the block timestamp exceeds the allowed
-/// drift or is earlier than the parent timestamp.
-pub fn check_timestamp_drift(
-	result: &mut sp_inherents::CheckInherentsResult,
-	block_ts_ms: u64,
-	node_ts_ms: u64,
-	parent_ts_ms: u64,
-) {
-	if block_ts_ms > node_ts_ms + MAX_TIMESTAMP_DRIFT_MS {
-		let _ = result.put_error(
-			sp_timestamp::INHERENT_IDENTIFIER,
-			&sp_timestamp::InherentError::TooFarInFuture,
-		);
-	}
-
-	if block_ts_ms < parent_ts_ms {
-		let _ = result.put_error(
-			sp_timestamp::INHERENT_IDENTIFIER,
-			&sp_timestamp::InherentError::TooEarly,
-		);
-	}
-}
 
 impl_runtime_apis! {
 	impl sp_api::Core<Block> for Runtime {

--- a/runtime/src/inherent_checks.rs
+++ b/runtime/src/inherent_checks.rs
@@ -1,0 +1,28 @@
+
+/// Maximum allowed timestamp drift from the node's local clock (milliseconds).
+pub const MAX_TIMESTAMP_DRIFT_MS: u64 = 2_000;
+
+/// Validate block timestamp against drift limits.
+///
+/// Appends errors to `result` if the block timestamp exceeds the allowed
+/// drift or is earlier than the parent timestamp.
+pub fn check_timestamp_drift(
+	result: &mut sp_inherents::CheckInherentsResult,
+	block_ts_ms: u64,
+	node_ts_ms: u64,
+	parent_ts_ms: u64,
+) {
+	if block_ts_ms > node_ts_ms + MAX_TIMESTAMP_DRIFT_MS {
+		let _ = result.put_error(
+			sp_timestamp::INHERENT_IDENTIFIER,
+			&sp_timestamp::InherentError::TooFarInFuture,
+		);
+	}
+
+	if block_ts_ms < parent_ts_ms {
+		let _ = result.put_error(
+			sp_timestamp::INHERENT_IDENTIFIER,
+			&sp_timestamp::InherentError::TooEarly,
+		);
+	}
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -7,6 +7,7 @@ pub mod apis;
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarks;
 pub mod configs;
+pub mod inherent_checks;
 
 extern crate alloc;
 use alloc::vec::Vec;

--- a/runtime/tests/timestamp_drift.rs
+++ b/runtime/tests/timestamp_drift.rs
@@ -1,0 +1,75 @@
+use solochain_template_runtime::apis::{check_timestamp_drift, MAX_TIMESTAMP_DRIFT_MS};
+use sp_inherents::CheckInherentsResult;
+
+fn empty_result() -> CheckInherentsResult {
+	CheckInherentsResult::new()
+}
+
+#[test]
+fn max_drift_constant_is_2s() {
+	assert_eq!(MAX_TIMESTAMP_DRIFT_MS, 2_000);
+}
+
+#[test]
+fn within_drift_accepted() {
+	let mut result = empty_result();
+	// node=100s, block=101s (1s drift), parent=90s
+	check_timestamp_drift(&mut result, 101_000, 100_000, 90_000);
+	assert!(result.ok(), "1s drift should be accepted");
+}
+
+#[test]
+fn exact_drift_boundary_accepted() {
+	let mut result = empty_result();
+	// node=100s, block=102s (exactly 2s drift), parent=90s
+	check_timestamp_drift(&mut result, 102_000, 100_000, 90_000);
+	assert!(result.ok(), "exactly 2s drift should be accepted");
+}
+
+#[test]
+fn just_over_drift_boundary_rejected() {
+	let mut result = empty_result();
+	// node=100s, block=102.001s (2.001s drift), parent=90s
+	check_timestamp_drift(&mut result, 102_001, 100_000, 90_000);
+	assert!(!result.ok(), "2.001s drift should be rejected");
+}
+
+#[test]
+fn large_future_drift_rejected() {
+	let mut result = empty_result();
+	// node=100s, block=110s (10s drift), parent=90s
+	check_timestamp_drift(&mut result, 110_000, 100_000, 90_000);
+	assert!(!result.ok(), "10s drift should be rejected");
+}
+
+#[test]
+fn before_parent_rejected() {
+	let mut result = empty_result();
+	// node=100s, block=89s, parent=90s
+	check_timestamp_drift(&mut result, 89_000, 100_000, 90_000);
+	assert!(!result.ok(), "timestamp before parent should be rejected");
+}
+
+#[test]
+fn equal_to_parent_accepted() {
+	let mut result = empty_result();
+	// node=100s, block=90s, parent=90s
+	check_timestamp_drift(&mut result, 90_000, 100_000, 90_000);
+	assert!(result.ok(), "timestamp equal to parent should be accepted");
+}
+
+#[test]
+fn after_parent_within_drift_accepted() {
+	let mut result = empty_result();
+	// node=100s, block=95s, parent=90s
+	check_timestamp_drift(&mut result, 95_000, 100_000, 90_000);
+	assert!(result.ok(), "block between parent and node time should be accepted");
+}
+
+#[test]
+fn zero_drift_accepted() {
+	let mut result = empty_result();
+	// node=100s, block=100s, parent=90s
+	check_timestamp_drift(&mut result, 100_000, 100_000, 90_000);
+	assert!(result.ok(), "zero drift should be accepted");
+}

--- a/runtime/tests/timestamp_drift.rs
+++ b/runtime/tests/timestamp_drift.rs
@@ -1,4 +1,4 @@
-use solochain_template_runtime::apis::{check_timestamp_drift, MAX_TIMESTAMP_DRIFT_MS};
+use solochain_template_runtime::inherent_checks::{check_timestamp_drift, MAX_TIMESTAMP_DRIFT_MS};
 use sp_inherents::CheckInherentsResult;
 
 fn empty_result() -> CheckInherentsResult {


### PR DESCRIPTION
## Summary

Prevent miners from manipulating block timestamps to game the ASERT difficulty calculation. Blocks with timestamps more than 2 seconds ahead of the node's local clock or earlier than the parent block's timestamp are now rejected during inherent checks.

## Changes

Overrides pallet_timestamp's hardcoded 30s `MAX_TIMESTAMP_DRIFT_MILLIS` with a stricter 2s limit.

**runtime/src/inherent_checks.rs** (new):
- `MAX_TIMESTAMP_DRIFT_MS = 2_000`
- `check_timestamp_drift(result, block_ts, node_ts, parent_ts)` — pure fn that appends `TooFarInFuture` or `TooEarly` errors to the `CheckInherentsResult`.

**runtime/src/apis.rs**:
- `check_inherents` now extracts the block timestamp from `pallet_timestamp::Call::set { now }`, reads the parent timestamp from storage, and delegates to `check_timestamp_drift`.

**runtime/tests/timestamp_drift.rs** (new):
- 8 unit tests covering boundary conditions (exact 2s boundary, just over, before parent, equal to parent, etc.).

Closes #16
Closes #3 