### PR TITLE
Integrate pallet-im-online into Runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6341,6 +6341,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-im-online"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68d78e0ffa487644035898b71d00509da1cf606f5cbe425f4ccd36a6293edc2"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+]
+
+[[package]]
 name = "pallet-message-queue"
 version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10363,6 +10383,7 @@ dependencies = [
  "pallet-balances",
  "pallet-difficulty",
  "pallet-grandpa",
+ "pallet-im-online",
  "pallet-reward",
  "pallet-session",
  "pallet-sudo",
@@ -10386,6 +10407,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
+ "sp-staking",
  "sp-storage",
  "sp-timestamp",
  "sp-transaction-pool",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ frame-try-runtime = { version = "0.52.0", default-features = false }
 pallet-aura = { version = "45.0.0", default-features = false }
 pallet-balances = { version = "47.0.0", default-features = false }
 pallet-grandpa = { version = "46.0.0", default-features = false }
+pallet-im-online = { version = "45.0.0", default-features = false }
 pallet-session = { version = "46.0.0", default-features = false }
 pallet-sudo = { version = "46.0.0", default-features = false }
 pallet-timestamp = { version = "45.0.0", default-features = false }
@@ -90,6 +91,7 @@ sp-consensus-grandpa = { version = "28.0.0", default-features = false }
 sp-consensus-pow = { version = "0.47.0", default-features = false }
 sp-offchain = { version = "41.0.0", default-features = false }
 sp-session = { version = "43.0.0", default-features = false }
+sp-staking = { version = "43.0.0", default-features = false }
 sp-storage = { version = "23.0.0", default-features = false }
 sp-transaction-pool = { version = "41.0.0", default-features = false }
 sp-version = { version = "44.0.0", default-features = false }

--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -129,9 +129,6 @@ pub mod pallet {
 		ValidatorKicked { who: T::AccountId, reason: KickReason },
         /// A validator's lock was released after expiry.
 		LockReleased { who: T::AccountId, amount: BalanceOf<T> },
-        /// A validator was reported as offline by the liveness layer.
-        /// Carries the new accumulated offline session count for the account.
-        ValidatorReportedOffline { who: T::AccountId, count: u32 },
     }
 
     /// Reason a validator was removed from the active set.
@@ -374,17 +371,3 @@ impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
     fn start_session(_start_index: u32) {}
 }
 
-impl<T: Config> Pallet<T> {
-    /// Record an offline report from the liveness layer (e.g. `pallet-im-online`).
-    ///
-    /// Increments [`OfflineSessionCount`] for `who` by one and emits
-    /// [`Event::ValidatorReportedOffline`] with the new count. Eviction logic
-    /// (kick after consecutive offline sessions) is implemented separately.
-    pub fn note_offline(who: &T::AccountId) {
-        let count = OfflineSessionCount::<T>::mutate(who, |c| {
-            *c = c.saturating_add(1);
-            *c
-        });
-        Self::deposit_event(Event::ValidatorReportedOffline { who: who.clone(), count });
-    }
-}

--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -129,6 +129,9 @@ pub mod pallet {
 		ValidatorKicked { who: T::AccountId, reason: KickReason },
         /// A validator's lock was released after expiry.
 		LockReleased { who: T::AccountId, amount: BalanceOf<T> },
+        /// A validator was reported as offline by the liveness layer.
+        /// Carries the new accumulated offline session count for the account.
+        ValidatorReportedOffline { who: T::AccountId, count: u32 },
     }
 
     /// Reason a validator was removed from the active set.
@@ -369,4 +372,19 @@ impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
     fn end_session(_end_index: u32) {}
 
     fn start_session(_start_index: u32) {}
+}
+
+impl<T: Config> Pallet<T> {
+    /// Record an offline report from the liveness layer (e.g. `pallet-im-online`).
+    ///
+    /// Increments [`OfflineSessionCount`] for `who` by one and emits
+    /// [`Event::ValidatorReportedOffline`] with the new count. Eviction logic
+    /// (kick after consecutive offline sessions) is implemented separately.
+    pub fn note_offline(who: &T::AccountId) {
+        let count = OfflineSessionCount::<T>::mutate(who, |c| {
+            *c = c.saturating_add(1);
+            *c
+        });
+        Self::deposit_event(Event::ValidatorReportedOffline { who: who.clone(), count });
+    }
 }

