### PR TITLE
Implement GRANDPA Equivocation Detection and Kick

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10381,6 +10381,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
+ "pallet-authorship",
  "pallet-balances",
  "pallet-difficulty",
  "pallet-grandpa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,10 +78,11 @@ frame-system-benchmarking = { version = "46.0.0", default-features = false }
 frame-system-rpc-runtime-api = { version = "41.0.0", default-features = false }
 frame-try-runtime = { version = "0.52.0", default-features = false }
 pallet-aura = { version = "45.0.0", default-features = false }
+pallet-authorship = { version = "46.0.0", default-features = false }
 pallet-balances = { version = "47.0.0", default-features = false }
 pallet-grandpa = { version = "46.0.0", default-features = false }
 pallet-im-online = { version = "45.0.0", default-features = false }
-pallet-session = { version = "46.0.0", default-features = false }
+pallet-session = { version = "46.0.0", default-features = false, features = ["historical"] }
 pallet-sudo = { version = "46.0.0", default-features = false }
 pallet-timestamp = { version = "45.0.0", default-features = false }
 pallet-transaction-payment-rpc-runtime-api = { version = "46.0.0", default-features = false }

--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -391,6 +391,14 @@ impl<T: Config> Pallet<T> {
         OfflineSessionCount::<T>::remove(who);
         OfflineThisSession::<T>::remove(who);
 
+        // Drop from the pending queue so the account is not promoted at the
+        // next session boundary if it had not yet been activated.
+        PendingValidators::<T>::mutate(|queue| {
+            if let Some(pos) = queue.iter().position(|a| a == who) {
+                queue.remove(pos);
+            }
+        });
+
         Self::deposit_event(Event::ValidatorKicked {
             who: who.clone(),
             reason: KickReason::Equivocation,

--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -355,6 +355,52 @@ impl<T: Config> Pallet<T> {
         );
     }
 
+    /// Mark `who` as kicked due to GRANDPA equivocation.
+    ///
+    /// Idempotent: a non-validator or an already kicked/cooldown account is
+    /// silently ignored. The currency lock is left in place so that funds
+    /// unlock at the original `expiry_block`; auto-renewal stops because the
+    /// status leaves [`ValidatorStatus::Active`]. The account is removed from
+    /// the active set at the next session boundary by `new_session`.
+    pub fn note_equivocation(who: &T::AccountId) {
+        let mut existed = false;
+        ValidatorLocks::<T>::mutate(who, |maybe_info| {
+            if let Some(info) = maybe_info {
+                existed = true;
+                if info.status == ValidatorStatus::Kicked
+                    || info.status == ValidatorStatus::Cooldown
+                {
+                    existed = false;
+                    return;
+                }
+                info.status = ValidatorStatus::Kicked;
+            }
+        });
+        if !existed {
+            log::debug!(
+                target: LOG_TARGET,
+                "equivocation report ignored: account is not an active validator",
+            );
+            return;
+        }
+
+        let now = frame_system::Pallet::<T>::block_number();
+        let cooldown = T::RejoinCooldownPeriod::get();
+        RejoinCooldown::<T>::insert(who, now.saturating_add(cooldown));
+
+        OfflineSessionCount::<T>::remove(who);
+        OfflineThisSession::<T>::remove(who);
+
+        Self::deposit_event(Event::ValidatorKicked {
+            who: who.clone(),
+            reason: KickReason::Equivocation,
+        });
+        log::info!(
+            target: LOG_TARGET,
+            "validator kicked due to GRANDPA equivocation",
+        );
+    }
+
     /// Update offline counters for the current active set and kick any
     /// validator that has reached `OfflineThreshold` consecutive offline
     /// sessions. Called at every session boundary before the active set is

--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -508,3 +508,22 @@ impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
     fn start_session(_start_index: u32) {}
 }
 
+/// `pallet-session/historical` specialization. We do not maintain a separate
+/// full-identification for validators (no nominator/exposure data), so the
+/// identification is `()`. The new-session set is the same one produced by
+/// the base `SessionManager`, zipped with unit identifications.
+impl<T: Config> pallet_session::historical::SessionManager<T::AccountId, ()> for Pallet<T> {
+    fn new_session(new_index: u32) -> Option<alloc::vec::Vec<(T::AccountId, ())>> {
+        <Self as pallet_session::SessionManager<T::AccountId>>::new_session(new_index)
+            .map(|v| v.into_iter().map(|id| (id, ())).collect())
+    }
+
+    fn start_session(start_index: u32) {
+        <Self as pallet_session::SessionManager<T::AccountId>>::start_session(start_index);
+    }
+
+    fn end_session(end_index: u32) {
+        <Self as pallet_session::SessionManager<T::AccountId>>::end_session(end_index);
+    }
+}
+

--- a/pallets/validator/src/tests.rs
+++ b/pallets/validator/src/tests.rs
@@ -521,3 +521,119 @@ fn lock_blocked_during_cooldown_then_succeeds() {
         assert_eq!(lock.status, ValidatorStatus::Active);
     });
 }
