### PR TITLE
Integrate pallet-session into Runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10350,6 +10350,7 @@ dependencies = [
  "pallet-difficulty",
  "pallet-grandpa",
  "pallet-reward",
+ "pallet-session",
  "pallet-sudo",
  "pallet-template",
  "pallet-timestamp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ frame-try-runtime = { version = "0.52.0", default-features = false }
 pallet-aura = { version = "45.0.0", default-features = false }
 pallet-balances = { version = "47.0.0", default-features = false }
 pallet-grandpa = { version = "46.0.0", default-features = false }
+pallet-session = { version = "46.0.0", default-features = false }
 pallet-sudo = { version = "46.0.0", default-features = false }
 pallet-timestamp = { version = "45.0.0", default-features = false }
 pallet-transaction-payment-rpc-runtime-api = { version = "46.0.0", default-features = false }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -26,6 +26,7 @@ pallet-balances.workspace = true
 pallet-difficulty.workspace = true
 pallet-grandpa.workspace = true
 pallet-reward.workspace = true
+pallet-session.workspace = true
 pallet-sudo.workspace = true
 pallet-template.workspace = true
 pallet-timestamp.workspace = true
@@ -69,6 +70,7 @@ std = [
 	"pallet-difficulty/std",
 	"pallet-grandpa/std",
 	"pallet-reward/std",
+	"pallet-session/std",
 	"pallet-sudo/std",
 	"pallet-template/std",
 	"pallet-timestamp/std",
@@ -104,6 +106,7 @@ runtime-benchmarks = [
 	"pallet-difficulty/runtime-benchmarks",
 	"pallet-grandpa/runtime-benchmarks",
 	"pallet-reward/runtime-benchmarks",
+	"pallet-session/runtime-benchmarks",
 	"pallet-sudo/runtime-benchmarks",
 	"pallet-template/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
@@ -120,6 +123,7 @@ try-runtime = [
 	"pallet-difficulty/try-runtime",
 	"pallet-grandpa/try-runtime",
 	"pallet-reward/try-runtime",
+	"pallet-session/try-runtime",
 	"pallet-sudo/try-runtime",
 	"pallet-template/try-runtime",
 	"pallet-timestamp/try-runtime",

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -33,15 +33,16 @@ use frame_support::{
 	},
 };
 use frame_system::limits::{BlockLength, BlockWeights};
+use pallet_session::PeriodicSessions;
 use pallet_transaction_payment::{FungibleAdapter, Multiplier, TargetedFeeAdjustment};
-use sp_runtime::{FixedPointNumber, Perbill, Perquintill};
+use sp_runtime::{traits::ConvertInto, FixedPointNumber, Perbill, Perquintill};
 use sp_version::RuntimeVersion;
 
 // Local module imports
 use super::{
 	AccountId, Balance, Balances, Block, BlockNumber, Hash, Nonce, PalletInfo, Runtime,
 	RuntimeCall, RuntimeEvent, RuntimeFreezeReason, RuntimeHoldReason, RuntimeOrigin, RuntimeTask,
-	System, EXISTENTIAL_DEPOSIT, SLOT_DURATION, VERSION,
+	SessionKeys, System, EXISTENTIAL_DEPOSIT, SLOT_DURATION, VERSION,
 };
 
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
@@ -185,4 +186,28 @@ impl pallet_grandpa::Config for Runtime {
 	type MaxSetIdSessionEntries = ConstU64<0>;
 	type KeyOwnerProof = sp_core::Void;
 	type EquivocationReportSystem = ();
+}
+
+parameter_types! {
+	/// Length of a session in blocks (~10 minutes at 6s block time, but our PoW
+	/// targets ~20s, so a session lasts ~10 minutes either way for genesis tests).
+	pub const SessionPeriod: BlockNumber = 30;
+	pub const SessionOffset: BlockNumber = 0;
+}
+
+impl pallet_session::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type ValidatorId = AccountId;
+	type ValidatorIdOf = ConvertInto;
+	type ShouldEndSession = PeriodicSessions<SessionPeriod, SessionOffset>;
+	type NextSessionRotation = PeriodicSessions<SessionPeriod, SessionOffset>;
+	// Hardcoded validator set comes from genesis. The session manager keeps
+	// the set unchanged until pallet-validator-staking takes over (issue #016).
+	type SessionManager = ();
+	type SessionHandler = <SessionKeys as sp_runtime::traits::OpaqueKeys>::KeyTypeIdProviders;
+	type Keys = SessionKeys;
+	type DisablingStrategy = ();
+	type WeightInfo = pallet_session::weights::SubstrateWeight<Runtime>;
+	type Currency = Balances;
+	type KeyDeposit = ConstU128<0>;
 }

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -15,7 +15,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{AccountId, BalancesConfig, DifficultyConfig, GrandpaConfig, RuntimeGenesisConfig, SudoConfig, UNIT};
+use crate::{
+	AccountId, BalancesConfig, DifficultyConfig, RuntimeGenesisConfig, SessionConfig, SessionKeys,
+	SudoConfig, UNIT,
+};
 use alloc::{vec, vec::Vec};
 use frame_support::build_struct_json_patch;
 use serde_json::Value;
@@ -27,7 +30,7 @@ use sp_keyring::{Ed25519Keyring, Sr25519Keyring};
 fn testnet_genesis(
 	endowed_accounts: Vec<AccountId>,
 	root: AccountId,
-	initial_grandpa_authorities: Vec<(GrandpaId, u64)>,
+	initial_validators: Vec<(AccountId, GrandpaId)>,
 ) -> Value {
 	let total_supply: u128 = 1_000_000_000 * UNIT;
 	let balance_per_account = total_supply / endowed_accounts.len() as u128;
@@ -46,11 +49,14 @@ fn testnet_genesis(
 			anchor_target: U256::zero(),
 			anchor_timestamp: 0,
 			anchor_height: 0,
-			..Default::default()
 		},
-		grandpa: GrandpaConfig {
-			authorities: initial_grandpa_authorities,
-			..Default::default()
+		session: SessionConfig {
+			keys: initial_validators
+				.into_iter()
+				.map(|(account, grandpa)| {
+					(account.clone(), account, SessionKeys { grandpa })
+				})
+				.collect::<Vec<_>>(),
 		},
 	})
 }
@@ -65,9 +71,9 @@ pub fn development_config_genesis() -> Value {
 		],
 		Sr25519Keyring::Alice.to_account_id(),
 		vec![
-			(Ed25519Keyring::Alice.public().into(), 1),
-			(Ed25519Keyring::Bob.public().into(), 1),
-			(Ed25519Keyring::Charlie.public().into(), 1),
+			(Sr25519Keyring::Alice.to_account_id(), Ed25519Keyring::Alice.public().into()),
+			(Sr25519Keyring::Bob.to_account_id(), Ed25519Keyring::Bob.public().into()),
+			(Sr25519Keyring::Charlie.to_account_id(), Ed25519Keyring::Charlie.public().into()),
 		],
 	)
 }
