### PR TITLE
Integrate pallet-validator into Runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6548,6 +6548,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-validator"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
 name = "parity-db"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10356,6 +10369,7 @@ dependencies = [
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-validator",
  "parity-scale-codec",
  "scale-info",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "pallets/difficulty",
     "pallets/reward",
     "pallets/template",
+    "pallets/validator",
     "runtime",
 ]
 resolver = "2"
@@ -23,6 +24,7 @@ sha256pow = { path = "./consensus/sha256pow", default-features = false }
 pallet-difficulty = { path = "./pallets/difficulty", default-features = false }
 pallet-reward = { path = "./pallets/reward", default-features = false }
 pallet-template = { path = "./pallets/template", default-features = false }
+pallet-validator = { path = "./pallets/validator", default-features = false }
 clap = { version = "4.6.0" }
 futures = { version = "0.3.32" }
 futures-timer = { version = "3.0.3" }

--- a/pallets/validator/Cargo.toml
+++ b/pallets/validator/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "pallet-validator"
+description = "Validator lifecycle pallet: lock, auto-renewal, exit, and kick."
+version = "0.1.0"
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+codec = { features = ["derive"], workspace = true }
+frame-support.workspace = true
+frame-system.workspace = true
+pallet-balances.workspace = true
+scale-info = { features = ["derive"], workspace = true }
+sp-runtime.workspace = true
+
+[dev-dependencies]
+sp-io.default-features = true
+sp-io.workspace = true
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"pallet-balances/std",
+	"scale-info/std",
+	"sp-runtime/std",
+]
+runtime-benchmarks = [
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+]
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"pallet-balances/try-runtime",
+]

--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -1,0 +1,147 @@
+//! # Pallet Validator
+//!
+//! Manages the full lifecycle of validators: lock, auto-renewal, exit,
+//! and kick. This crate currently provides the storage, event, and error
+//! skeleton.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
+use frame_support::traits::Currency;
+use scale_info::TypeInfo;
+
+/// Balance type alias derived from the configured `Currency`.
+pub type BalanceOf<T> =
+	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+
+/// Lifecycle state of a validator's stake.
+#[derive(
+	Clone, Copy, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen,
+)]
+pub enum ValidatorStatus {
+	/// Active in the validator set; eligible for auto-renewal.
+	Active,
+	/// Voluntary exit requested; auto-renewal stopped, awaiting expiry.
+	ExitRequested,
+	/// Kicked due to offline or equivocation; in cooldown.
+	Kicked,
+	/// Cooldown period after equivocation kick.
+	Cooldown,
+}
+
+/// Lock record for a validator's stake.
+#[derive(
+	Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen,
+)]
+pub struct LockInfo<Balance, BlockNumber> {
+	/// Locked amount.
+	pub amount: Balance,
+	/// Block at which the lock was created.
+	pub lock_block: BlockNumber,
+	/// Block at which the lock expires (subject to auto-renewal).
+	pub expiry_block: BlockNumber,
+	/// Whether the lock auto-renews while `Active`.
+	pub auto_renew: bool,
+	/// Current lifecycle status.
+	pub status: ValidatorStatus,
+}
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config<RuntimeEvent: From<Event<Self>>> {
+		/// Currency used for validator stake locking.
+		type Currency: Currency<Self::AccountId>;
+	}
+
+	/// Active validator lock records, keyed by account.
+	#[pallet::storage]
+	pub type ValidatorLocks<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		T::AccountId,
+		LockInfo<BalanceOf<T>, BlockNumberFor<T>>,
+		OptionQuery,
+	>;
+
+	/// Equivocation cooldown deadline per account (block number).
+	#[pallet::storage]
+	pub type EquivocationCooldown<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, BlockNumberFor<T>, OptionQuery>;
+
+	/// Consecutive offline session count per account.
+	#[pallet::storage]
+	pub type OfflineSessionCount<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, u32, ValueQuery>;
+
+	#[pallet::event]
+	// `deposit_event` is unused until dispatchables/hooks land in follow-up
+	// issues (#012b onwards); declare it now so callers don't need to be
+	// retro-fitted later.
+	#[allow(dead_code)]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// A validator locked stake. `[who, amount, expiry_block]`
+		ValidatorLocked {
+			who: T::AccountId,
+			amount: BalanceOf<T>,
+			expiry_block: BlockNumberFor<T>,
+		},
+		/// A validator requested voluntary exit.
+		ValidatorExitRequested { who: T::AccountId },
+		/// A validator was kicked (offline or equivocation).
+		ValidatorKicked { who: T::AccountId, reason: KickReason },
+		/// A validator's lock was released after expiry.
+		LockReleased { who: T::AccountId, amount: BalanceOf<T> },
+		/// A validator's lock was auto-renewed to a new expiry block.
+		LockRenewed { who: T::AccountId, new_expiry_block: BlockNumberFor<T> },
+	}
+
+	/// Reason a validator was removed from the active set.
+	#[derive(
+		Clone,
+		Copy,
+		PartialEq,
+		Eq,
+		Debug,
+		Encode,
+		Decode,
+		DecodeWithMemTracking,
+		TypeInfo,
+		MaxEncodedLen,
+	)]
+	pub enum KickReason {
+		/// Removed for being offline beyond the threshold.
+		Offline,
+		/// Removed for GRANDPA equivocation.
+		Equivocation,
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// Account is already a validator.
+		AlreadyValidator,
+		/// Account is not a registered validator.
+		NotValidator,
+		/// Provided stake amount is below the minimum threshold.
+		InsufficientStake,
+		/// Provided lock duration is below the minimum.
+		LockDurationTooShort,
+		/// Operation not permitted in the current validator status.
+		InvalidStatus,
+		/// Lock has not yet reached its expiry block.
+		LockNotExpired,
+		/// Account is currently within an equivocation cooldown.
+		InCooldown,
+	}
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -32,6 +32,7 @@ pallet-template.workspace = true
 pallet-timestamp.workspace = true
 pallet-transaction-payment-rpc-runtime-api.workspace = true
 pallet-transaction-payment.workspace = true