+
+#[test]
+fn note_equivocation_ignores_non_validator() {
+    new_test_ext().execute_with(|| {
+        Validator::note_equivocation(&ALICE);
+        assert!(ValidatorLocks::<Test>::get(ALICE).is_none());
+        assert!(RejoinCooldown::<Test>::get(ALICE).is_none());
+    });
+}
+
+#[test]
+fn note_equivocation_kicks_active_validator() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        // Clear the lock-event so the equivocation event is the last one.
+        System::reset_events();
+
+        Validator::note_equivocation(&ALICE);
+
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock retained");
+        assert_eq!(lock.status, ValidatorStatus::Kicked);
+        // Lock amount and expiry are unchanged so funds unlock at the original block.
+        assert_eq!(lock.amount, 1_000);
+        assert_eq!(lock.expiry_block, 11);
+
+        let cooldown = RejoinCooldown::<Test>::get(ALICE).expect("cooldown recorded");
+        assert_eq!(cooldown, System::block_number() + 20);
+
+        System::assert_last_event(
+            Event::ValidatorKicked { who: ALICE, reason: KickReason::Equivocation }.into(),
+        );
+    });
+}
+
+#[test]
+fn note_equivocation_is_idempotent() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        Validator::note_equivocation(&ALICE);
+        let cooldown_first = RejoinCooldown::<Test>::get(ALICE).expect("cooldown recorded");
+
+        // Advance a block and report again: the cooldown deadline must not move.
+        System::set_block_number(System::block_number() + 5);
+        Validator::note_equivocation(&ALICE);
+
+        assert_eq!(RejoinCooldown::<Test>::get(ALICE), Some(cooldown_first));
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock retained");
+        assert_eq!(lock.status, ValidatorStatus::Kicked);
+    });
+}
+
+#[test]
+fn equivocation_kick_stops_auto_renewal() {
+    new_test_ext().execute_with(|| {
+        // Lock at block 1 -> expiry 11; renewal window starts at block 6.
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        Validator::note_equivocation(&ALICE);
+
+        run_to_block(8);
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock retained");
+        assert_eq!(lock.expiry_block, 11);
+        assert_eq!(lock.status, ValidatorStatus::Kicked);
+    });
+}
+
+#[test]
+fn equivocation_lock_released_at_original_expiry() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        Validator::note_equivocation(&ALICE);
+
+        run_to_block(11);
+        assert!(ValidatorLocks::<Test>::get(ALICE).is_none());
+        // Cooldown deadline survives lock release.
+        assert!(RejoinCooldown::<Test>::get(ALICE).is_some());
+    });
+}
+
+#[test]
+fn equivocation_removes_from_active_set_next_session() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(BOB)));
+        let _ = rotate_session(1);
+        assert_eq!(ActiveValidators::<Test>::get().to_vec(), vec![ALICE, BOB]);
+
+        Validator::note_equivocation(&ALICE);
+
+        let set = rotate_session(2).expect("set must shrink");
+        assert_eq!(set, vec![BOB]);
+        assert_eq!(ActiveValidators::<Test>::get().to_vec(), vec![BOB]);
+    });
+}
+
+#[test]
+fn equivocation_blocks_relock_during_cooldown() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        Validator::note_equivocation(&ALICE);
+
+        // Let the original lock expire to free the account for a relock attempt.
+        run_to_block(11);
+        assert!(ValidatorLocks::<Test>::get(ALICE).is_none());
+
+        let cooldown_until = RejoinCooldown::<Test>::get(ALICE).expect("cooldown set");
+        assert!(cooldown_until > System::block_number());
+        assert_noop!(
+            Validator::lock(RuntimeOrigin::signed(ALICE)),
+            Error::<Test>::InCooldown,
+        );
+
+        System::set_block_number(cooldown_until.saturating_add(1));
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        assert!(RejoinCooldown::<Test>::get(ALICE).is_none());
+    });
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -22,6 +22,7 @@ frame-system-benchmarking = { optional = true, workspace = true }
 frame-system-rpc-runtime-api.workspace = true
 frame-system.workspace = true
 frame-try-runtime = { optional = true, workspace = true }
