### PR TITLE
Implement SessionManager Trait for pallet-session Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6554,6 +6554,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
+ "pallet-session",
  "parity-scale-codec",
  "scale-info",
  "sp-io",

--- a/pallets/validator/Cargo.toml
+++ b/pallets/validator/Cargo.toml
@@ -14,6 +14,7 @@ codec = { features = ["derive"], workspace = true }
 frame-support.workspace = true
 frame-system.workspace = true
 pallet-balances.workspace = true
+pallet-session.workspace = true
 scale-info = { features = ["derive"], workspace = true }
 sp-runtime.workspace = true
 
@@ -28,6 +29,7 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"pallet-balances/std",
+	"pallet-session/std",
 	"scale-info/std",
 	"sp-runtime/std",
 ]
@@ -40,4 +42,5 @@ try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"pallet-balances/try-runtime",
+	"pallet-session/try-runtime",
 ]

--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -17,305 +17,308 @@ extern crate alloc;
 
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::{
-	traits::{Currency, LockableCurrency},
-	BoundedVec,
+    traits::{Currency, LockableCurrency},
+    BoundedVec,
 };
 use scale_info::TypeInfo;
 use sp_runtime::traits::{Saturating, Zero};
 
 /// Balance type alias derived from the configured `Currency`.
-pub type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId,>>::Balance;
+pub type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
 /// Lifecycle state of a validator's stake.
-#[derive(
-	Clone, Copy, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen,
-)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen)]
 pub enum ValidatorStatus {
-	/// Active in the validator set; eligible for auto-renewal.
-	Active,
-	/// Voluntary exit requested; auto-renewal stopped, awaiting expiry.
-	ExitRequested,
-	/// Kicked due to offline or equivocation; in cooldown.
-	Kicked,
-	/// Cooldown period after equivocation kick.
-	Cooldown,
+    /// Active in the validator set; eligible for auto-renewal.
+    Active,
+    /// Voluntary exit requested; auto-renewal stopped, awaiting expiry.
+    ExitRequested,
+    /// Kicked due to offline or equivocation; in cooldown.
+    Kicked,
+    /// Cooldown period after equivocation kick.
+    Cooldown,
 }
 
 /// Lock record for a validator's stake.
 #[derive(
-	Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen,
+    Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen,
 )]
 pub struct LockInfo<Balance, BlockNumber> {
-	pub amount: Balance,
-	pub lock_block: BlockNumber,
-	pub expiry_block: BlockNumber,
-	pub status: ValidatorStatus,
+    pub amount: Balance,
+    pub lock_block: BlockNumber,
+    pub expiry_block: BlockNumber,
+    pub status: ValidatorStatus,
 }
 
 #[frame_support::pallet]
 pub mod pallet {
-	use super::*;
-	use frame_support::{
-		pallet_prelude::*,
-		traits::{LockIdentifier, WithdrawReasons},
-	};
-	use frame_system::pallet_prelude::*;
+    use super::*;
+    use frame_support::{
+        pallet_prelude::*,
+        traits::{LockIdentifier, WithdrawReasons},
+    };
+    use frame_system::pallet_prelude::*;
 
-	#[pallet::pallet]
-	pub struct Pallet<T>(_);
+    #[pallet::pallet]
+    pub struct Pallet<T>(_);
 
-	#[pallet::config]
-	pub trait Config: frame_system::Config<RuntimeEvent: From<Event<Self>>> {
-		/// Currency used for validator stake locking.
-		type Currency: LockableCurrency<Self::AccountId, Moment = BlockNumberFor<Self>>;
+    #[pallet::config]
+    pub trait Config: frame_system::Config<RuntimeEvent: From<Event<Self>>> {
+        /// Currency used for validator stake locking.
+        type Currency: LockableCurrency<Self::AccountId, Moment = BlockNumberFor<Self>>;
 
-		/// Amount to lock when registering as a validator.
-		#[pallet::constant]
-		type LockAmount: Get<BalanceOf<Self>>;
+        /// Amount to lock when registering as a validator.
+        #[pallet::constant]
+        type LockAmount: Get<BalanceOf<Self>>;
 
-		/// Lock duration (in blocks) applied at registration and on each renewal.
-		#[pallet::constant]
-		type LockDuration: Get<BlockNumberFor<Self>>;
+        /// Lock duration (in blocks) applied at registration and on each renewal.
+        #[pallet::constant]
+        type LockDuration: Get<BlockNumberFor<Self>>;
 
-		/// Lock identifier used when calling `set_lock` on the underlying currency.
-		#[pallet::constant]
-		type LockId: Get<LockIdentifier>;
+        /// Lock identifier used when calling `set_lock` on the underlying currency.
+        #[pallet::constant]
+        type LockId: Get<LockIdentifier>;
 
-		/// Upper bound for the number of pending/active validators tracked in storage.
-		#[pallet::constant]
-		type MaxValidators: Get<u32>;
+        /// Upper bound for the number of pending/active validators tracked in storage.
+        #[pallet::constant]
+        type MaxValidators: Get<u32>;
 
-		/// Interval (in blocks) between auto-renewal sweeps.
-		#[pallet::constant]
-		type RenewInterval: Get<BlockNumberFor<Self>>;
-	}
+        /// Interval (in blocks) between auto-renewal sweeps.
+        #[pallet::constant]
+        type RenewInterval: Get<BlockNumberFor<Self>>;
+    }
 
-	/// Active validator lock records, keyed by account.
-	#[pallet::storage]
-	pub type ValidatorLocks<T: Config> = StorageMap<
-		_,
-		Blake2_128Concat,
-		T::AccountId,
-		LockInfo<BalanceOf<T>, BlockNumberFor<T>>,
-		OptionQuery,
-	>;
+    /// Active validator lock records, keyed by account.
+    #[pallet::storage]
+    pub type ValidatorLocks<T: Config> = StorageMap<
+        _,
+        Blake2_128Concat,
+        T::AccountId,
+        LockInfo<BalanceOf<T>, BlockNumberFor<T>>,
+        OptionQuery,
+    >;
 
-	/// Validators waiting to be promoted into the active set at the next session boundary.
-	#[pallet::storage]
+    /// Validators waiting to be promoted into the active set at the next session boundary.
+    #[pallet::storage]
 	pub type PendingValidators<T: Config> = StorageValue<_, BoundedVec<T::AccountId, T::MaxValidators>, ValueQuery>;
 
-	/// Validators currently selected for the active session. Updated at every session boundary.
-	#[pallet::storage]
+    /// Validators currently selected for the active session. Updated at every session boundary.
+    #[pallet::storage]
 	pub type ActiveValidators<T: Config> = StorageValue<_, BoundedVec<T::AccountId, T::MaxValidators>, ValueQuery>;
 
-	/// Rejoin cooldown deadline per account (block number).
-	#[pallet::storage]
+    /// Rejoin cooldown deadline per account (block number).
+    #[pallet::storage]
 	pub type RejoinCooldown<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, BlockNumberFor<T>, OptionQuery>;
 
-	/// Consecutive offline session count per account.
-	#[pallet::storage]
+    /// Consecutive offline session count per account.
+    #[pallet::storage]
 	pub type OfflineSessionCount<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, u32, ValueQuery>;
 
-	#[pallet::event]
-	#[pallet::generate_deposit(pub(super) fn deposit_event)]
-	pub enum Event<T: Config> {
-		/// A validator locked stake. `[who, amount, expiry_block]`
-		ValidatorLocked {
-			who: T::AccountId,
-			amount: BalanceOf<T>,
-			expiry_block: BlockNumberFor<T>,
-		},
-		/// A validator requested voluntary exit.
-		ValidatorExitRequested { who: T::AccountId },
-		/// A validator was kicked (offline or equivocation).
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
+        /// A validator locked stake. `[who, amount, expiry_block]`
+        ValidatorLocked {
+            who: T::AccountId,
+            amount: BalanceOf<T>,
+            expiry_block: BlockNumberFor<T>,
+        },
+        /// A validator requested voluntary exit.
+        ValidatorExitRequested { who: T::AccountId },
+        /// A validator was kicked (offline or equivocation).
 		ValidatorKicked { who: T::AccountId, reason: KickReason },
-		/// A validator's lock was released after expiry.
+        /// A validator's lock was released after expiry.
 		LockReleased { who: T::AccountId, amount: BalanceOf<T> },
-	}
+    }
 