+pallet-validator.workspace = true
 scale-info = { features = ["derive", "serde"], workspace = true }
 serde_json = { workspace = true, default-features = false, features = ["alloc"] }
 sha256pow.workspace = true
@@ -76,6 +77,7 @@ std = [
 	"pallet-timestamp/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	"pallet-transaction-payment/std",
+	"pallet-validator/std",
 	"scale-info/std",
 	"serde_json/std",
 	"sha256pow/std",
@@ -111,6 +113,7 @@ runtime-benchmarks = [
 	"pallet-template/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"pallet-transaction-payment/runtime-benchmarks",
+	"pallet-validator/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 ]
 
@@ -128,6 +131,7 @@ try-runtime = [
 	"pallet-template/try-runtime",
 	"pallet-timestamp/try-runtime",
 	"pallet-transaction-payment/try-runtime",
+	"pallet-validator/try-runtime",
 	"sp-runtime/try-runtime",
 ]
 

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -211,3 +211,7 @@ impl pallet_session::Config for Runtime {
 	type Currency = Balances;
 	type KeyDeposit = ConstU128<0>;
 }
+
+impl pallet_validator::Config for Runtime {
+	type Currency = Balances;
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -232,4 +232,7 @@ mod runtime {
 
 	#[runtime::pallet_index(11)]
 	pub type Session = pallet_session;
+
+	#[runtime::pallet_index(12)]
+	pub type Validator = pallet_validator;
 }


### PR DESCRIPTION
## Summary

Integrates `pallet-validator` into the runtime. This pallet will manage the full validator lifecycle (lock, auto-renewal, exit, kick).
This PR establishes only the type, storage, event, and error skeleton, the dispatchables and lifecycle hooks are delivered by follow-up issues.

## Changes

### Pallets

  - `LockInfo`, `ValidatorStatus`, `KickReason` types
  - `Config` trait with `Currency` association
  - Storages: `ValidatorLocks`, `EquivocationCooldown`, `OfflineSessionCount`
  - Events: locked / exit-requested / kicked / released / renewed
  - Errors: AlreadyValidator, NotValidator, InsufficientStake,
    LockDurationTooShort, InvalidStatus, LockNotExpired, InCooldown
  - Empty `Hooks` (filled by follow-up issues)

### Runtime

  - Added `pallet-validator` to workspace and runtime `Cargo.toml`
    (std / runtime-benchmarks / try-runtime features)
  - `impl pallet_validator::Config for Runtime`
  - Registered in `construct_runtime!` at pallet index 12

Closes #22 