### PR TITLE
Implement Offline Kick Logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6573,6 +6573,7 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
+ "log",
  "pallet-balances",
  "pallet-session",
  "parity-scale-codec",

--- a/pallets/validator/Cargo.toml
+++ b/pallets/validator/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 codec = { features = ["derive"], workspace = true }
 frame-support.workspace = true
 frame-system.workspace = true
+log.workspace = true
 pallet-balances.workspace = true
 pallet-session.workspace = true
 scale-info = { features = ["derive"], workspace = true }

--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -17,7 +17,7 @@ extern crate alloc;
 
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::{
-    traits::{Currency, LockableCurrency},
+    traits::{Currency, Get, LockableCurrency},
     BoundedVec,
 };
 use scale_info::TypeInfo;
@@ -86,6 +86,15 @@ pub mod pallet {
         /// Interval (in blocks) between auto-renewal sweeps.
         #[pallet::constant]
         type RenewInterval: Get<BlockNumberFor<Self>>;
+
+        /// Number of consecutive offline sessions that triggers an offline kick.
+        #[pallet::constant]
+        type OfflineThreshold: Get<u32>;
+
+        /// Cooldown period (in blocks) applied to a kicked validator before they
+        /// are allowed to call `lock()` again.
+        #[pallet::constant]
+        type RejoinCooldownPeriod: Get<BlockNumberFor<Self>>;
     }
 
     /// Active validator lock records, keyed by account.
@@ -113,6 +122,11 @@ pub mod pallet {
     /// Consecutive offline session count per account.
     #[pallet::storage]
 	pub type OfflineSessionCount<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, u32, ValueQuery>;
+
+    /// Accounts reported as offline during the current session. Cleared when
+    /// the next session boundary is processed.
+    #[pallet::storage]
+	pub type OfflineThisSession<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, (), OptionQuery>;
 
     #[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
@@ -321,6 +335,81 @@ pub mod pallet {
     }
 }
 
+/// Log target for liveness-related diagnostics.
+const LOG_TARGET: &str = "runtime::validator";
+
+impl<T: Config> Pallet<T> {
+    /// Record `who` as offline for the current session.
+    ///
+    /// Intended to be invoked by the runtime adapter that bridges
+    /// `pallet-im-online`'s `ReportUnresponsiveness` into this pallet.
+    /// Repeated calls within the same session are idempotent.
+    pub fn note_offline(who: T::AccountId) {
+        if !ValidatorLocks::<T>::contains_key(&who) {
+            return;
+        }
+        OfflineThisSession::<T>::insert(&who, ());
+        log::debug!(
+            target: LOG_TARGET,
+            "validator reported offline for current session",
+        );
+    }
+
+    /// Update offline counters for the current active set and kick any
+    /// validator that has reached `OfflineThreshold` consecutive offline
+    /// sessions. Called at every session boundary before the active set is
+    /// recomputed.
+    fn process_offline_counters() {
+        let threshold = T::OfflineThreshold::get();
+        let cooldown = T::RejoinCooldownPeriod::get();
+        let now = frame_system::Pallet::<T>::block_number();
+        let active = ActiveValidators::<T>::get();
+
+        for who in active.iter() {
+            let was_offline = OfflineThisSession::<T>::take(who).is_some();
+            if !was_offline {
+                if OfflineSessionCount::<T>::contains_key(who) {
+                    OfflineSessionCount::<T>::remove(who);
+                }
+                continue;
+            }
+
+            let count = OfflineSessionCount::<T>::get(who).saturating_add(1);
+            if count < threshold {
+                OfflineSessionCount::<T>::insert(who, count);
+                log::debug!(
+                    target: LOG_TARGET,
+                    "offline counter incremented to {} (threshold {})",
+                    count,
+                    threshold,
+                );
+                continue;
+            }
+
+            // Threshold reached: kick.
+            OfflineSessionCount::<T>::remove(who);
+            ValidatorLocks::<T>::mutate(who, |maybe_info| {
+                if let Some(info) = maybe_info {
+                    info.status = ValidatorStatus::Kicked;
+                }
+            });
+            RejoinCooldown::<T>::insert(who, now.saturating_add(cooldown));
+            Self::deposit_event(Event::ValidatorKicked {
+                who: who.clone(),
+                reason: KickReason::Offline,
+            });
+            log::info!(
+                target: LOG_TARGET,
+                "validator kicked after {} consecutive offline sessions",
+                threshold,
+            );
+        }
+
+        // Drop any leftover entries (offenders that are not in the active set).
+        let _ = OfflineThisSession::<T>::clear(u32::MAX, None);
+    }
+}
+
 /// Drives `pallet-session` from the validator lifecycle storage.
 ///
 /// At every new session, the active set is recomputed as:
