### PR TITLE
Integrate pallet-grandpa into Runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -6318,6 +6318,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-grandpa"
+version = "46.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3546e596001808dd1c371b5237a0f11a85679a98a861535de04f9d486a95722f"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "pallet-session",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+]
+
+[[package]]
 name = "pallet-message-queue"
 version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7531,8 +7554,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.12.1",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -7551,8 +7574,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.12.1",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -7584,7 +7607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7597,7 +7620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10234,6 +10257,7 @@ dependencies = [
  "frame-try-runtime",
  "pallet-balances",
  "pallet-difficulty",
+ "pallet-grandpa",
  "pallet-reward",
  "pallet-sudo",
  "pallet-template",
@@ -10246,6 +10270,7 @@ dependencies = [
  "sha256pow",
  "sp-api",
  "sp-block-builder",
+ "sp-consensus-grandpa",
  "sp-consensus-pow",
  "sp-core",
  "sp-genesis-builder",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -24,6 +24,7 @@ frame-system.workspace = true
 frame-try-runtime = { optional = true, workspace = true }
 pallet-balances.workspace = true
 pallet-difficulty.workspace = true
+pallet-grandpa.workspace = true
 pallet-reward.workspace = true
 pallet-sudo.workspace = true
 pallet-template.workspace = true
@@ -35,6 +36,7 @@ serde_json = { workspace = true, default-features = false, features = ["alloc"] 
 sha256pow.workspace = true
 sp-api.workspace = true
 sp-block-builder.workspace = true
+sp-consensus-grandpa = { features = ["serde"], workspace = true }
 sp-consensus-pow.workspace = true
 sp-core = { features = ["serde"], workspace = true }
 sp-genesis-builder.workspace = true
@@ -65,6 +67,7 @@ std = [
 	"frame-try-runtime?/std",
 	"pallet-balances/std",
 	"pallet-difficulty/std",
+	"pallet-grandpa/std",
 	"pallet-reward/std",
 	"pallet-sudo/std",
 	"pallet-template/std",
@@ -76,6 +79,7 @@ std = [
 	"sha256pow/std",
 	"sp-api/std",
 	"sp-block-builder/std",
+	"sp-consensus-grandpa/std",
 	"sp-consensus-pow/std",
 	"sp-core/std",
 	"sp-genesis-builder/std",
@@ -98,6 +102,7 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"pallet-difficulty/runtime-benchmarks",
+	"pallet-grandpa/runtime-benchmarks",
 	"pallet-reward/runtime-benchmarks",
 	"pallet-sudo/runtime-benchmarks",
 	"pallet-template/runtime-benchmarks",
@@ -113,6 +118,7 @@ try-runtime = [
 	"frame-try-runtime/try-runtime",
 	"pallet-balances/try-runtime",
 	"pallet-difficulty/try-runtime",
+	"pallet-grandpa/try-runtime",
 	"pallet-reward/try-runtime",
 	"pallet-sudo/try-runtime",
 	"pallet-template/try-runtime",

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -40,7 +40,7 @@ use sp_version::RuntimeVersion;
 
 // Local module imports
 use super::{
-	AccountId, Balance, Block, Executive, InherentDataExt, Nonce, Runtime,
+	AccountId, Balance, Block, Executive, Grandpa, InherentDataExt, Nonce, Runtime,
 	RuntimeCall, RuntimeGenesisConfig, SessionKeys, System, TransactionPayment, VERSION,
 	inherent_checks::check_timestamp_drift,
 };
@@ -294,6 +294,33 @@ impl_runtime_apis! {
 	impl sha256pow::PowVerifyApi<Block> for Runtime {
 		fn verify_seal(pre_hash: sp_core::H256, seal: Vec<u8>, difficulty: U256) -> bool {
 			sha256pow::verify_seal(pre_hash, &seal, difficulty).unwrap_or(false)
+		}
+	}
+
+	impl sp_consensus_grandpa::GrandpaApi<Block> for Runtime {
+		fn grandpa_authorities() -> sp_consensus_grandpa::AuthorityList {
+			Grandpa::grandpa_authorities()
+		}
+
+		fn current_set_id() -> sp_consensus_grandpa::SetId {
+			Grandpa::current_set_id()
+		}
+
+		fn submit_report_equivocation_unsigned_extrinsic(
+			_equivocation_proof: sp_consensus_grandpa::EquivocationProof<
+				<Block as sp_runtime::traits::Block>::Hash,
+				sp_runtime::traits::NumberFor<Block>,
+			>,
+			_key_owner_proof: sp_consensus_grandpa::OpaqueKeyOwnershipProof,
+		) -> Option<()> {
+			None
+		}
+
+		fn generate_key_ownership_proof(
+			_set_id: sp_consensus_grandpa::SetId,
+			_authority_id: sp_consensus_grandpa::AuthorityId,
+		) -> Option<sp_consensus_grandpa::OpaqueKeyOwnershipProof> {
+			None
 		}
 	}
 

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -176,3 +176,13 @@ impl pallet_difficulty::Config for Runtime {
 	type TargetBlockTime = TargetBlockTime;
 	type Halflife = DifficultyHalflife;
 }
+
+impl pallet_grandpa::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+	type MaxAuthorities = ConstU32<1000>;
+	type MaxNominators = ConstU32<0>;
+	type MaxSetIdSessionEntries = ConstU64<0>;
+	type KeyOwnerProof = sp_core::Void;
+	type EquivocationReportSystem = ();
+}

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -15,17 +15,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{AccountId, BalancesConfig, DifficultyConfig, RuntimeGenesisConfig, SudoConfig, UNIT};
+use crate::{AccountId, BalancesConfig, DifficultyConfig, GrandpaConfig, RuntimeGenesisConfig, SudoConfig, UNIT};
 use alloc::{vec, vec::Vec};
 use frame_support::build_struct_json_patch;
 use serde_json::Value;
+use sp_consensus_grandpa::AuthorityId as GrandpaId;
 use sp_core::U256;
 use sp_genesis_builder::{self, PresetId};
-use sp_keyring::Sr25519Keyring;
+use sp_keyring::{Ed25519Keyring, Sr25519Keyring};
 
 fn testnet_genesis(
 	endowed_accounts: Vec<AccountId>,
 	root: AccountId,
+	initial_grandpa_authorities: Vec<(GrandpaId, u64)>,
 ) -> Value {
 	let total_supply: u128 = 1_000_000_000 * UNIT;
 	let balance_per_account = total_supply / endowed_accounts.len() as u128;
@@ -46,6 +48,10 @@ fn testnet_genesis(
 			anchor_height: 0,
 			..Default::default()
 		},
+		grandpa: GrandpaConfig {
+			authorities: initial_grandpa_authorities,
+			..Default::default()
+		},
 	})
 }
 
@@ -58,6 +64,11 @@ pub fn development_config_genesis() -> Value {
 			Sr25519Keyring::BobStash.to_account_id(),
 		],
 		Sr25519Keyring::Alice.to_account_id(),
+		vec![
+			(Ed25519Keyring::Alice.public().into(), 1),
+			(Ed25519Keyring::Bob.public().into(), 1),
+			(Ed25519Keyring::Charlie.public().into(), 1),
+		],
 	)
 }
 
@@ -68,6 +79,11 @@ pub fn local_config_genesis() -> Value {
 			.map(|v| v.to_account_id())
 			.collect::<Vec<_>>(),
 		Sr25519Keyring::Alice.to_account_id(),
+		vec![
+			(Ed25519Keyring::Alice.public().into(), 1),
+			(Ed25519Keyring::Bob.public().into(), 1),
+			(Ed25519Keyring::Charlie.public().into(), 1),
+		],
 	)
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -224,4 +224,7 @@ mod runtime {
 
 	#[runtime::pallet_index(9)]
 	pub type Difficulty = pallet_difficulty;
+
+	#[runtime::pallet_index(10)]
+	pub type Grandpa = pallet_grandpa;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -52,7 +52,9 @@ pub mod opaque {
 }
 
 impl_opaque_keys! {
-	pub struct SessionKeys {}
+	pub struct SessionKeys {
+		pub grandpa: Grandpa,
+	}
 }
 
 // To learn more about runtime versioning, see:


### PR DESCRIPTION
## Summary

Integrate `pallet-grandpa` into the runtime to enable GRANDPA BFT finality.

## Changes

- Added `pallet-grandpa` and `sp-consensus-grandpa` as runtime dependencies
- Implemented `pallet_grandpa::Config` with `MaxAuthorities = 1000` and `MaxNominators = 0`
- Registered GRANDPA pallet at runtime index 10
- Added `GrandpaId` to `SessionKeys`
- Implemented `GrandpaApi` runtime API (`grandpa_authorities`, `current_set_id`)
- Configured genesis presets (dev & local) with 3 initial validators: Alice, Bob, Charlie

Closes #17