-	/// Reason a validator was removed from the active set.
-	#[derive(
-		Clone,
-		Copy,
-		PartialEq,
-		Eq,
-		Debug,
-		Encode,
-		Decode,
-		DecodeWithMemTracking,
-		TypeInfo,
-		MaxEncodedLen,
-	)]
-	pub enum KickReason {
-		/// Removed for being offline beyond the threshold.
-		Offline,
-		/// Removed for GRANDPA equivocation.
-		Equivocation,
-	}
+    /// Reason a validator was removed from the active set.
+    #[derive(
+        Clone,
+        Copy,
+        PartialEq,
+        Eq,
+        Debug,
+        Encode,
+        Decode,
+        DecodeWithMemTracking,
+        TypeInfo,
+        MaxEncodedLen,
+    )]
+    pub enum KickReason {
+        /// Removed for being offline beyond the threshold.
+        Offline,
+        /// Removed for GRANDPA equivocation.
+        Equivocation,
+    }
 
-	#[pallet::error]
-	pub enum Error<T> {
-		/// Account is already a validator.
-		AlreadyValidator,
-		/// Account is not a registered validator.
-		NotValidator,
-		/// Operation not permitted in the current validator status.
-		InvalidStatus,
-		/// Lock has not yet reached its expiry block.
-		LockNotExpired,
-		/// Account is currently within an equivocation cooldown.
-		InCooldown,
-		/// Account does not have enough free balance to cover the configured lock.
-		InsufficientBalance,
-		/// The pending validator queue is full.
-		TooManyValidators,
-	}
+    #[pallet::error]
+    pub enum Error<T> {
+        /// Account is already a validator.
+        AlreadyValidator,
+        /// Account is not a registered validator.
+        NotValidator,
+        /// Operation not permitted in the current validator status.
+        InvalidStatus,
+        /// Lock has not yet reached its expiry block.
+        LockNotExpired,
+        /// Account is currently within an equivocation cooldown.
+        InCooldown,
+        /// Account does not have enough free balance to cover the configured lock.
+        InsufficientBalance,
+        /// The pending validator queue is full.
+        TooManyValidators,
+    }
 