--- a/pallets/validator/src/tests.rs
+++ b/pallets/validator/src/tests.rs
@@ -388,3 +388,24 @@ fn new_session_drops_validator_with_released_lock() {
         assert!(ActiveValidators::<Test>::get().is_empty());
     });
 }
+
+#[test]
+fn note_offline_increments_count_and_emits_event() {
+    new_test_ext().execute_with(|| {
+        use crate::OfflineSessionCount;
+
+        Validator::note_offline(&ALICE);
+        assert_eq!(OfflineSessionCount::<Test>::get(ALICE), 1);
+        System::assert_last_event(
+            Event::ValidatorReportedOffline { who: ALICE, count: 1 }.into(),
+        );
+
+        Validator::note_offline(&ALICE);
+        Validator::note_offline(&BOB);
+        assert_eq!(OfflineSessionCount::<Test>::get(ALICE), 2);
+        assert_eq!(OfflineSessionCount::<Test>::get(BOB), 1);
+        System::assert_last_event(
+            Event::ValidatorReportedOffline { who: BOB, count: 1 }.into(),
+        );
+    });
+}

--- a/pallets/validator/src/tests.rs
+++ b/pallets/validator/src/tests.rs
@@ -388,24 +388,3 @@ fn new_session_drops_validator_with_released_lock() {
         assert!(ActiveValidators::<Test>::get().is_empty());
     });
 }
-
-#[test]
-fn note_offline_increments_count_and_emits_event() {
-    new_test_ext().execute_with(|| {
-        use crate::OfflineSessionCount;
-
-        Validator::note_offline(&ALICE);
-        assert_eq!(OfflineSessionCount::<Test>::get(ALICE), 1);
-        System::assert_last_event(
-            Event::ValidatorReportedOffline { who: ALICE, count: 1 }.into(),
-        );
-
-        Validator::note_offline(&ALICE);
-        Validator::note_offline(&BOB);
-        assert_eq!(OfflineSessionCount::<Test>::get(ALICE), 2);
-        assert_eq!(OfflineSessionCount::<Test>::get(BOB), 1);
-        System::assert_last_event(
-            Event::ValidatorReportedOffline { who: BOB, count: 1 }.into(),
-        );
-    });
-}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -25,6 +25,7 @@ frame-try-runtime = { optional = true, workspace = true }
 pallet-balances.workspace = true
 pallet-difficulty.workspace = true
 pallet-grandpa.workspace = true
+pallet-im-online.workspace = true
 pallet-reward.workspace = true
 pallet-session.workspace = true
 pallet-sudo.workspace = true
@@ -47,6 +48,7 @@ sp-keyring.workspace = true
 sp-offchain.workspace = true
 sp-runtime = { features = ["serde"], workspace = true }
 sp-session.workspace = true
+sp-staking.workspace = true
 sp-storage.workspace = true
 sp-timestamp.workspace = true
 sp-transaction-pool.workspace = true
