### PR TITLE
Implement Validator Lock

### DIFF
--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -8,6 +8,11 @@
 
 pub use pallet::*;
 
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::traits::{Currency, LockableCurrency};
 use scale_info::TypeInfo;

--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -9,12 +9,12 @@
 pub use pallet::*;
 
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
-use frame_support::traits::Currency;
+use frame_support::traits::{Currency, LockableCurrency};
 use scale_info::TypeInfo;
+use sp_runtime::traits::Saturating;
 
 /// Balance type alias derived from the configured `Currency`.
-pub type BalanceOf<T> =
-	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+pub type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId,>>::Balance;
 
 /// Lifecycle state of a validator's stake.
 #[derive(
@@ -36,22 +36,18 @@ pub enum ValidatorStatus {
 	Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen,
 )]
 pub struct LockInfo<Balance, BlockNumber> {
-	/// Locked amount.
 	pub amount: Balance,
-	/// Block at which the lock was created.
 	pub lock_block: BlockNumber,
-	/// Block at which the lock expires (subject to auto-renewal).
 	pub expiry_block: BlockNumber,
-	/// Whether the lock auto-renews while `Active`.
-	pub auto_renew: bool,
-	/// Current lifecycle status.
-	pub status: ValidatorStatus,
 }
 
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_support::pallet_prelude::*;
+	use frame_support::{
+		pallet_prelude::*,
+		traits::{LockIdentifier, WithdrawReasons},
+	};
 	use frame_system::pallet_prelude::*;
 
 	#[pallet::pallet]