+pallet-authorship.workspace = true
 pallet-balances.workspace = true
 pallet-difficulty.workspace = true
 pallet-grandpa.workspace = true
@@ -69,6 +70,7 @@ std = [
 	"frame-system-rpc-runtime-api/std",
 	"frame-system/std",
 	"frame-try-runtime?/std",
+	"pallet-authorship/std",
 	"pallet-balances/std",
 	"pallet-difficulty/std",
 	"pallet-grandpa/std",
@@ -127,6 +129,7 @@ try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"frame-try-runtime/try-runtime",
+	"pallet-authorship/try-runtime",
 	"pallet-balances/try-runtime",
 	"pallet-difficulty/try-runtime",
 	"pallet-grandpa/try-runtime",

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -40,7 +40,7 @@ use sp_version::RuntimeVersion;
 
 // Local module imports
 use super::{
-	AccountId, Balance, Block, Executive, Grandpa, InherentDataExt, Nonce, Runtime,
+	AccountId, Balance, Block, Executive, Grandpa, Historical, InherentDataExt, Nonce, Runtime,
 	RuntimeCall, RuntimeGenesisConfig, SessionKeys, System, TransactionPayment, VERSION,
 	inherent_checks::check_timestamp_drift,
 };
@@ -307,20 +307,25 @@ impl_runtime_apis! {
 		}
 
 		fn submit_report_equivocation_unsigned_extrinsic(
-			_equivocation_proof: sp_consensus_grandpa::EquivocationProof<
+			equivocation_proof: sp_consensus_grandpa::EquivocationProof<
 				<Block as sp_runtime::traits::Block>::Hash,
 				sp_runtime::traits::NumberFor<Block>,
 			>,
-			_key_owner_proof: sp_consensus_grandpa::OpaqueKeyOwnershipProof,
+			key_owner_proof: sp_consensus_grandpa::OpaqueKeyOwnershipProof,
 		) -> Option<()> {
-			None
+			let key_owner_proof = key_owner_proof.decode()?;
+			Grandpa::submit_unsigned_equivocation_report(equivocation_proof, key_owner_proof)
 		}
 
 		fn generate_key_ownership_proof(
 			_set_id: sp_consensus_grandpa::SetId,
-			_authority_id: sp_consensus_grandpa::AuthorityId,
+			authority_id: sp_consensus_grandpa::AuthorityId,
 		) -> Option<sp_consensus_grandpa::OpaqueKeyOwnershipProof> {
-			None
+			use codec::Encode;
+			use frame_support::traits::KeyOwnerProofSystem;
+			Historical::prove((sp_consensus_grandpa::KEY_TYPE, authority_id))
+				.map(|p| p.encode())
+				.map(sp_consensus_grandpa::OpaqueKeyOwnershipProof::new)
 		}
 	}
 

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -328,6 +328,41 @@ where
 	}
 }
 