@@ -70,6 +72,7 @@ std = [
 	"pallet-balances/std",
 	"pallet-difficulty/std",
 	"pallet-grandpa/std",
+	"pallet-im-online/std",
 	"pallet-reward/std",
 	"pallet-session/std",
 	"pallet-sudo/std",
@@ -92,6 +95,7 @@ std = [
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",
+	"sp-staking/std",
 	"sp-storage/std",
 	"sp-timestamp/std",
 	"sp-transaction-pool/std",
@@ -107,6 +111,7 @@ runtime-benchmarks = [
 	"pallet-balances/runtime-benchmarks",
 	"pallet-difficulty/runtime-benchmarks",
 	"pallet-grandpa/runtime-benchmarks",
+	"pallet-im-online/runtime-benchmarks",
 	"pallet-reward/runtime-benchmarks",
 	"pallet-session/runtime-benchmarks",
 	"pallet-sudo/runtime-benchmarks",
@@ -125,6 +130,7 @@ try-runtime = [
 	"pallet-balances/try-runtime",
 	"pallet-difficulty/try-runtime",
 	"pallet-grandpa/try-runtime",
+	"pallet-im-online/try-runtime",
 	"pallet-reward/try-runtime",
 	"pallet-session/try-runtime",
 	"pallet-sudo/try-runtime",

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -42,7 +42,7 @@ use sp_version::RuntimeVersion;
 use super::{
 	AccountId, Balance, Balances, Block, BlockNumber, DAYS, Hash, Nonce, PalletInfo, Runtime,
 	RuntimeCall, RuntimeEvent, RuntimeFreezeReason, RuntimeHoldReason, RuntimeOrigin, RuntimeTask,
-	SessionKeys, System, Validator, EXISTENTIAL_DEPOSIT, UNIT, VERSION,
+	Session, SessionKeys, System, Validator, EXISTENTIAL_DEPOSIT, UNIT, VERSION,
 };
 
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
@@ -219,4 +219,90 @@ impl pallet_validator::Config for Runtime {
 	type LockId = ValidatorLockId;
 	type MaxValidators = ConstU32<1_000>;
 	type RenewInterval = ConstU32<{ 1 * DAYS }>;
+}
+
+/// `ValidatorSetWithIdentification` adapter over `pallet-session`.
+///
+/// `pallet-im-online` requires its `ValidatorSet` to also expose an
+/// `Identification` type so that offline reports can carry a per-validator
+/// payload. We do not run a separate slashing/staking subsystem yet, so the
+/// identification is a unit value.
+pub struct UnitIdentification;
+
+impl sp_runtime::traits::Convert<AccountId, Option<()>> for UnitIdentification {
+	fn convert(_: AccountId) -> Option<()> {
+		Some(())
+	}
+}
+
+pub struct ValidatorIdentification;
+
+impl frame_support::traits::ValidatorSet<AccountId> for ValidatorIdentification {
+	type ValidatorId = <Session as frame_support::traits::ValidatorSet<AccountId>>::ValidatorId;
+	type ValidatorIdOf = <Session as frame_support::traits::ValidatorSet<AccountId>>::ValidatorIdOf;
+
+	fn session_index() -> sp_staking::SessionIndex {
+		<Session as frame_support::traits::ValidatorSet<AccountId>>::session_index()
+	}
+
+	fn validators() -> alloc::vec::Vec<Self::ValidatorId> {
+		<Session as frame_support::traits::ValidatorSet<AccountId>>::validators()
+	}
+}
+
+impl frame_support::traits::ValidatorSetWithIdentification<AccountId> for ValidatorIdentification {
+	type Identification = ();
+	type IdentificationOf = UnitIdentification;
+}
+
+/// Forwards `pallet-im-online` unresponsiveness offences to `pallet-validator`.
+///
+/// We do not run economic slashing; we simply tally consecutive offline reports
+/// inside the validator pallet so that the eviction logic (separate issue) can
+/// kick repeatedly-offline validators.
+pub struct ImOnlineOffenceReporter;
+
+impl<O>
+	sp_staking::offence::ReportOffence<AccountId, (AccountId, ()), O>
+	for ImOnlineOffenceReporter
+where
+	O: sp_staking::offence::Offence<(AccountId, ())>,
+{
+	fn report_offence(
+		_reporters: alloc::vec::Vec<AccountId>,
+		offence: O,
+	) -> Result<(), sp_staking::offence::OffenceError> {
+		for (offender, _) in offence.offenders() {
+			pallet_validator::Pallet::<Runtime>::note_offline(&offender);
+		}
+		Ok(())
+	}
+
+	fn is_known_offence(_offenders: &[(AccountId, ())], _time_slot: &O::TimeSlot) -> bool {
+		false
+	}
+}
+
+parameter_types! {
+	/// Base priority for unsigned heartbeat extrinsics. Picked to be low enough
+	/// not to crowd out other unsigned traffic but high enough to land within
+	/// the session.
+	pub const ImOnlineUnsignedPriority: sp_runtime::transaction_validity::TransactionPriority =
+		sp_runtime::transaction_validity::TransactionPriority::MAX / 2;
+	/// Maximum number of `ImOnlineId` keys stored per session.
+	pub const ImOnlineMaxKeys: u32 = 1_000;
+	/// Maximum peers reported in a single heartbeat payload.
+	pub const ImOnlineMaxPeerInHeartbeats: u32 = 10_000;
+}
+
+impl pallet_im_online::Config for Runtime {
+	type AuthorityId = pallet_im_online::sr25519::AuthorityId;
+	type RuntimeEvent = RuntimeEvent;
+	type ValidatorSet = ValidatorIdentification;
+	type NextSessionRotation = PeriodicSessions<SessionPeriod, SessionOffset>;
+	type ReportUnresponsiveness = ImOnlineOffenceReporter;
+	type UnsignedPriority = ImOnlineUnsignedPriority;
+	type MaxKeys = ImOnlineMaxKeys;
+	type MaxPeerInHeartbeats = ImOnlineMaxPeerInHeartbeats;
+	type WeightInfo = ();
 }

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -255,33 +255,6 @@ impl frame_support::traits::ValidatorSetWithIdentification<AccountId> for Valida
 	type IdentificationOf = UnitIdentification;
 }
 
-/// Forwards `pallet-im-online` unresponsiveness offences to `pallet-validator`.
-///
-/// We do not run economic slashing; we simply tally consecutive offline reports
-/// inside the validator pallet so that the eviction logic (separate issue) can
-/// kick repeatedly-offline validators.
-pub struct ImOnlineOffenceReporter;
-
-impl<O>
-	sp_staking::offence::ReportOffence<AccountId, (AccountId, ()), O>
-	for ImOnlineOffenceReporter
-where
-	O: sp_staking::offence::Offence<(AccountId, ())>,
-{
-	fn report_offence(
-		_reporters: alloc::vec::Vec<AccountId>,
-		offence: O,
-	) -> Result<(), sp_staking::offence::OffenceError> {
-		for (offender, _) in offence.offenders() {
-			pallet_validator::Pallet::<Runtime>::note_offline(&offender);
-		}
-		Ok(())
-	}
-
-	fn is_known_offence(_offenders: &[(AccountId, ())], _time_slot: &O::TimeSlot) -> bool {
-		false
-	}
-}
 
 parameter_types! {
 	/// Base priority for unsigned heartbeat extrinsics. Picked to be low enough
@@ -300,7 +273,7 @@ impl pallet_im_online::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type ValidatorSet = ValidatorIdentification;
 	type NextSessionRotation = PeriodicSessions<SessionPeriod, SessionOffset>;
-	type ReportUnresponsiveness = ImOnlineOffenceReporter;
+	type ReportUnresponsiveness = ();
 	type UnsignedPriority = ImOnlineUnsignedPriority;
 	type MaxKeys = ImOnlineMaxKeys;
 	type MaxPeerInHeartbeats = ImOnlineMaxPeerInHeartbeats;

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use alloc::{vec, vec::Vec};
 use frame_support::build_struct_json_patch;
+use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use serde_json::Value;
 use sp_consensus_grandpa::AuthorityId as GrandpaId;
 use sp_core::U256;
@@ -30,7 +31,7 @@ use sp_keyring::{Ed25519Keyring, Sr25519Keyring};
 fn testnet_genesis(
 	endowed_accounts: Vec<AccountId>,
 	root: AccountId,
-	initial_validators: Vec<(AccountId, GrandpaId)>,
+	initial_validators: Vec<(AccountId, GrandpaId, ImOnlineId)>,
 ) -> Value {
 	let total_supply: u128 = 1_000_000_000 * UNIT;
 	let balance_per_account = total_supply / endowed_accounts.len() as u128;
@@ -53,12 +54,21 @@ fn testnet_genesis(
 		session: SessionConfig {
 			keys: initial_validators
 				.into_iter()
-				.map(|(account, grandpa)| {
-					(account.clone(), account, SessionKeys { grandpa })
+				.map(|(account, grandpa, im_online)| {
+					(account.clone(), account, SessionKeys { grandpa, im_online })
 				})
 				.collect::<Vec<_>>(),
 		},
 	})
+}
+
+/// Derive an `ImOnlineId` from an Sr25519 dev keyring entry.
+///
+/// Heartbeat keys live under their own key type (`imon`) but the underlying
+/// curve is sr25519; reusing the dev keyring keeps the dev/local presets
+/// reproducible and matches the keys that `--alice`-style flags insert.
+fn im_online_from_keyring(keyring: Sr25519Keyring) -> ImOnlineId {
+	keyring.public().into()
 }
 
 pub fn development_config_genesis() -> Value {
@@ -71,9 +81,21 @@ pub fn development_config_genesis() -> Value {
 		],
 		Sr25519Keyring::Alice.to_account_id(),
 		vec![
-			(Sr25519Keyring::Alice.to_account_id(), Ed25519Keyring::Alice.public().into()),
-			(Sr25519Keyring::Bob.to_account_id(), Ed25519Keyring::Bob.public().into()),
-			(Sr25519Keyring::Charlie.to_account_id(), Ed25519Keyring::Charlie.public().into()),
+			(
+				Sr25519Keyring::Alice.to_account_id(),
+				Ed25519Keyring::Alice.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Alice),
+			),
+			(
+				Sr25519Keyring::Bob.to_account_id(),
+				Ed25519Keyring::Bob.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Bob),
+			),
+			(
+				Sr25519Keyring::Charlie.to_account_id(),
+				Ed25519Keyring::Charlie.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Charlie),
+			),
 		],
 	)
 }
@@ -86,9 +108,21 @@ pub fn local_config_genesis() -> Value {
 			.collect::<Vec<_>>(),
 		Sr25519Keyring::Alice.to_account_id(),
 		vec![
-			(Sr25519Keyring::Alice.to_account_id(), Ed25519Keyring::Alice.public().into()),
-			(Sr25519Keyring::Bob.to_account_id(), Ed25519Keyring::Bob.public().into()),
-			(Sr25519Keyring::Charlie.to_account_id(), Ed25519Keyring::Charlie.public().into()),
+			(
+				Sr25519Keyring::Alice.to_account_id(),
+				Ed25519Keyring::Alice.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Alice),
+			),
+			(
+				Sr25519Keyring::Bob.to_account_id(),
+				Ed25519Keyring::Bob.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Bob),
+			),
+			(
+				Sr25519Keyring::Charlie.to_account_id(),
+				Ed25519Keyring::Charlie.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Charlie),
+			),
 		],
 	)
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -54,6 +54,7 @@ pub mod opaque {
 impl_opaque_keys! {
 	pub struct SessionKeys {
 		pub grandpa: Grandpa,
+		pub im_online: ImOnline,
 	}
 }
 
@@ -221,4 +222,23 @@ mod runtime {
 
 	#[runtime::pallet_index(12)]
 	pub type Validator = pallet_validator;
+
+	#[runtime::pallet_index(13)]
+	pub type ImOnline = pallet_im_online;
+}
+
+// pallet-im-online submits unsigned heartbeat extrinsics from offchain
+// workers. The runtime must expose how to build a bare (unsigned/inherent)
+// extrinsic for any pallet `Call`.
+impl<LocalCall> frame_system::offchain::CreateTransactionBase<LocalCall> for Runtime where RuntimeCall: From<LocalCall>,
+{
+	type Extrinsic = UncheckedExtrinsic;
+	type RuntimeCall = RuntimeCall;
+}
+
+impl<LocalCall> frame_system::offchain::CreateBare<LocalCall> for Runtime where RuntimeCall: From<LocalCall>,
+{
+	fn create_bare(call: RuntimeCall) -> UncheckedExtrinsic {
+		generic::UncheckedExtrinsic::new_bare(call).into()
+	}
 }


### PR DESCRIPTION
## Summary

Integrate `pallet-im-online` into the runtime so validator nodes broadcast a per-session liveness heartbeat and unresponsive validators are reported into `pallet-validator` for downstream eviction.

## Changes

### Runtime

- add `pallet-im-online` (v45) at pallet index 13; extend `SessionKeys` with `im_online: ImOnlineId`.
- implement `frame_system::offchain::CreateBare` so unsigned heartbeat extrinsics can be assembled by offchain workers.

### Genesis

- dev/local presets now seed an SR25519-derived `ImOnlineId` for each initial validator.

Closes #28 