@@ -60,7 +56,23 @@ pub mod pallet {
 	#[pallet::config]
 	pub trait Config: frame_system::Config<RuntimeEvent: From<Event<Self>>> {
 		/// Currency used for validator stake locking.
-		type Currency: Currency<Self::AccountId>;
+		type Currency: LockableCurrency<Self::AccountId, Moment = BlockNumberFor<Self>>;
+
+		/// Minimum amount that must be locked to register as a validator.
+		#[pallet::constant]
+		type MinLockAmount: Get<BalanceOf<Self>>;
+
+		/// Minimum lock duration (in blocks) required at registration time.
+		#[pallet::constant]
+		type MinLockDuration: Get<BlockNumberFor<Self>>;
+
+		/// Lock identifier used when calling `set_lock` on the underlying currency.
+		#[pallet::constant]
+		type LockId: Get<LockIdentifier>;
+
+		/// Upper bound for the number of pending/active validators tracked in storage.
+		#[pallet::constant]
+		type MaxValidators: Get<u32>;
 	}
 
 	/// Active validator lock records, keyed by account.
@@ -73,19 +85,20 @@ pub mod pallet {
 		OptionQuery,
 	>;
 
-	/// Equivocation cooldown deadline per account (block number).
+	/// Validators waiting to be promoted into the active set at the next session boundary.
 	#[pallet::storage]
-	pub type EquivocationCooldown<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, BlockNumberFor<T>, OptionQuery>;
+	pub type PendingValidators<T: Config> =
+		StorageValue<_, BoundedVec<T::AccountId, T::MaxValidators>, ValueQuery>;
+
+	/// Rejoin cooldown deadline per account (block number).
+	#[pallet::storage]
+	pub type RejoinCooldown<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, BlockNumberFor<T>, OptionQuery>;
 
 	/// Consecutive offline session count per account.
 	#[pallet::storage]
 	pub type OfflineSessionCount<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, u32, ValueQuery>;
 
 	#[pallet::event]
-	// `deposit_event` is unused until dispatchables/hooks land in follow-up
-	// issues (#012b onwards); declare it now so callers don't need to be
-	// retro-fitted later.
-	#[allow(dead_code)]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// A validator locked stake. `[who, amount, expiry_block]`
@@ -130,18 +143,79 @@ pub mod pallet {
 		AlreadyValidator,
 		/// Account is not a registered validator.
 		NotValidator,
-		/// Provided stake amount is below the minimum threshold.
-		InsufficientStake,
-		/// Provided lock duration is below the minimum.
-		LockDurationTooShort,
 		/// Operation not permitted in the current validator status.
 		InvalidStatus,
 		/// Lock has not yet reached its expiry block.
 		LockNotExpired,
 		/// Account is currently within an equivocation cooldown.
 		InCooldown,
+		/// Account does not have enough free balance to cover the configured lock.
+		InsufficientBalance,
+		/// The pending validator queue is full.
+		TooManyValidators,
 	}
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Lock the configured stake amount for the configured duration and
+		/// queue the caller into [`PendingValidators`] for the next session.
+		///
+		/// The locked amount and duration are taken from `Config::MinLockAmount`
+		/// and `Config::MinLockDuration` respectively; callers do not choose them.
+		#[pallet::call_index(0)]
+		#[pallet::weight(Weight::from_parts(50_000_000, 0))]
+		pub fn lock(origin: OriginFor<T>) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+
+			ensure!(!ValidatorLocks::<T>::contains_key(&who), Error::<T>::AlreadyValidator);
+
+			let now = frame_system::Pallet::<T>::block_number();
+			if let Some(deadline) = RejoinCooldown::<T>::get(&who) {
+				if deadline > now {
+					return Err(Error::<T>::InCooldown.into());
+				}
+				RejoinCooldown::<T>::remove(&who);
+			}
+
+			let amount = T::MinLockAmount::get();
+			let duration = T::MinLockDuration::get();
+
+			ensure!(
+				T::Currency::free_balance(&who) >= amount,
+				Error::<T>::InsufficientBalance,
+			);
+
+			let expiry_block = now.saturating_add(duration);
+
+			PendingValidators::<T>::try_mutate(|queue| -> DispatchResult {
+				ensure!(!queue.iter().any(|a| a == &who), Error::<T>::AlreadyValidator);
+				queue
+					.try_push(who.clone())
+					.map_err(|_| Error::<T>::TooManyValidators)?;
+				Ok(())
+			})?;
+
+			T::Currency::set_lock(
+				T::LockId::get(),
+				&who,
+				amount,
+				WithdrawReasons::all(),
+			);
+
+			ValidatorLocks::<T>::insert(
+				&who,
+				LockInfo {
+					amount,
+					lock_block: now,
+					expiry_block
+				},
+			);
+
+			Self::deposit_event(Event::ValidatorLocked { who, amount, expiry_block });
+			Ok(())
+		}
+	}
 }