-	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_initialize(now: BlockNumberFor<T>) -> Weight {
-			let duration = T::LockDuration::get();
-			let interval = T::RenewInterval::get();
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+        fn on_initialize(now: BlockNumberFor<T>) -> Weight {
+            let duration = T::LockDuration::get();
+            let interval = T::RenewInterval::get();
 
-			// First pass: collect expired locks and (when enabled) renewal candidates.
-			let mut to_release: alloc::vec::Vec<(T::AccountId, BalanceOf<T>)> =
-				alloc::vec::Vec::new();
-			let mut to_renew: alloc::vec::Vec<T::AccountId> = alloc::vec::Vec::new();
-			for (who, info) in ValidatorLocks::<T>::iter() {
-				if info.expiry_block <= now {
-					to_release.push((who, info.amount));
-					continue;
-				}
-				if interval.is_zero() || info.status != ValidatorStatus::Active {
-					continue;
-				}
-				let remaining = info.expiry_block.saturating_sub(now);
-				let elapsed_window = duration.saturating_sub(remaining);
-				if elapsed_window >= interval {
-					to_renew.push(who);
-				}
-			}
+            // First pass: collect expired locks and (when enabled) renewal candidates.
+            let mut to_release: alloc::vec::Vec<(T::AccountId, BalanceOf<T>)> =
+                alloc::vec::Vec::new();
+            let mut to_renew: alloc::vec::Vec<T::AccountId> = alloc::vec::Vec::new();
+            for (who, info) in ValidatorLocks::<T>::iter() {
+                if info.expiry_block <= now {
+                    to_release.push((who, info.amount));
+                    continue;
+                }
+                if interval.is_zero() || info.status != ValidatorStatus::Active {
+                    continue;
+                }
+                let remaining = info.expiry_block.saturating_sub(now);
+                let elapsed_window = duration.saturating_sub(remaining);
+                if elapsed_window >= interval {
+                    to_renew.push(who);
+                }
+            }
 
-			// Release expired locks: drop the currency lock, clear storage, emit event.
-			let release_count = to_release.len() as u64;
-			for (who, amount) in to_release {
-				T::Currency::remove_lock(T::LockId::get(), &who);
-				ValidatorLocks::<T>::remove(&who);
-				Self::deposit_event(Event::LockReleased { who, amount });
-			}
+            // Release expired locks: drop the currency lock, clear storage, emit event.
+            let release_count = to_release.len() as u64;
+            for (who, amount) in to_release {
+                T::Currency::remove_lock(T::LockId::get(), &who);
+                ValidatorLocks::<T>::remove(&who);
+                Self::deposit_event(Event::LockReleased { who, amount });
+            }
 
-			// Renew Active locks whose elapsed window has reached the configured interval.
-			let renew_count = to_renew.len() as u64;
-			for who in to_renew {
-				ValidatorLocks::<T>::mutate(&who, |maybe_info| {
-					if let Some(info) = maybe_info {
-						info.expiry_block = now.saturating_add(duration);
-						Self::deposit_event(Event::ValidatorLocked {
-							who: who.clone(),
-							amount: info.amount,
-							expiry_block: info.expiry_block,
-						});
-					}
-				});
-			}
+            // Renew Active locks whose elapsed window has reached the configured interval.
+            let renew_count = to_renew.len() as u64;
+            for who in to_renew {
+                ValidatorLocks::<T>::mutate(&who, |maybe_info| {
+                    if let Some(info) = maybe_info {
+                        info.expiry_block = now.saturating_add(duration);
+                        Self::deposit_event(Event::ValidatorLocked {
+                            who: who.clone(),
+                            amount: info.amount,
+                            expiry_block: info.expiry_block,
+                        });
+                    }
+                });
+            }
 
-			// Rough weight: one read per scanned lock + one write per mutation.
-			let count = release_count.saturating_add(renew_count);
-			T::DbWeight::get().reads_writes(count, count)
-		}
-	}
+            // Rough weight: one read per scanned lock + one write per mutation.
+            let count = release_count.saturating_add(renew_count);
+            T::DbWeight::get().reads_writes(count, count)
+        }
+    }
 
-	#[pallet::call]
-	impl<T: Config> Pallet<T> {
-		/// Lock the configured stake amount for the configured duration and
-		/// queue the caller into [`PendingValidators`] for the next session.
-		///
-		/// The locked amount and duration are taken from `Config::LockAmount`
-		/// and `Config::LockDuration` respectively; callers do not choose them.
-		#[pallet::call_index(0)]
-		#[pallet::weight(Weight::from_parts(50_000_000, 0))]
-		pub fn lock(origin: OriginFor<T>) -> DispatchResult {
-			let who = ensure_signed(origin)?;
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        /// Lock the configured stake amount for the configured duration and
+        /// queue the caller into [`PendingValidators`] for the next session.
+        ///
+        /// The locked amount and duration are taken from `Config::LockAmount`
+        /// and `Config::LockDuration` respectively; callers do not choose them.
+        #[pallet::call_index(0)]
+        #[pallet::weight(Weight::from_parts(50_000_000, 0))]
+        pub fn lock(origin: OriginFor<T>) -> DispatchResult {
+            let who = ensure_signed(origin)?;
 
 			ensure!(!ValidatorLocks::<T>::contains_key(&who), Error::<T>::AlreadyValidator);
 
-			let now = frame_system::Pallet::<T>::block_number();
-			if let Some(deadline) = RejoinCooldown::<T>::get(&who) {
-				if deadline > now {
-					return Err(Error::<T>::InCooldown.into());
-				}
-				RejoinCooldown::<T>::remove(&who);
-			}
+            let now = frame_system::Pallet::<T>::block_number();
+            if let Some(deadline) = RejoinCooldown::<T>::get(&who) {
+                if deadline > now {
+                    return Err(Error::<T>::InCooldown.into());
+                }
+                RejoinCooldown::<T>::remove(&who);
+            }
 
-			let amount = T::LockAmount::get();
-			let duration = T::LockDuration::get();
+            let amount = T::LockAmount::get();
+            let duration = T::LockDuration::get();
 
-			ensure!(
-				T::Currency::free_balance(&who) >= amount,
-				Error::<T>::InsufficientBalance,
-			);
+            ensure!(
+                T::Currency::free_balance(&who) >= amount,
+                Error::<T>::InsufficientBalance,
+            );
 
-			let expiry_block = now.saturating_add(duration);
+            let expiry_block = now.saturating_add(duration);
 
-			PendingValidators::<T>::try_mutate(|queue| -> DispatchResult {
-				ensure!(!queue.iter().any(|a| a == &who), Error::<T>::AlreadyValidator);
-				queue
-					.try_push(who.clone())
-					.map_err(|_| Error::<T>::TooManyValidators)?;
-				Ok(())
-			})?;
+            PendingValidators::<T>::try_mutate(|queue| -> DispatchResult {
+                ensure!(
+                    !queue.iter().any(|a| a == &who),
+                    Error::<T>::AlreadyValidator
+                );
+                queue
+                    .try_push(who.clone())
+                    .map_err(|_| Error::<T>::TooManyValidators)?;
+                Ok(())
+            })?;
 
-			T::Currency::set_lock(
-				T::LockId::get(),
-				&who,
-				amount,
-				WithdrawReasons::all(),
-			);
+            T::Currency::set_lock(T::LockId::get(), &who, amount, WithdrawReasons::all());
 
-			ValidatorLocks::<T>::insert(
-				&who,
-				LockInfo {
-					amount,
-					lock_block: now,
-					expiry_block,
-					status: ValidatorStatus::Active,
-				},
-			);
+            ValidatorLocks::<T>::insert(
+                &who,
+                LockInfo {
+                    amount,
+                    lock_block: now,
+                    expiry_block,
+                    status: ValidatorStatus::Active,
+                },
+            );
 
-			Self::deposit_event(Event::ValidatorLocked { who, amount, expiry_block });
-			Ok(())
-		}
+            Self::deposit_event(Event::ValidatorLocked {
+                who,
+                amount,
+                expiry_block,
+            });
+            Ok(())
+        }
 
-		/// Request voluntary exit from the active validator set.
-		///
-		/// Only an `Active` validator may call this. The validator's status
-		/// becomes `ExitRequested`, auto-renewal stops, and the account is
-		/// removed from [`PendingValidators`] so it will not be promoted at
-		/// the next session boundary. The underlying currency lock is kept in
-		/// place until its original `expiry_block` is reached; early unlocking
-		/// is not permitted.
-		#[pallet::call_index(1)]
-		#[pallet::weight(Weight::from_parts(40_000_000, 0))]
-		pub fn request_exit(origin: OriginFor<T>) -> DispatchResult {
-			let who = ensure_signed(origin)?;
+        /// Request voluntary exit from the active validator set.
+        ///
+        /// Only an `Active` validator may call this. The validator's status
+        /// becomes `ExitRequested`, auto-renewal stops, and the account is
+        /// removed from [`PendingValidators`] so it will not be promoted at
+        /// the next session boundary. The underlying currency lock is kept in
+        /// place until its original `expiry_block` is reached; early unlocking
+        /// is not permitted.
+        #[pallet::call_index(1)]
+        #[pallet::weight(Weight::from_parts(40_000_000, 0))]
+        pub fn request_exit(origin: OriginFor<T>) -> DispatchResult {
+            let who = ensure_signed(origin)?;
 
-			ValidatorLocks::<T>::try_mutate(&who, |maybe_info| -> DispatchResult {
-				let info = maybe_info.as_mut().ok_or(Error::<T>::NotValidator)?;
-				ensure!(info.status == ValidatorStatus::Active, Error::<T>::InvalidStatus);
-				info.status = ValidatorStatus::ExitRequested;
-				Ok(())
-			})?;
+            ValidatorLocks::<T>::try_mutate(&who, |maybe_info| -> DispatchResult {
+                let info = maybe_info.as_mut().ok_or(Error::<T>::NotValidator)?;
+                ensure!(
+                    info.status == ValidatorStatus::Active,
+                    Error::<T>::InvalidStatus
+                );
+                info.status = ValidatorStatus::ExitRequested;
+                Ok(())
+            })?;
 
-			PendingValidators::<T>::mutate(|queue| {
-				if let Some(pos) = queue.iter().position(|a| a == &who) {
-					queue.remove(pos);
-				}
-			});
+            PendingValidators::<T>::mutate(|queue| {
+                if let Some(pos) = queue.iter().position(|a| a == &who) {
+                    queue.remove(pos);
+                }
+            });
 
-			Self::deposit_event(Event::ValidatorExitRequested { who });
-			Ok(())
-		}
-	}
+            Self::deposit_event(Event::ValidatorExitRequested { who });
+            Ok(())
+        }
+    }
 }
 
 /// Drives `pallet-session` from the validator lifecycle storage.
