### PR TITLE
Implement Lock Expiry Auto-Unlock

### DIFF
--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -167,15 +167,19 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_initialize(now: BlockNumberFor<T>) -> Weight {
-			let interval = T::RenewInterval::get();
-			if interval.is_zero() {
-				return Weight::from_parts(0, 0);
-			}
-
 			let duration = T::LockDuration::get();
+			let interval = T::RenewInterval::get();
+
+			// First pass: collect expired locks and (when enabled) renewal candidates.
+			let mut to_release: alloc::vec::Vec<(T::AccountId, BalanceOf<T>)> =
+				alloc::vec::Vec::new();
 			let mut to_renew: alloc::vec::Vec<T::AccountId> = alloc::vec::Vec::new();
 			for (who, info) in ValidatorLocks::<T>::iter() {
-				if info.status != ValidatorStatus::Active {
+				if info.expiry_block <= now {
+					to_release.push((who, info.amount));
+					continue;
+				}
+				if interval.is_zero() || info.status != ValidatorStatus::Active {
 					continue;
 				}
 				let remaining = info.expiry_block.saturating_sub(now);
@@ -185,7 +189,16 @@ pub mod pallet {
 				}
 			}
 
-			let count = to_renew.len() as u64;
+			// Release expired locks: drop the currency lock, clear storage, emit event.
+			let release_count = to_release.len() as u64;
+			for (who, amount) in to_release {
+				T::Currency::remove_lock(T::LockId::get(), &who);
+				ValidatorLocks::<T>::remove(&who);
+				Self::deposit_event(Event::LockReleased { who, amount });
+			}
+
+			// Renew Active locks whose elapsed window has reached the configured interval.
+			let renew_count = to_renew.len() as u64;
 			for who in to_renew {
 				ValidatorLocks::<T>::mutate(&who, |maybe_info| {
 					if let Some(info) = maybe_info {
@@ -199,7 +212,8 @@ pub mod pallet {
 				});
 			}
 
-			// Rough weight: one read per lock scanned + one write per renewal.
+			// Rough weight: one read per scanned lock + one write per mutation.
+			let count = release_count.saturating_add(renew_count);
 			T::DbWeight::get().reads_writes(count, count)
 		}
 	}

--- a/pallets/validator/src/tests.rs
+++ b/pallets/validator/src/tests.rs
@@ -240,3 +240,66 @@ fn request_exit_keeps_lock_until_expiry() {
 		assert_eq!(res.unwrap_err().error, DispatchError::Token(TokenError::Frozen));
 	});
 }
+
+#[test]
+fn lock_released_when_expiry_reached() {
+	new_test_ext().execute_with(|| {
+		// Lock at block 1 -> expiry = 11. Request exit so renewal does not extend it.
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+		assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+
+		// Right before expiry: lock still in place.
+		run_to_block(10);
+		assert!(ValidatorLocks::<Test>::get(ALICE).is_some());
+
+		// At expiry block: lock released, storage cleared, event emitted.
+		run_to_block(11);
+		assert!(ValidatorLocks::<Test>::get(ALICE).is_none());
+		System::assert_last_event(
+			Event::LockReleased { who: ALICE, amount: 1_000 }.into(),
+		);
+
+		// Funds are fully transferable again.
+		assert_ok!(Balances::transfer_keep_alive(
+			RuntimeOrigin::signed(ALICE),
+			BOB,
+			9_500
+		));
+	});
+}
+
+#[test]
+fn unexpired_locks_not_released() {
+	new_test_ext().execute_with(|| {
+		// Two validators locked at block 1; both expire at block 11.
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(BOB)));
+		// Only ALICE requests exit so BOB keeps renewing.
+		assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+
+		// Advance to block 11: ALICE expires and is released. BOB renews twice
+		// (at blocks 6 and 11), so its expiry advances to 21 and stays Active.
+		run_to_block(11);
+		assert!(ValidatorLocks::<Test>::get(ALICE).is_none());
+		let bob = ValidatorLocks::<Test>::get(BOB).expect("bob lock kept");
+		assert_eq!(bob.expiry_block, 21);
+		assert_eq!(bob.status, ValidatorStatus::Active);
+	});
+}
+
+#[test]
+fn released_account_can_relock() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+		assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+		run_to_block(11);
+		assert!(ValidatorLocks::<Test>::get(ALICE).is_none());
+
+		// Storage is cleaned up, so a fresh lock call must succeed.
+		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+		let lock = ValidatorLocks::<Test>::get(ALICE).expect("relock recorded");
+		assert_eq!(lock.lock_block, 11);
+		assert_eq!(lock.expiry_block, 21);
+		assert_eq!(lock.status, ValidatorStatus::Active);
+	});
+}


### PR DESCRIPTION
## Summary

Implements automatic release of validator stake locks when their `expiry_block` is reached. The `on_initialize` hook now scans `ValidatorLocks` each block, removes expired entries from both the underlying currency lock and pallet storage, and emits the `LockReleased` event. Expiry handling runs before the existing renewal pass so an expired entry is never accidentally extended.

## Changes

### pallet/validator

- `on_initialize` collects expired entries (`expiry_block <= now`) and renewal candidates in a single scan
- Expired entries: `T::Currency::remove_lock(LockId, &who)`, storage entry removed, `LockReleased { who, amount }` emitted
- Renewal pass unchanged for `Active` locks; `RenewInterval == 0` still skips renewal but no longer short-circuits expiry processing

### Tests

- `lock_released_when_expiry_reached`
- `unexpired_locks_not_released`
- `released_account_can_relock`

Closes #26