@@ -332,6 +421,8 @@ pub mod pallet {
 /// active set, matching the `pallet-session` convention.
 impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
     fn new_session(_new_index: u32) -> Option<alloc::vec::Vec<T::AccountId>> {
+        Self::process_offline_counters();
+
         let previous = ActiveValidators::<T>::get();
 
         let is_active = |who: &T::AccountId| {

--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -344,7 +344,7 @@ impl<T: Config> Pallet<T> {
     /// Intended to be invoked by the runtime adapter that bridges
     /// `pallet-im-online`'s `ReportUnresponsiveness` into this pallet.
     /// Repeated calls within the same session are idempotent.
-    pub fn note_offline(who: T::AccountId) {
+    pub fn note_offline(who: &T::AccountId) {
         if !ValidatorLocks::<T>::contains_key(&who) {
             return;
         }

--- a/pallets/validator/src/mock.rs
+++ b/pallets/validator/src/mock.rs
@@ -73,6 +73,8 @@ impl pallet_validator::Config for Test {
 	type LockId = TestLockId;
 	type MaxValidators = ConstU32<3>;
 	type RenewInterval = ConstU64<5>;
+	type OfflineThreshold = ConstU32<3>;
+	type RejoinCooldownPeriod = ConstU64<20>;
 }
 
 pub const ALICE: AccountId = 1;

--- a/pallets/validator/src/tests.rs
+++ b/pallets/validator/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-    mock::*, ActiveValidators, Error, Event, LockInfo, PendingValidators, RejoinCooldown,
-    ValidatorLocks, ValidatorStatus,
+    mock::*, ActiveValidators, Error, Event, KickReason, LockInfo, OfflineSessionCount,
+    OfflineThisSession, PendingValidators, RejoinCooldown, ValidatorLocks, ValidatorStatus,
 };
 use frame_support::{assert_noop, assert_ok, traits::Hooks};
 use pallet_session::SessionManager;
@@ -386,5 +386,138 @@ fn new_session_drops_validator_with_released_lock() {
             .expect("set must shrink to empty");
         assert!(set.is_empty());
         assert!(ActiveValidators::<Test>::get().is_empty());
+    });
+}
+
+/// Helper: mark `who` as offline for the current session window.
+fn report_offline(who: AccountId) {
+    Validator::note_offline(&who);
+}
+
+/// Helper: advance to the next session boundary by invoking `new_session`.
+fn rotate_session(index: u32) -> Option<alloc::vec::Vec<AccountId>> {
+    <Validator as SessionManager<AccountId>>::new_session(index)
+}
+
+#[test]
+fn note_offline_ignores_non_validator() {
+    new_test_ext().execute_with(|| {
+        Validator::note_offline(&ALICE);
+        assert!(OfflineThisSession::<Test>::get(ALICE).is_none());
+    });
+}
+
+#[test]
+fn consecutive_offline_kicks_validator() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(BOB)));
+        let _ = rotate_session(1);
+        assert_eq!(ActiveValidators::<Test>::get().to_vec(), vec![ALICE, BOB]);
+
+        // ALICE misses three consecutive sessions while BOB stays online.
+        for idx in 2..=4u32 {
+            report_offline(ALICE);
+            let _ = rotate_session(idx);
+        }
+
+        let alice_lock = ValidatorLocks::<Test>::get(ALICE).expect("lock retained");
+        assert_eq!(alice_lock.status, ValidatorStatus::Kicked);
+        assert!(RejoinCooldown::<Test>::get(ALICE).is_some());
+        assert_eq!(OfflineSessionCount::<Test>::get(ALICE), 0);
+        assert_eq!(ActiveValidators::<Test>::get().to_vec(), vec![BOB]);
+        // The transient set must be empty after processing.
+        assert!(OfflineThisSession::<Test>::iter().next().is_none());
+        // Event emitted with `Offline` reason.
+        let kicked = System::events().into_iter().any(|e| matches!(
+            e.event,
+            RuntimeEvent::Validator(Event::ValidatorKicked { who: ALICE, reason: KickReason::Offline })
+        ));
+        assert!(kicked, "ValidatorKicked event with Offline reason expected");
+    });
+}
+
+#[test]
+fn intermittent_heartbeat_resets_counter() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        let _ = rotate_session(1);
+
+        // Two offline sessions: counter reaches 2, still below threshold (3).
+        report_offline(ALICE);
+        let _ = rotate_session(2);
+        report_offline(ALICE);
+        let _ = rotate_session(3);
+        assert_eq!(OfflineSessionCount::<Test>::get(ALICE), 2);
+
+        // Heartbeat received this session: counter resets.
+        let _ = rotate_session(4);
+        assert_eq!(OfflineSessionCount::<Test>::get(ALICE), 0);
+
+        // Two more offline sessions: only counter == 2 again, still no kick.
+        report_offline(ALICE);
+        let _ = rotate_session(5);
+        report_offline(ALICE);
+        let _ = rotate_session(6);
+        assert_eq!(OfflineSessionCount::<Test>::get(ALICE), 2);
+
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock retained");
+        assert_eq!(lock.status, ValidatorStatus::Active);
+        assert!(RejoinCooldown::<Test>::get(ALICE).is_none());
+    });
+}
+
+#[test]
+fn kicked_validator_skips_auto_renewal() {
+    new_test_ext().execute_with(|| {
+        // Lock at block 1, expiry = 11. Renewal would extend at block 6.
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        let _ = rotate_session(1);
+
+        // Drive ALICE offline for three sessions to trigger a kick.
+        for idx in 2..=4u32 {
+            report_offline(ALICE);
+            let _ = rotate_session(idx);
+        }
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock retained");
+        assert_eq!(lock.status, ValidatorStatus::Kicked);
+        assert_eq!(lock.expiry_block, 11);
+
+        // Past the next renewal window: status is no longer Active so no extension.
+        run_to_block(8);
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock retained");
+        assert_eq!(lock.expiry_block, 11);
+    });
+}
+
+#[test]
+fn lock_blocked_during_cooldown_then_succeeds() {
+    new_test_ext().execute_with(|| {
+        // Lock and kick ALICE.
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        let _ = rotate_session(1);
+        for idx in 2..=4u32 {
+            report_offline(ALICE);
+            let _ = rotate_session(idx);
+        }
+
+        // Let the original lock expire so the account is free to relock.
+        run_to_block(11);
+        assert!(ValidatorLocks::<Test>::get(ALICE).is_none());
+
+        // Cooldown still active: lock() must reject.
+        let cooldown_until = RejoinCooldown::<Test>::get(ALICE).expect("cooldown set");
+        assert!(cooldown_until > System::block_number());
+        assert_noop!(
+            Validator::lock(RuntimeOrigin::signed(ALICE)),
+            Error::<Test>::InCooldown,
+        );
+
+        // Move past cooldown deadline; lock() now succeeds and the record is cleared.
+        System::set_block_number(cooldown_until.saturating_add(1));
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert!(RejoinCooldown::<Test>::get(ALICE).is_none());
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("relock recorded");
+        assert_eq!(lock.status, ValidatorStatus::Active);
     });
 }

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -219,6 +219,8 @@ impl pallet_validator::Config for Runtime {
 	type LockId = ValidatorLockId;
 	type MaxValidators = ConstU32<1_000>;
 	type RenewInterval = ConstU32<{ 1 * DAYS }>;
+	type OfflineThreshold = ConstU32<12>;
+	type RejoinCooldownPeriod = ConstU32<{ 1 * DAYS }>;
 }
 
 /// `ValidatorSetWithIdentification` adapter over `pallet-session`.

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -270,12 +270,35 @@ parameter_types! {
 	pub const ImOnlineMaxPeerInHeartbeats: u32 = 10_000;
 }
 