--- a/pallets/validator/src/mock.rs
+++ b/pallets/validator/src/mock.rs
@@ -1,0 +1,102 @@
+use crate as pallet_validator;
+use frame_support::{
+	derive_impl, parameter_types,
+	traits::{ConstU128, ConstU32, ConstU64, LockIdentifier, VariantCountOf},
+};
+use sp_runtime::BuildStorage;
+
+pub type AccountId = u64;
+pub type Balance = u128;
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+#[frame_support::runtime]
+mod runtime {
+	#[runtime::runtime]
+	#[runtime::derive(
+		RuntimeCall,
+		RuntimeEvent,
+		RuntimeError,
+		RuntimeOrigin,
+		RuntimeFreezeReason,
+		RuntimeHoldReason,
+		RuntimeSlashReason,
+		RuntimeLockId,
+		RuntimeTask,
+		RuntimeViewFunction
+	)]
+	pub struct Test;
+
+	#[runtime::pallet_index(0)]
+	pub type System = frame_system::Pallet<Test>;
+
+	#[runtime::pallet_index(1)]
+	pub type Balances = pallet_balances::Pallet<Test>;
+
+	#[runtime::pallet_index(2)]
+	pub type Validator = pallet_validator::Pallet<Test>;
+}
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+	type Block = Block;
+	type AccountId = AccountId;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type Lookup = sp_runtime::traits::IdentityLookup<AccountId>;
+}
+
+impl pallet_balances::Config for Test {
+	type MaxLocks = ConstU32<10>;
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 8];
+	type Balance = Balance;
+	type RuntimeEvent = RuntimeEvent;
+	type DustRemoval = ();
+	type ExistentialDeposit = ConstU128<1>;
+	type AccountStore = System;
+	type WeightInfo = ();
+	type FreezeIdentifier = RuntimeFreezeReason;
+	type MaxFreezes = VariantCountOf<RuntimeFreezeReason>;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
+	type DoneSlashHandler = ();
+}
+
+parameter_types! {
+	pub const TestLockId: LockIdentifier = *b"validatr";
+}
+
+impl pallet_validator::Config for Test {
+	type Currency = Balances;
+	type MinLockAmount = ConstU128<1_000>;
+	type MinLockDuration = ConstU64<10>;
+	type LockId = TestLockId;
+	type MaxValidators = ConstU32<3>;
+}
+
+pub const ALICE: AccountId = 1;
+pub const BOB: AccountId = 2;
+pub const CHARLIE: AccountId = 3;
+pub const DAVE: AccountId = 4;
+pub const EVE: AccountId = 5;
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let mut t = frame_system::GenesisConfig::<Test>::default()
+		.build_storage()
+		.unwrap();
+	pallet_balances::GenesisConfig::<Test> {
+		balances: vec![
+			(ALICE, 10_000),
+			(BOB, 10_000),
+			(CHARLIE, 10_000),
+			(DAVE, 10_000),
+			(EVE, 500),
+		],
+		..Default::default()
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+	let mut ext: sp_io::TestExternalities = t.into();
+	ext.execute_with(|| System::set_block_number(1));
+	ext
+}

--- a/pallets/validator/src/tests.rs
+++ b/pallets/validator/src/tests.rs
@@ -1,0 +1,100 @@
+use crate::{
+	mock::*, Error, Event, LockInfo, PendingValidators, RejoinCooldown, ValidatorLocks,
+};
+use frame_support::{assert_noop, assert_ok};
+use sp_runtime::{traits::Dispatchable, DispatchError, TokenError};
+
+#[test]
+fn lock_succeeds_and_records_state() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+
+		let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock recorded");
+		assert_eq!(
+			lock,
+			LockInfo { amount: 1_000, lock_block: 1, expiry_block: 11 }
+		);
+		assert_eq!(PendingValidators::<Test>::get().to_vec(), vec![ALICE]);
+		System::assert_last_event(
+			Event::ValidatorLocked { who: ALICE, amount: 1_000, expiry_block: 11 }.into(),
+		);
+	});
+}
+
+#[test]
+fn lock_fails_when_balance_insufficient() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Validator::lock(RuntimeOrigin::signed(EVE)),
+			Error::<Test>::InsufficientBalance
+		);
+		assert!(ValidatorLocks::<Test>::get(EVE).is_none());
+		assert!(PendingValidators::<Test>::get().is_empty());
+	});
+}
+
+#[test]
+fn lock_fails_when_already_validator() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+		assert_noop!(
+			Validator::lock(RuntimeOrigin::signed(ALICE)),
+			Error::<Test>::AlreadyValidator
+		);
+	});
+}
+
+#[test]
+fn lock_rejected_during_active_cooldown() {
+	new_test_ext().execute_with(|| {
+		RejoinCooldown::<Test>::insert(ALICE, 100u64);
+		assert_noop!(
+			Validator::lock(RuntimeOrigin::signed(ALICE)),
+			Error::<Test>::InCooldown
+		);
+		assert!(RejoinCooldown::<Test>::get(ALICE).is_some());
+	});
+}
+
+#[test]
+fn lock_succeeds_after_cooldown_expires_and_clears_record() {
+	new_test_ext().execute_with(|| {
+		RejoinCooldown::<Test>::insert(ALICE, 1u64);
+		System::set_block_number(2);
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+		assert!(RejoinCooldown::<Test>::get(ALICE).is_none());
+	});
+}
+
+#[test]
+fn locked_balance_cannot_be_transferred() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+
+		// Free balance is 10_000 and 1_000 is locked. Anything that would push the
+		// usable balance below 1_000 must be rejected by pallet-balances.
+		let call = pallet_balances::Call::<Test>::transfer_keep_alive {
+			dest: BOB,
+			value: 9_500,
+		};
+		let res = RuntimeCall::Balances(call).dispatch(RuntimeOrigin::signed(ALICE));
+		assert_eq!(res.unwrap_err().error, DispatchError::Token(TokenError::Frozen));
+
+		// A transfer that respects the lock still works.
+		assert_ok!(Balances::transfer_keep_alive(RuntimeOrigin::signed(ALICE), BOB, 8_000));
+	});
+}
+
+#[test]
+fn lock_fails_when_pending_queue_full() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(BOB)));
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(CHARLIE)));
+		assert_noop!(
+			Validator::lock(RuntimeOrigin::signed(DAVE)),
+			Error::<Test>::TooManyValidators
+		);
+		assert!(ValidatorLocks::<Test>::get(DAVE).is_none());
+	});
+}

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -42,7 +42,7 @@ use sp_version::RuntimeVersion;
 use super::{
 	AccountId, Balance, Balances, Block, BlockNumber, Hash, Nonce, PalletInfo, Runtime,
 	RuntimeCall, RuntimeEvent, RuntimeFreezeReason, RuntimeHoldReason, RuntimeOrigin, RuntimeTask,
-	SessionKeys, System, EXISTENTIAL_DEPOSIT, SLOT_DURATION, VERSION,
+	SessionKeys, System, EXISTENTIAL_DEPOSIT, SLOT_DURATION, UNIT, VERSION,
 };
 
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
@@ -212,6 +212,14 @@ impl pallet_session::Config for Runtime {
 	type KeyDeposit = ConstU128<0>;
 }
 