@@ -328,42 +331,42 @@ pub mod pallet {
 /// Returns `Some(_)` only when the resulting set differs from the previous
 /// active set, matching the `pallet-session` convention.
 impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
-	fn new_session(_new_index: u32) -> Option<alloc::vec::Vec<T::AccountId>> {
-		let previous = ActiveValidators::<T>::get();
+    fn new_session(_new_index: u32) -> Option<alloc::vec::Vec<T::AccountId>> {
+        let previous = ActiveValidators::<T>::get();
 
-		let is_active = |who: &T::AccountId| {
-			ValidatorLocks::<T>::get(who)
-				.map(|info| info.status == ValidatorStatus::Active)
-				.unwrap_or(false)
-		};
+        let is_active = |who: &T::AccountId| {
+            ValidatorLocks::<T>::get(who)
+                .map(|info| info.status == ValidatorStatus::Active)
+                .unwrap_or(false)
+        };
 
-		let mut next: BoundedVec<T::AccountId, T::MaxValidators> = BoundedVec::default();
-		for who in previous.iter() {
-			if is_active(who) {
-				// Bound is identical to `previous`'s, so this push cannot exceed it.
-				let _ = next.try_push(who.clone());
-			}
-		}
+        let mut next: BoundedVec<T::AccountId, T::MaxValidators> = BoundedVec::default();
+        for who in previous.iter() {
+            if is_active(who) {
+                // Bound is identical to `previous`'s, so this push cannot exceed it.
+                let _ = next.try_push(who.clone());
+            }
+        }
 
-		let pending = PendingValidators::<T>::take();
-		for who in pending.into_iter() {
-			if !is_active(&who) || next.iter().any(|a| a == &who) {
-				continue;
-			}
-			if next.try_push(who).is_err() {
-				// Bounded by `MaxValidators`; remaining entries stay dropped this session.
-				break;
-			}
-		}
+        let pending = PendingValidators::<T>::take();
+        for who in pending.into_iter() {
+            if !is_active(&who) || next.iter().any(|a| a == &who) {
+                continue;
+            }
+            if next.try_push(who).is_err() {
+                // Bounded by `MaxValidators`; remaining entries stay dropped this session.
+                break;
+            }
+        }
 
-		if next == previous {
-			return None;
-		}
-		ActiveValidators::<T>::put(&next);
-		Some(next.into_inner())
-	}
+        if next == previous {
+            return None;
+        }
+        ActiveValidators::<T>::put(&next);
+        Some(next.into_inner())
+    }
 
-	fn end_session(_end_index: u32) {}
+    fn end_session(_end_index: u32) {}
 
-	fn start_session(_start_index: u32) {}
+    fn start_session(_start_index: u32) {}
 }

--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -16,7 +16,10 @@ mod tests;
 extern crate alloc;
 
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
-use frame_support::traits::{Currency, LockableCurrency};
+use frame_support::{
+	traits::{Currency, LockableCurrency},
+	BoundedVec,
+};
 use scale_info::TypeInfo;
 use sp_runtime::traits::{Saturating, Zero};
 
@@ -100,6 +103,10 @@ pub mod pallet {
 	/// Validators waiting to be promoted into the active set at the next session boundary.
 	#[pallet::storage]
 	pub type PendingValidators<T: Config> = StorageValue<_, BoundedVec<T::AccountId, T::MaxValidators>, ValueQuery>;
+
+	/// Validators currently selected for the active session. Updated at every session boundary.
+	#[pallet::storage]
+	pub type ActiveValidators<T: Config> = StorageValue<_, BoundedVec<T::AccountId, T::MaxValidators>, ValueQuery>;
 
 	/// Rejoin cooldown deadline per account (block number).
 	#[pallet::storage]
@@ -309,4 +316,54 @@ pub mod pallet {
 			Ok(())
 		}
 	}