+/// Offence reporter that forwards GRANDPA equivocation reports into
+/// `pallet-validator`.
+///
+/// The `pallet-grandpa` built-in [`pallet_grandpa::EquivocationReportSystem`]
+/// expects a [`ReportOffence`] implementation keyed by the
+/// `IdentificationTuple` produced by `pallet-session/historical`, which in
+/// this runtime is `(AccountId, ())`. Upon receiving a verified offence we
+/// call [`pallet_validator::Pallet::note_equivocation`] for the offender,
+/// which switches the validator's lock to `Kicked`, records the rejoin
+/// cooldown deadline, and emits the `ValidatorKicked { Equivocation }`
+/// event. The next session boundary removes the validator from the active
+/// set via the existing session manager logic.
+pub struct GrandpaOffenceReporter;
+
+impl<O>
+	sp_staking::offence::ReportOffence<AccountId, (AccountId, ()), O>
+	for GrandpaOffenceReporter
+where
+	O: sp_staking::offence::Offence<(AccountId, ())>,
+{
+	fn report_offence(
+		_reporters: alloc::vec::Vec<AccountId>,
+		offence: O,
+	) -> Result<(), sp_staking::offence::OffenceError> {
+		for (offender, _) in offence.offenders() {
+			pallet_validator::Pallet::<Runtime>::note_equivocation(&offender);
+		}
+		Ok(())
+	}
+
+	fn is_known_offence(_offenders: &[(AccountId, ())], _time_slot: &O::TimeSlot) -> bool {
+		false
+	}
+}
+
 impl pallet_im_online::Config for Runtime {
 	type AuthorityId = pallet_im_online::sr25519::AuthorityId;
 	type RuntimeEvent = RuntimeEvent;

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -176,14 +176,25 @@ impl pallet_difficulty::Config for Runtime {
 	type Halflife = DifficultyHalflife;
 }
 
+parameter_types! {
+	/// Maximum number of blocks a GRANDPA equivocation report transaction is
+	/// considered valid for inclusion before expiring from the pool.
+	pub const GrandpaReportLongevity: u64 = 25;
+}
+
 impl pallet_grandpa::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
 	type MaxAuthorities = ConstU32<1000>;
 	type MaxNominators = ConstU32<0>;
-	type MaxSetIdSessionEntries = ConstU64<0>;
-	type KeyOwnerProof = sp_core::Void;
-	type EquivocationReportSystem = ();
+	type MaxSetIdSessionEntries = ConstU64<168>;
+	type KeyOwnerProof = sp_session::MembershipProof;
+	type EquivocationReportSystem = pallet_grandpa::EquivocationReportSystem<
+		Self,
+		GrandpaOffenceReporter,
+		pallet_session::historical::Pallet<Runtime>,
+		GrandpaReportLongevity,
+	>;
 }
 
 /// Block-author finder for `pallet-authorship`.

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -186,6 +186,41 @@ impl pallet_grandpa::Config for Runtime {
 	type EquivocationReportSystem = ();
 }
 