+pub struct ImOnlineOffenceReporter;
+
+impl<O>
+	sp_staking::offence::ReportOffence<AccountId, (AccountId, ()), O>
+	for ImOnlineOffenceReporter
+where
+	O: sp_staking::offence::Offence<(AccountId, ())>,
+{
+	fn report_offence(
+		_reporters: alloc::vec::Vec<AccountId>,
+		offence: O,
+	) -> Result<(), sp_staking::offence::OffenceError> {
+		for (offender, _) in offence.offenders() {
+			pallet_validator::Pallet::<Runtime>::note_offline(&offender);
+		}
+		Ok(())
+	}
+
+	fn is_known_offence(_offenders: &[(AccountId, ())], _time_slot: &O::TimeSlot) -> bool {
+		false
+	}
+}
+
 impl pallet_im_online::Config for Runtime {
 	type AuthorityId = pallet_im_online::sr25519::AuthorityId;
 	type RuntimeEvent = RuntimeEvent;
 	type ValidatorSet = ValidatorIdentification;
 	type NextSessionRotation = PeriodicSessions<SessionPeriod, SessionOffset>;
-	type ReportUnresponsiveness = ();
+	type ReportUnresponsiveness = ImOnlineOffenceReporter;
 	type UnsignedPriority = ImOnlineUnsignedPriority;
 	type MaxKeys = ImOnlineMaxKeys;
 	type MaxPeerInHeartbeats = ImOnlineMaxPeerInHeartbeats;


### PR DESCRIPTION
## Summary

Implement the offline-kick path for `pallet-validator`. A validator that misses heartbeats for `OfflineThreshold` consecutive sessions (12 on the runtime, ≈ 2 hours) is automatically moved to `Kicked` state, dropped from the active set, blocked from auto-renewal, and held in a `RejoinCooldownPeriod` cooldown (1 day on the runtime, ≈ 4320 blocks) before they can call `lock()` again. A heartbeat received before the threshold resets the counter.

## Changes

### pallet-validator

- New `Config` constants: `OfflineThreshold: u32` and `RejoinCooldownPeriod: BlockNumber`.
- New transient storage `OfflineThisSession: StorageMap<AccountId, ()>` that accumulates accounts reported as offline during the current session.
- New public API `Pallet::note_offline(&AccountId)` for the runtime adapter to forward offline reports. Calls for unlocked accounts are silently ignored; repeated calls within the same session are idempotent.
- New internal `process_offline_counters()` invoked at every `SessionManager::new_session` boundary, before the active set is recomputed: for each currently-active validator, increment `OfflineSessionCount` when they appear in `OfflineThisSession`, reset it otherwise, and once the threshold is reached flip `LockInfo.status` to `Kicked`, write `RejoinCooldown`, and emit `ValidatorKicked { reason: Offline }`. The transient set is cleared at the end.

### runtime

- New `OfflineReporter` adapter implementing `sp_staking::offence::ReportOffence<AccountId, IdentificationTuple<Runtime>, _>` that forwards each offender from any incoming offence to `pallet_validator::Pallet::<Runtime>::note_offline`.
- Wire `pallet_im_online::Config::ReportUnresponsiveness = OfflineReporter`
- Configure `OfflineThreshold = 12` and `RejoinCooldownPeriod = 1 * DAYS`.

### Tests

- note_offline_ignores_non_validator
- consecutive_offline_kicks_validator
- intermittent_heartbeat_resets_counter
- kicked_validator_skips_auto_renewal
- lock_blocked_during_cooldown_then_succeeds

Closes #29