+}
+
+/// Drives `pallet-session` from the validator lifecycle storage.
+///
+/// At every new session, the active set is recomputed as:
+/// * keep current `ActiveValidators` whose [`ValidatorLocks`] entry is still in
+///   [`ValidatorStatus::Active`] (drops exited, kicked, cooldown, or removed accounts);
+/// * drain [`PendingValidators`] and append new entrants whose lock is `Active`.
+///
+/// Returns `Some(_)` only when the resulting set differs from the previous
+/// active set, matching the `pallet-session` convention.
+impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
+	fn new_session(_new_index: u32) -> Option<alloc::vec::Vec<T::AccountId>> {
+		let previous = ActiveValidators::<T>::get();
+
+		let is_active = |who: &T::AccountId| {
+			ValidatorLocks::<T>::get(who)
+				.map(|info| info.status == ValidatorStatus::Active)
+				.unwrap_or(false)
+		};
+
+		let mut next: BoundedVec<T::AccountId, T::MaxValidators> = BoundedVec::default();
+		for who in previous.iter() {
+			if is_active(who) {
+				// Bound is identical to `previous`'s, so this push cannot exceed it.
+				let _ = next.try_push(who.clone());
+			}
+		}
+
+		let pending = PendingValidators::<T>::take();
+		for who in pending.into_iter() {
+			if !is_active(&who) || next.iter().any(|a| a == &who) {
+				continue;
+			}
+			if next.try_push(who).is_err() {
+				// Bounded by `MaxValidators`; remaining entries stay dropped this session.
+				break;
+			}
+		}
+
+		if next == previous {
+			return None;
+		}
+		ActiveValidators::<T>::put(&next);
+		Some(next.into_inner())
+	}
+
+	fn end_session(_end_index: u32) {}
+
+	fn start_session(_start_index: u32) {}
 }

--- a/pallets/validator/src/tests.rs
+++ b/pallets/validator/src/tests.rs
@@ -1,305 +1,390 @@
 use crate::{
-	mock::*, Error, Event, LockInfo, PendingValidators, RejoinCooldown, ValidatorLocks,
-	ValidatorStatus,
+    mock::*, ActiveValidators, Error, Event, LockInfo, PendingValidators, RejoinCooldown,
+    ValidatorLocks, ValidatorStatus,
 };
 use frame_support::{assert_noop, assert_ok, traits::Hooks};
+use pallet_session::SessionManager;
 use sp_runtime::{traits::Dispatchable, DispatchError, TokenError};
 
 /// Advance the chain to `target` block, calling `on_initialize` for each new block.
 fn run_to_block(target: u64) {
-	while System::block_number() < target {
-		let next = System::block_number() + 1;
-		System::set_block_number(next);
-		Validator::on_initialize(next);
-	}
+    while System::block_number() < target {
+        let next = System::block_number() + 1;
+        System::set_block_number(next);
+        Validator::on_initialize(next);
+    }
 }
 
 #[test]
 fn lock_succeeds_and_records_state() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
 
-		let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock recorded");
-		assert_eq!(
-			lock,
-			LockInfo {
-				amount: 1_000,
-				lock_block: 1,
-				expiry_block: 11,
-				status: ValidatorStatus::Active,
-			}
-		);
-		assert_eq!(PendingValidators::<Test>::get().to_vec(), vec![ALICE]);
-		System::assert_last_event(
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock recorded");
+        assert_eq!(
+            lock,
+            LockInfo {
+                amount: 1_000,
+                lock_block: 1,
+                expiry_block: 11,
+                status: ValidatorStatus::Active,
+            }
+        );
+        assert_eq!(PendingValidators::<Test>::get().to_vec(), vec![ALICE]);
+        System::assert_last_event(
 			Event::ValidatorLocked { who: ALICE, amount: 1_000, expiry_block: 11 }.into(),
-		);
-	});
+        );
+    });
 }
 
 #[test]
 fn lock_fails_when_balance_insufficient() {
-	new_test_ext().execute_with(|| {
-		assert_noop!(
-			Validator::lock(RuntimeOrigin::signed(EVE)),
-			Error::<Test>::InsufficientBalance
-		);
-		assert!(ValidatorLocks::<Test>::get(EVE).is_none());
-		assert!(PendingValidators::<Test>::get().is_empty());
-	});
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            Validator::lock(RuntimeOrigin::signed(EVE)),
+            Error::<Test>::InsufficientBalance
+        );
+        assert!(ValidatorLocks::<Test>::get(EVE).is_none());
+        assert!(PendingValidators::<Test>::get().is_empty());
+    });
 }
 
 #[test]
 fn lock_fails_when_already_validator() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
-		assert_noop!(
-			Validator::lock(RuntimeOrigin::signed(ALICE)),
-			Error::<Test>::AlreadyValidator
-		);
-	});
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert_noop!(
+            Validator::lock(RuntimeOrigin::signed(ALICE)),
+            Error::<Test>::AlreadyValidator
+        );
+    });
 }
 
 #[test]
 fn lock_rejected_during_active_cooldown() {
-	new_test_ext().execute_with(|| {
-		RejoinCooldown::<Test>::insert(ALICE, 100u64);
-		assert_noop!(
-			Validator::lock(RuntimeOrigin::signed(ALICE)),
-			Error::<Test>::InCooldown
-		);
-		assert!(RejoinCooldown::<Test>::get(ALICE).is_some());
-	});
+    new_test_ext().execute_with(|| {
+        RejoinCooldown::<Test>::insert(ALICE, 100u64);
+        assert_noop!(
+            Validator::lock(RuntimeOrigin::signed(ALICE)),
+            Error::<Test>::InCooldown
+        );
+        assert!(RejoinCooldown::<Test>::get(ALICE).is_some());
+    });
 }
 
 #[test]
 fn lock_succeeds_after_cooldown_expires_and_clears_record() {
-	new_test_ext().execute_with(|| {
-		RejoinCooldown::<Test>::insert(ALICE, 1u64);
-		System::set_block_number(2);
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
-		assert!(RejoinCooldown::<Test>::get(ALICE).is_none());
-	});
+    new_test_ext().execute_with(|| {
+        RejoinCooldown::<Test>::insert(ALICE, 1u64);
+        System::set_block_number(2);
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert!(RejoinCooldown::<Test>::get(ALICE).is_none());
+    });
 }
 
 #[test]
 fn locked_balance_cannot_be_transferred() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
 