+/// Block-author finder for `pallet-authorship`.
+///
+/// PoW does not have a first-class authority, so we do not attribute block
+/// authorship for reward or reporter purposes here. The value is only consumed
+/// by the GRANDPA equivocation report pipeline as a fallback reporter when an
+/// offchain worker submits a report; leaving it `None` means the report carries
+/// no reporter, which is fine because our reporting adapter ignores reporters.
+pub struct PowFindAuthor;
+
+impl frame_support::traits::FindAuthor<AccountId> for PowFindAuthor {
+	fn find_author<'a, I>(_digests: I) -> Option<AccountId>
+	where
+		I: 'a + IntoIterator<Item = (sp_runtime::ConsensusEngineId, &'a [u8])>,
+	{
+		None
+	}
+}
+
+impl pallet_authorship::Config for Runtime {
+	type FindAuthor = PowFindAuthor;
+	type EventHandler = ();
+}
+
+/// `pallet-session/historical` configuration.
+///
+/// Full identification is unit because this chain does not maintain exposures
+/// or nominator stakes. The historical trie is required to validate GRANDPA
+/// equivocation key-ownership proofs against the session in which the offence
+/// occurred.
+impl pallet_session::historical::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type FullIdentification = ();
+	type FullIdentificationOf = UnitIdentification;
+}
+
 parameter_types! {
 	/// Length of a session in blocks (~10 minutes at 6s block time, but our PoW
 	/// targets ~20s, so a session lasts ~10 minutes either way for genesis tests).
@@ -199,7 +234,7 @@ impl pallet_session::Config for Runtime {
 	type ValidatorIdOf = ConvertInto;
 	type ShouldEndSession = PeriodicSessions<SessionPeriod, SessionOffset>;
 	type NextSessionRotation = PeriodicSessions<SessionPeriod, SessionOffset>;
-	type SessionManager = Validator;
+	type SessionManager = pallet_session::historical::NoteHistoricalRoot<Runtime, Validator>;
 	type SessionHandler = <SessionKeys as sp_runtime::traits::OpaqueKeys>::KeyTypeIdProviders;
 	type Keys = SessionKeys;
 	type DisablingStrategy = ();

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -225,6 +225,12 @@ mod runtime {
 
 	#[runtime::pallet_index(13)]
 	pub type ImOnline = pallet_im_online;
+
+	#[runtime::pallet_index(14)]
+	pub type Authorship = pallet_authorship;
+
+	#[runtime::pallet_index(15)]
+	pub type Historical = pallet_session::historical;
 }
 
 // pallet-im-online submits unsigned heartbeat extrinsics from offchain


### PR DESCRIPTION



## Summary

Detect GRANDPA equivocation and kick the offender. The validator's lock stops auto-renewing, funds unlock at the original expiry, and the account enters a rejoin cooldown.

## Changes

### pallet/validator
  - New `note_equivocation(&AccountId)` entry point: idempotent; switches status to `Kicked`, records the cooldown deadline, clears offline counters, drops the account from the pending queue, and emits `ValidatorKicked { reason: Equivocation }`.
  - Implement `pallet_session::historical::SessionManager<AccountId, ()>` so the base session set can be zipped with a unit full identification.

### runtime
  - Enable `pallet-session`'s `historical` feature; register `Authorship` and `Historical` pallets.
  - Route the session manager through `NoteHistoricalRoot<Runtime, Validator>` to maintain the per-session merkle trie.
  - Configure `pallet_authorship` with a no-op `FindAuthor` (PoW has no consensus-level author) and `pallet_session::historical` with unit `FullIdentification`.
  - Add `GrandpaOffenceReporter`, a `ReportOffence` adapter that forwards verified equivocation offenders into `Validator::note_equivocation`.
  - Wire `pallet_grandpa::Config::EquivocationReportSystem` to `pallet_grandpa::EquivocationReportSystem<Self, GrandpaOffenceReporter, Historical, GrandpaReportLongevity>`; switch `KeyOwnerProof` to `sp_session::MembershipProof`;raise `MaxSetIdSessionEntries` so set-id history covers a useful reporting window.
  - Implement `GrandpaApi::generate_key_ownership_proof` via `Historical::prove` and wire `submit_report_equivocation_unsigned_extrinsic` through `Grandpa::submit_unsigned_equivocation_report`.

### Tests

- note_equivocation_ignores_non_validator
- note_equivocation_kicks_active_validator
- note_equivocation_is_idempotent
- equivocation_kick_stops_auto_renewal
- equivocation_lock_released_at_original_expiry
- equivocation_removes_from_active_set_next_session
- equivocation_blocks_relock_during_cooldown



Closes #30