### PR TITLE
Implement Validator Exit Mechanism

### DIFF
--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -264,5 +264,35 @@ pub mod pallet {
 			Self::deposit_event(Event::ValidatorLocked { who, amount, expiry_block });
 			Ok(())
 		}
+
+		/// Request voluntary exit from the active validator set.
+		///
+		/// Only an `Active` validator may call this. The validator's status
+		/// becomes `ExitRequested`, auto-renewal stops, and the account is
+		/// removed from [`PendingValidators`] so it will not be promoted at
+		/// the next session boundary. The underlying currency lock is kept in
+		/// place until its original `expiry_block` is reached; early unlocking
+		/// is not permitted.
+		#[pallet::call_index(1)]
+		#[pallet::weight(Weight::from_parts(40_000_000, 0))]
+		pub fn request_exit(origin: OriginFor<T>) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+
+			ValidatorLocks::<T>::try_mutate(&who, |maybe_info| -> DispatchResult {
+				let info = maybe_info.as_mut().ok_or(Error::<T>::NotValidator)?;
+				ensure!(info.status == ValidatorStatus::Active, Error::<T>::InvalidStatus);
+				info.status = ValidatorStatus::ExitRequested;
+				Ok(())
+			})?;
+
+			PendingValidators::<T>::mutate(|queue| {
+				if let Some(pos) = queue.iter().position(|a| a == &who) {
+					queue.remove(pos);
+				}
+			});
+
+			Self::deposit_event(Event::ValidatorExitRequested { who });
+			Ok(())
+		}
 	}
 }

--- a/pallets/validator/src/tests.rs
+++ b/pallets/validator/src/tests.rs
@@ -157,3 +157,86 @@ fn auto_renew_skips_non_active_status() {
 		assert_eq!(lock.status, ValidatorStatus::ExitRequested);
 	});
 }
+
+#[test]
+fn request_exit_changes_status_and_removes_from_pending() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(BOB)));
+		assert_eq!(PendingValidators::<Test>::get().to_vec(), vec![ALICE, BOB]);
+
+		assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+
+		let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock kept");
+		assert_eq!(lock.status, ValidatorStatus::ExitRequested);
+		assert_eq!(lock.expiry_block, 11);
+		assert_eq!(PendingValidators::<Test>::get().to_vec(), vec![BOB]);
+		System::assert_last_event(Event::ValidatorExitRequested { who: ALICE }.into());
+	});
+}
+
+#[test]
+fn request_exit_fails_when_not_validator() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Validator::request_exit(RuntimeOrigin::signed(ALICE)),
+			Error::<Test>::NotValidator
+		);
+	});
+}
+
+#[test]
+fn request_exit_fails_when_not_active() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+		assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+		// Second call: status is ExitRequested, not Active.
+		assert_noop!(
+			Validator::request_exit(RuntimeOrigin::signed(ALICE)),
+			Error::<Test>::InvalidStatus
+		);
+
+		// Kicked status also rejected.
+		ValidatorLocks::<Test>::mutate(BOB, |maybe| {
+			*maybe = Some(LockInfo {
+				amount: 1_000,
+				lock_block: 1,
+				expiry_block: 11,
+				status: ValidatorStatus::Kicked,
+			});
+		});
+		assert_noop!(
+			Validator::request_exit(RuntimeOrigin::signed(BOB)),
+			Error::<Test>::InvalidStatus
+		);
+	});
+}
+
+#[test]
+fn request_exit_stops_auto_renewal() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+		assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+		// Pass the renewal threshold: without exit, expiry would extend at block 6.
+		run_to_block(8);
+		let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock kept");
+		assert_eq!(lock.expiry_block, 11);
+		assert_eq!(lock.status, ValidatorStatus::ExitRequested);
+	});
+}
+
+#[test]
+fn request_exit_keeps_lock_until_expiry() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+		assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+
+		// Lock is still enforced: cannot move balance below the locked amount.
+		let call = pallet_balances::Call::<Test>::transfer_keep_alive {
+			dest: BOB,
+			value: 9_500,
+		};
+		let res = RuntimeCall::Balances(call).dispatch(RuntimeOrigin::signed(ALICE));
+		assert_eq!(res.unwrap_err().error, DispatchError::Token(TokenError::Frozen));
+	});
+}


### PR DESCRIPTION
## Summary

Implement the validator voluntary exit mechanism.

## Changes

### `pallets/validator`

- Add `request_exit()` extrinsic (`call_index = 1`)

### Tests

- request_exit_changes_status_and_removes_from_pending
- request_exit_fails_when_not_validator
- request_exit_fails_when_not_active
- request_exit_stops_auto_renewal
- request_exit_keeps_lock_until_expiry

Closes #25 