-		// Free balance is 10_000 and 1_000 is locked. Anything that would push the
-		// usable balance below 1_000 must be rejected by pallet-balances.
-		let call = pallet_balances::Call::<Test>::transfer_keep_alive {
-			dest: BOB,
-			value: 9_500,
-		};
-		let res = RuntimeCall::Balances(call).dispatch(RuntimeOrigin::signed(ALICE));
+        // Free balance is 10_000 and 1_000 is locked. Anything that would push the
+        // usable balance below 1_000 must be rejected by pallet-balances.
+        let call = pallet_balances::Call::<Test>::transfer_keep_alive {
+            dest: BOB,
+            value: 9_500,
+        };
+        let res = RuntimeCall::Balances(call).dispatch(RuntimeOrigin::signed(ALICE));
 		assert_eq!(res.unwrap_err().error, DispatchError::Token(TokenError::Frozen));
 
-		// A transfer that respects the lock still works.
+        // A transfer that respects the lock still works.
 		assert_ok!(Balances::transfer_keep_alive(RuntimeOrigin::signed(ALICE), BOB, 8_000));
-	});
+    });
 }
 
 #[test]
 fn lock_fails_when_pending_queue_full() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(BOB)));
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(CHARLIE)));
-		assert_noop!(
-			Validator::lock(RuntimeOrigin::signed(DAVE)),
-			Error::<Test>::TooManyValidators
-		);
-		assert!(ValidatorLocks::<Test>::get(DAVE).is_none());
-	});
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(BOB)));
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(CHARLIE)));
+        assert_noop!(
+            Validator::lock(RuntimeOrigin::signed(DAVE)),
+            Error::<Test>::TooManyValidators
+        );
+        assert!(ValidatorLocks::<Test>::get(DAVE).is_none());
+    });
 }
 
 #[test]
 fn auto_renew_skips_within_interval() {
-	new_test_ext().execute_with(|| {
-		// Lock at block 1 -> expiry = 11.
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
-		// At block 5: expiry - now = 6, elapsed_window = 5, not > 5 -> no renewal.
-		run_to_block(5);
-		let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock recorded");
-		assert_eq!(lock.expiry_block, 11);
-	});
+    new_test_ext().execute_with(|| {
+        // Lock at block 1 -> expiry = 11.
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        // At block 5: expiry - now = 6, elapsed_window = 5, not > 5 -> no renewal.
+        run_to_block(5);
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock recorded");
+        assert_eq!(lock.expiry_block, 11);
+    });
 }
 
 #[test]
 fn auto_renew_extends_active_validator_lock() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
-		// At block 6: expiry - now = 5, elapsed_window = 5 >= 5 -> renew.
-		// New expiry = 6 + 10 = 16.
-		run_to_block(6);
-		let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock recorded");
-		assert_eq!(lock.expiry_block, 16);
-		assert_eq!(lock.lock_block, 1);
-		assert_eq!(lock.status, ValidatorStatus::Active);
-		System::assert_last_event(
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        // At block 6: expiry - now = 5, elapsed_window = 5 >= 5 -> renew.
+        // New expiry = 6 + 10 = 16.
+        run_to_block(6);
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock recorded");
+        assert_eq!(lock.expiry_block, 16);
+        assert_eq!(lock.lock_block, 1);
+        assert_eq!(lock.status, ValidatorStatus::Active);
+        System::assert_last_event(
 			Event::ValidatorLocked { who: ALICE, amount: 1_000, expiry_block: 16 }.into(),
-		);
-	});
+        );
+    });
 }
 
 #[test]
 fn auto_renew_skips_non_active_status() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
-		// Mark the validator as having requested exit; renewal must stop.
-		ValidatorLocks::<Test>::mutate(ALICE, |maybe| {
-			maybe.as_mut().unwrap().status = ValidatorStatus::ExitRequested;
-		});
-		run_to_block(8);
-		let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock recorded");
-		assert_eq!(lock.expiry_block, 11);
-		assert_eq!(lock.status, ValidatorStatus::ExitRequested);
-	});
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        // Mark the validator as having requested exit; renewal must stop.
+        ValidatorLocks::<Test>::mutate(ALICE, |maybe| {
+            maybe.as_mut().unwrap().status = ValidatorStatus::ExitRequested;
+        });
+        run_to_block(8);
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock recorded");
+        assert_eq!(lock.expiry_block, 11);
+        assert_eq!(lock.status, ValidatorStatus::ExitRequested);
+    });
 }
 
 #[test]
 fn request_exit_changes_status_and_removes_from_pending() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(BOB)));
-		assert_eq!(PendingValidators::<Test>::get().to_vec(), vec![ALICE, BOB]);
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(BOB)));
+        assert_eq!(PendingValidators::<Test>::get().to_vec(), vec![ALICE, BOB]);
 
-		assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+        assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
 
-		let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock kept");
-		assert_eq!(lock.status, ValidatorStatus::ExitRequested);
-		assert_eq!(lock.expiry_block, 11);
-		assert_eq!(PendingValidators::<Test>::get().to_vec(), vec![BOB]);
-		System::assert_last_event(Event::ValidatorExitRequested { who: ALICE }.into());
-	});
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock kept");
+        assert_eq!(lock.status, ValidatorStatus::ExitRequested);
+        assert_eq!(lock.expiry_block, 11);
+        assert_eq!(PendingValidators::<Test>::get().to_vec(), vec![BOB]);
+        System::assert_last_event(Event::ValidatorExitRequested { who: ALICE }.into());
+    });
 }
 
 #[test]
 fn request_exit_fails_when_not_validator() {
-	new_test_ext().execute_with(|| {
-		assert_noop!(
-			Validator::request_exit(RuntimeOrigin::signed(ALICE)),
-			Error::<Test>::NotValidator
-		);
-	});
+    new_test_ext().execute_with(|| {
+        assert_noop!(
+            Validator::request_exit(RuntimeOrigin::signed(ALICE)),
+            Error::<Test>::NotValidator
+        );
+    });
 }
 
 #[test]
 fn request_exit_fails_when_not_active() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