@@ -80,9 +86,9 @@ pub fn local_config_genesis() -> Value {
 			.collect::<Vec<_>>(),
 		Sr25519Keyring::Alice.to_account_id(),
 		vec![
-			(Ed25519Keyring::Alice.public().into(), 1),
-			(Ed25519Keyring::Bob.public().into(), 1),
-			(Ed25519Keyring::Charlie.public().into(), 1),
+			(Sr25519Keyring::Alice.to_account_id(), Ed25519Keyring::Alice.public().into()),
+			(Sr25519Keyring::Bob.to_account_id(), Ed25519Keyring::Bob.public().into()),
+			(Sr25519Keyring::Charlie.to_account_id(), Ed25519Keyring::Charlie.public().into()),
 		],
 	)
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -229,4 +229,7 @@ mod runtime {
 
 	#[runtime::pallet_index(10)]
 	pub type Grandpa = pallet_grandpa;
+
+	#[runtime::pallet_index(11)]
+	pub type Session = pallet_session;
 }


### PR DESCRIPTION
## Summary

Integrates `pallet-session` into the runtime so that the validator set rotates on a fixed 30-block cadence. Session keys are now the single source of truth for GRANDPA authorities at genesis, paving the way for `pallet-validator-staking` (issue #016) to take over the `SessionManager` role later.

## Changes

- Add `pallet-session 46.0.0` workspace dependency and wire it into the runtime crate (`std`, `runtime-benchmarks`, `try-runtime`)
- Configure `pallet_session::Config` with `PeriodicSessions<30, 0>`, `SessionHandler` derived from `SessionKeys`, `Balances` as the deposit currency, and `KeyDeposit = 0`
- Use `SessionManager = ()` as a placeholder so the genesis validator set stays put until staking is wired
- Register `Session` at runtime pallet index 11
- Replace direct `GrandpaConfig.authorities` seeding with `SessionConfig.keys`; `pallet_grandpa::OneSessionHandler::on_genesis_session` now installs the initial authority set
- Update dev/local presets to declare validators as `(AccountId, GrandpaId)` pairs

Closes #20