+parameter_types! {
+	pub const ValidatorLockId: frame_support::traits::LockIdentifier = *b"validatr";
+}
+
 impl pallet_validator::Config for Runtime {
 	type Currency = Balances;
+	type MinLockAmount = ConstU128<{ 1_000 * UNIT }>;
+	type MinLockDuration = ConstU32<4_320>;
+	type LockId = ValidatorLockId;
+	type MaxValidators = ConstU32<1_000>;
 }


### PR DESCRIPTION
## Summary

Implements the `lock` extrinsic in `pallet-validator`, allowing accounts to register as validators by locking the configured stake amount for the configured duration. Also wires the corresponding runtime constants and adds unit tests for the locking flow.

## Changes

### `pallet-validator`

- `Config` trait
  - Bound `Currency` upgraded from `Currency` to `LockableCurrency`.
  - New constants: `MinLockAmount`, `MinLockDuration`, `LockId`, `MaxValidators`.
- Storage
  - New `PendingValidators: BoundedVec<AccountId, MaxValidators>` queue consumed by the upcoming session manager.
  - Renamed cooldown storage to `RejoinCooldown` to reflect its broader scope.
- Errors
  - Added `InsufficientBalance` and `TooManyValidators`.
- Extrinsic
  - `lock(origin)` (no parameters): the locked amount and duration are taken from `Config::MinLockAmount` / `Config::MinLockDuration`.
  - Validates: caller is not already locked, not in active cooldown (cleans up expired cooldown entries), and has sufficient free balance.
  - Calls `set_lock(LockId, who, amount, WithdrawReasons::all())` on the underlying lockable currency, records `LockInfo`, queues the caller into `PendingValidators`, and emits `ValidatorLocked`.

### Tests

- Adds `mock.rs` with a minimal runtime (System + Balances + Validator).
- Adds `tests.rs` covering:
  - `lock` happy path (storage, queue, event)
  - rejection on insufficient balance
  - rejection on duplicate registration
  - rejection while in active cooldown
  - success after cooldown expiry (with cleanup)
  - locked balance is non-transferable; unlocked portion still spendable
  - `PendingValidators` capacity limit

Closes #23 