-		assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
-		// Second call: status is ExitRequested, not Active.
-		assert_noop!(
-			Validator::request_exit(RuntimeOrigin::signed(ALICE)),
-			Error::<Test>::InvalidStatus
-		);
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+        // Second call: status is ExitRequested, not Active.
+        assert_noop!(
+            Validator::request_exit(RuntimeOrigin::signed(ALICE)),
+            Error::<Test>::InvalidStatus
+        );
 
-		// Kicked status also rejected.
-		ValidatorLocks::<Test>::mutate(BOB, |maybe| {
-			*maybe = Some(LockInfo {
-				amount: 1_000,
-				lock_block: 1,
-				expiry_block: 11,
-				status: ValidatorStatus::Kicked,
-			});
-		});
-		assert_noop!(
-			Validator::request_exit(RuntimeOrigin::signed(BOB)),
-			Error::<Test>::InvalidStatus
-		);
-	});
+        // Kicked status also rejected.
+        ValidatorLocks::<Test>::mutate(BOB, |maybe| {
+            *maybe = Some(LockInfo {
+                amount: 1_000,
+                lock_block: 1,
+                expiry_block: 11,
+                status: ValidatorStatus::Kicked,
+            });
+        });
+        assert_noop!(
+            Validator::request_exit(RuntimeOrigin::signed(BOB)),
+            Error::<Test>::InvalidStatus
+        );
+    });
 }
 
 #[test]
 fn request_exit_stops_auto_renewal() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
-		assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
-		// Pass the renewal threshold: without exit, expiry would extend at block 6.
-		run_to_block(8);
-		let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock kept");
-		assert_eq!(lock.expiry_block, 11);
-		assert_eq!(lock.status, ValidatorStatus::ExitRequested);
-	});
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+        // Pass the renewal threshold: without exit, expiry would extend at block 6.
+        run_to_block(8);
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock kept");
+        assert_eq!(lock.expiry_block, 11);
+        assert_eq!(lock.status, ValidatorStatus::ExitRequested);
+    });
 }
 
 #[test]
 fn request_exit_keeps_lock_until_expiry() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
-		assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
 
-		// Lock is still enforced: cannot move balance below the locked amount.
-		let call = pallet_balances::Call::<Test>::transfer_keep_alive {
-			dest: BOB,
-			value: 9_500,
-		};
-		let res = RuntimeCall::Balances(call).dispatch(RuntimeOrigin::signed(ALICE));
+        // Lock is still enforced: cannot move balance below the locked amount.
+        let call = pallet_balances::Call::<Test>::transfer_keep_alive {
+            dest: BOB,
+            value: 9_500,
+        };
+        let res = RuntimeCall::Balances(call).dispatch(RuntimeOrigin::signed(ALICE));
 		assert_eq!(res.unwrap_err().error, DispatchError::Token(TokenError::Frozen));
-	});
+    });
 }
 
 #[test]
 fn lock_released_when_expiry_reached() {
-	new_test_ext().execute_with(|| {
-		// Lock at block 1 -> expiry = 11. Request exit so renewal does not extend it.
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
-		assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+    new_test_ext().execute_with(|| {
+        // Lock at block 1 -> expiry = 11. Request exit so renewal does not extend it.
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
 
-		// Right before expiry: lock still in place.
-		run_to_block(10);
-		assert!(ValidatorLocks::<Test>::get(ALICE).is_some());
+        // Right before expiry: lock still in place.
+        run_to_block(10);
+        assert!(ValidatorLocks::<Test>::get(ALICE).is_some());
 
-		// At expiry block: lock released, storage cleared, event emitted.
-		run_to_block(11);
-		assert!(ValidatorLocks::<Test>::get(ALICE).is_none());
-		System::assert_last_event(
+        // At expiry block: lock released, storage cleared, event emitted.
+        run_to_block(11);
+        assert!(ValidatorLocks::<Test>::get(ALICE).is_none());
+        System::assert_last_event(
 			Event::LockReleased { who: ALICE, amount: 1_000 }.into(),
-		);
+        );
 
-		// Funds are fully transferable again.
-		assert_ok!(Balances::transfer_keep_alive(
-			RuntimeOrigin::signed(ALICE),
-			BOB,
-			9_500
-		));
-	});
+        // Funds are fully transferable again.
+        assert_ok!(Balances::transfer_keep_alive(
+            RuntimeOrigin::signed(ALICE),
+            BOB,
+            9_500
+        ));
+    });
 }
 
 #[test]
 fn unexpired_locks_not_released() {
-	new_test_ext().execute_with(|| {
-		// Two validators locked at block 1; both expire at block 11.
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(BOB)));
-		// Only ALICE requests exit so BOB keeps renewing.
-		assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+    new_test_ext().execute_with(|| {
+        // Two validators locked at block 1; both expire at block 11.
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(BOB)));
+        // Only ALICE requests exit so BOB keeps renewing.
+        assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
 
-		// Advance to block 11: ALICE expires and is released. BOB renews twice
-		// (at blocks 6 and 11), so its expiry advances to 21 and stays Active.
-		run_to_block(11);
-		assert!(ValidatorLocks::<Test>::get(ALICE).is_none());
-		let bob = ValidatorLocks::<Test>::get(BOB).expect("bob lock kept");
-		assert_eq!(bob.expiry_block, 21);
-		assert_eq!(bob.status, ValidatorStatus::Active);
-	});
+        // Advance to block 11: ALICE expires and is released. BOB renews twice
+        // (at blocks 6 and 11), so its expiry advances to 21 and stays Active.
+        run_to_block(11);
+        assert!(ValidatorLocks::<Test>::get(ALICE).is_none());
+        let bob = ValidatorLocks::<Test>::get(BOB).expect("bob lock kept");
+        assert_eq!(bob.expiry_block, 21);
+        assert_eq!(bob.status, ValidatorStatus::Active);
+    });
 }
 
 #[test]
 fn released_account_can_relock() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
-		assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
-		run_to_block(11);
-		assert!(ValidatorLocks::<Test>::get(ALICE).is_none());
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+        run_to_block(11);
+        assert!(ValidatorLocks::<Test>::get(ALICE).is_none());
 
-		// Storage is cleaned up, so a fresh lock call must succeed.
-		assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
-		let lock = ValidatorLocks::<Test>::get(ALICE).expect("relock recorded");
-		assert_eq!(lock.lock_block, 11);
-		assert_eq!(lock.expiry_block, 21);
-		assert_eq!(lock.status, ValidatorStatus::Active);
-	});
+        // Storage is cleaned up, so a fresh lock call must succeed.
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("relock recorded");
+        assert_eq!(lock.lock_block, 11);
+        assert_eq!(lock.expiry_block, 21);
+        assert_eq!(lock.status, ValidatorStatus::Active);
+    });
+}
+
+#[test]
+fn new_session_promotes_pending_validators() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(BOB)));
+
+        let set = <Validator as SessionManager<AccountId>>::new_session(1)
+            .expect("set must change from empty");
+        assert_eq!(set, vec![ALICE, BOB]);
+        assert_eq!(ActiveValidators::<Test>::get().to_vec(), vec![ALICE, BOB]);
+        assert!(PendingValidators::<Test>::get().is_empty());
+    });
+}
+
+#[test]
+fn new_session_removes_exited_validator() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(BOB)));
+        let _ = <Validator as SessionManager<AccountId>>::new_session(1);
+
+        assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+
+        let set = <Validator as SessionManager<AccountId>>::new_session(2)
+            .expect("set must change after exit");
+        assert_eq!(set, vec![BOB]);
+        assert_eq!(ActiveValidators::<Test>::get().to_vec(), vec![BOB]);
+    });
+}
+
+#[test]
+fn new_session_removes_kicked_and_cooldown_validators() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(BOB)));
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(CHARLIE)));
+        let _ = <Validator as SessionManager<AccountId>>::new_session(1);
+
+        // Simulate kick / cooldown by mutating storage directly.
+        ValidatorLocks::<Test>::mutate(BOB, |maybe| {
+            maybe.as_mut().unwrap().status = ValidatorStatus::Kicked;
+        });
+        ValidatorLocks::<Test>::mutate(CHARLIE, |maybe| {
+            maybe.as_mut().unwrap().status = ValidatorStatus::Cooldown;
+        });
+
+        let set = <Validator as SessionManager<AccountId>>::new_session(2)
+            .expect("set must change after kick/cooldown");
+        assert_eq!(set, vec![ALICE]);
+        assert_eq!(ActiveValidators::<Test>::get().to_vec(), vec![ALICE]);
+    });
+}
+
+#[test]
+fn new_session_returns_none_when_unchanged() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        let _ = <Validator as SessionManager<AccountId>>::new_session(1);
+        // No new lock and no exit: next session must be a no-op.
+        assert!(<Validator as SessionManager<AccountId>>::new_session(2).is_none());
+        assert_eq!(ActiveValidators::<Test>::get().to_vec(), vec![ALICE]);
+    });
+}
+
+#[test]
+fn new_session_drops_validator_with_released_lock() {
+    new_test_ext().execute_with(|| {
+        // Lock and promote ALICE to active.
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        let _ = <Validator as SessionManager<AccountId>>::new_session(1);
+        assert_eq!(ActiveValidators::<Test>::get().to_vec(), vec![ALICE]);
+
+        // Exit and let the lock expire so ValidatorLocks is cleared.
+        assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+        run_to_block(11);
+        assert!(ValidatorLocks::<Test>::get(ALICE).is_none());
+
+        let set = <Validator as SessionManager<AccountId>>::new_session(2)
+            .expect("set must shrink to empty");
+        assert!(set.is_empty());
+        assert!(ActiveValidators::<Test>::get().is_empty());
+    });
 }

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -42,7 +42,7 @@ use sp_version::RuntimeVersion;
 use super::{
 	AccountId, Balance, Balances, Block, BlockNumber, DAYS, Hash, Nonce, PalletInfo, Runtime,
 	RuntimeCall, RuntimeEvent, RuntimeFreezeReason, RuntimeHoldReason, RuntimeOrigin, RuntimeTask,
-	SessionKeys, System, EXISTENTIAL_DEPOSIT, UNIT, VERSION,
+	SessionKeys, System, Validator, EXISTENTIAL_DEPOSIT, UNIT, VERSION,
 };
 
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
@@ -199,7 +199,7 @@ impl pallet_session::Config for Runtime {
 	type ValidatorIdOf = ConvertInto;
 	type ShouldEndSession = PeriodicSessions<SessionPeriod, SessionOffset>;
 	type NextSessionRotation = PeriodicSessions<SessionPeriod, SessionOffset>;
-	type SessionManager = ();
+	type SessionManager = Validator;
 	type SessionHandler = <SessionKeys as sp_runtime::traits::OpaqueKeys>::KeyTypeIdProviders;
 	type Keys = SessionKeys;
 	type DisablingStrategy = ();


### PR DESCRIPTION
## Summary

Replace the placeholder `()` `SessionManager` in the runtime with a real implementation provided by `pallet-validator`, so the active validator set is driven by the validator lock lifecycle (lock / exit / kick / cooldown / lock release) instead of being fixed at genesis.

## Changes

- `pallet-validator`
  - Add `pallet-session` as a dependency (std + try-runtime features).
  - Add `ActiveValidators<T>: BoundedVec<AccountId, MaxValidators>` storage
    that mirrors the set currently in use by the session.
  - Implement `pallet_session::SessionManager<T::AccountId>`:
    - `new_session(_)` rebuilds the next set as `previous ∩ {status == Active}`
      plus accounts drained from `PendingValidators` whose lock status is
      `Active`. Returns `None` when the result equals the previous set,
      matching the pallet-session convention. Persists the new set into
      `ActiveValidators`.
    - `start_session` / `end_session` are no-ops in this iteration.

### runtime/configs
  - Import `Validator` and set `pallet_session::Config::SessionManager = Validator`.

### Tests
  - `new_session_promotes_pending_validators`
  - `new_session_removes_exited_validator`
  - `new_session_removes_kicked_and_cooldown_validators`
  - `new_session_returns_none_when_unchanged`
  - `new_session_drops_validator_with_released_lock`

Closes #27 