### PR TITLE
ASERT re-anchoring

### DIFF
--- a/pallets/difficulty/README.md
+++ b/pallets/difficulty/README.md
@@ -4,7 +4,7 @@ ASERT (Absolutely Scheduled Exponentially Rising Targets) difficulty adjustment 
 
 ## Overview
 
-This pallet dynamically adjusts the mining difficulty to keep block production close to the target interval (default: 20 seconds). Unlike recursive parent-based algorithms, ASERT computes each block's difficulty from a fixed anchor block using an exponential formula, eliminating cumulative rounding errors and feedback oscillation.
+This pallet dynamically adjusts the mining difficulty to keep block production close to the target interval (default: 20 seconds). It uses ASERT against a fixed anchor block (the original chain anchor), so each block's target is computed independently of intermediate blocks. When the gap between two consecutive blocks exceeds a configured threshold, the chain is considered to have resumed from an outage and the anchor is moved forward to the recovery block, so subsequent blocks are evaluated relative to the resumption point rather than dragging the long gap into every future computation.
 
 ### Formula
 
@@ -18,17 +18,23 @@ next_target = anchor_target × 2^((time_delta - target_block_time × height_delt
 - `target_block_time` — ideal block interval (20s)
 - `halflife` — 1800s (30 minutes)
 
+### Interruption recovery
+
+In `on_finalize`, after computing the new difficulty for the just-finalized block N, the pallet checks the gap from block N-1's timestamp. If the gap exceeds `BreakThresholdSecs` (default 1800s), it re-anchors to block N: `AnchorTarget = next_target`, `AnchorTimestamp = ts(N)`, `AnchorHeight = N`. From the next block onward, ASERT evaluates against the resumed anchor with `Δh` restarting from 1, so the chain does not need to mine many catch-up blocks to "work off" the outage gap.
+
+Miners continue to query `realtime_difficulty(now_secs)` which evaluates ASERT against the current anchor with wall-clock `Δt`. During an outage `Δt` grows and difficulty decays naturally, so the recovery block remains feasible to mine.
+
 ### Key Properties
 
-- **Absolute scheduling**: difficulty derived from anchor block, not recursively from parent
-- **No cumulative error**: each computation is independent
-- **Natural decay**: when blocks fall behind schedule, difficulty automatically decreases
-- **Pure integer arithmetic**: 16-bit fixed-point with cubic polynomial 2^x approximation, no floating point
+- **Absolute scheduling**: difficulty derived from a fixed anchor while the chain is healthy.
+- **No cumulative error**: each computation is independent of intermediate blocks.
+- **Natural decay**: when blocks fall behind schedule, difficulty automatically decreases.
+- **Interruption recovery**: anchor advances to the recovery block, eliminating the need to mine long bursts of catch-up blocks.
 
 ### Difficulty Decay (Hashrate Drop)
 
 | Time Without Blocks | Difficulty |
-|---------------------|------------|
+| ------------------- | ---------- |
 | 0                   | 100%       |
 | 30 min              | 50%        |
 | 1 hour              | 25%        |
@@ -46,12 +52,14 @@ The pallet exposes `DifficultyApi` with two methods:
 
 ```rust
 parameter_types! {
-    pub const TargetBlockTime: u64 = 20;      // seconds
-    pub const DifficultyHalflife: u64 = 1800;  // seconds (30 minutes)
+    pub const TargetBlockTime: u64 = 20;                       // seconds
+    pub const DifficultyHalflife: u64 = 1800;                  // seconds (30 minutes)
+    pub const DifficultyBreakThresholdSecs: u64 = 1800;        // outage threshold (seconds)
 }
 
 impl pallet_difficulty::Config for Runtime {
     type TargetBlockTime = TargetBlockTime;
     type Halflife = DifficultyHalflife;
+    type BreakThresholdSecs = DifficultyBreakThresholdSecs;
 }
 ```

--- a/pallets/difficulty/src/lib.rs
+++ b/pallets/difficulty/src/lib.rs
@@ -13,6 +13,11 @@ pub use pallet::*;
 
 pub mod asert;
 
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
 sp_api::decl_runtime_apis! {
 	/// Runtime API for querying ASERT difficulty parameters and computing
 	/// real-time difficulty.
@@ -47,6 +52,10 @@ pub mod pallet {
 		/// ASERT halflife in seconds (e.g. 1800 = 30 minutes).
 		#[pallet::constant]
 		type Halflife: Get<u64>;
+
+		/// Interruption threshold in seconds.
+		#[pallet::constant]
+		type BreakThresholdSecs: Get<u64>;
 	}
 
 	/// Current mining difficulty (U256).
@@ -59,14 +68,17 @@ pub mod pallet {
 
 	/// Anchor block target value (inverse of difficulty).
 	///
-	/// `target = U256::MAX / difficulty`. Set at genesis.
+	/// `target = U256::MAX / difficulty`. Set at genesis and only
+	/// updated when `on_finalize` detects an interruption (a gap from
+	/// the parent block exceeding [`Config::BreakThresholdSecs`]).
 	#[pallet::storage]
 	#[pallet::getter(fn anchor_target)]
 	pub type AnchorTarget<T: Config> = StorageValue<_, U256, ValueQuery>;
 
 	/// Timestamp of the anchor block (seconds since Unix epoch).
 	///
-	/// Auto-initialized on the first block with a valid timestamp.
+	/// Auto-initialized on the first block with a valid timestamp,
+	/// then only re-set on interruption recovery.
 	#[pallet::storage]
 	#[pallet::getter(fn anchor_timestamp)]
 	pub type AnchorTimestamp<T: Config> = StorageValue<_, u64, ValueQuery>;
@@ -75,6 +87,14 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn anchor_height)]
 	pub type AnchorHeight<T: Config> = StorageValue<_, u32, ValueQuery>;
+
+	/// Timestamp of the most recently finalized block (seconds).
+	///
+	/// Used to detect inter-block gaps and decide whether the next
+	/// block resumes from an interruption.
+	#[pallet::storage]
+	#[pallet::getter(fn last_block_timestamp)]
+	pub type LastBlockTimestamp<T: Config> = StorageValue<_, u64, ValueQuery>;
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
@@ -145,12 +165,13 @@ pub mod pallet {
 			let now_secs = now_ms / 1000;
 
 			// Auto-initialize anchor on the first block with a valid
-			// timestamp.  This block becomes the anchor — keep the
+			// timestamp. This block becomes the anchor — keep the
 			// initial difficulty unchanged.
 			let anchor_ts = AnchorTimestamp::<T>::get();
 			if anchor_ts == 0 && now_secs > 0 {
 				AnchorTimestamp::<T>::put(now_secs);
 				AnchorHeight::<T>::put(current_height);
+				LastBlockTimestamp::<T>::put(now_secs);
 				return;
 			}
 
@@ -158,6 +179,7 @@ pub mod pallet {
 
 			// Skip ASERT on the anchor block itself.
 			if current_height <= anchor_height {
+				LastBlockTimestamp::<T>::put(now_secs);
 				return;
 			}
 
@@ -171,6 +193,7 @@ pub mod pallet {
 
 			let anchor_target = AnchorTarget::<T>::get();
 			if anchor_target.is_zero() {
+				LastBlockTimestamp::<T>::put(now_secs);
 				return;
 			}
 
@@ -190,6 +213,22 @@ pub mod pallet {
 			};
 
 			CurrentDifficulty::<T>::put(new_difficulty);
+
+			// Interruption recovery: if the gap from the parent block
+			// exceeded `BreakThresholdSecs`, re-anchor onto the just-
+			// finalized block. This resets `height_delta` so that
+			// subsequent blocks compute their target relative to the
+			// recovery block rather than having to "pay back" the long
+			// outage gap through many fast catch-up blocks.
+			let last_ts = LastBlockTimestamp::<T>::get();
+			let block_gap = now_secs.saturating_sub(last_ts);
+			if block_gap > T::BreakThresholdSecs::get() {
+				AnchorTarget::<T>::put(next_target);
+				AnchorTimestamp::<T>::put(now_secs);
+				AnchorHeight::<T>::put(current_height);
+			}
+
+			LastBlockTimestamp::<T>::put(now_secs);
 		}
 	}
 }

--- a/pallets/difficulty/src/mock.rs
+++ b/pallets/difficulty/src/mock.rs
@@ -1,0 +1,87 @@
+use crate as pallet_difficulty;
+use frame_support::{derive_impl, traits::ConstU64};
+use sp_core::U256;
+use sp_runtime::BuildStorage;
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+#[frame_support::runtime]
+mod runtime {
+	#[runtime::runtime]
+	#[runtime::derive(
+		RuntimeCall,
+		RuntimeEvent,
+		RuntimeError,
+		RuntimeOrigin,
+		RuntimeFreezeReason,
+		RuntimeHoldReason,
+		RuntimeSlashReason,
+		RuntimeLockId,
+		RuntimeTask,
+		RuntimeViewFunction
+	)]
+	pub struct Test;
+
+	#[runtime::pallet_index(0)]
+	pub type System = frame_system::Pallet<Test>;
+
+	#[runtime::pallet_index(1)]
+	pub type Timestamp = pallet_timestamp::Pallet<Test>;
+
+	#[runtime::pallet_index(2)]
+	pub type Difficulty = pallet_difficulty::Pallet<Test>;
+}
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+	type Block = Block;
+}
+
+#[derive_impl(pallet_timestamp::config_preludes::TestDefaultConfig)]
+impl pallet_timestamp::Config for Test {}
+
+frame_support::parameter_types! {
+	pub const TargetBlockTime: u64 = 20;
+	pub const Halflife: u64 = 1800;
+}
+
+impl pallet_difficulty::Config for Test {
+	type TargetBlockTime = TargetBlockTime;
+	type Halflife = Halflife;
+	type BreakThresholdSecs = ConstU64<1800>;
+}
+
+/// Initial difficulty used by tests.
+pub const INITIAL_DIFFICULTY: u128 = 1_000_000;
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let mut storage = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+
+	let initial = U256::from(INITIAL_DIFFICULTY);
+	pallet_difficulty::GenesisConfig::<Test> {
+		initial_difficulty: initial,
+		anchor_target: U256::MAX / initial,
+		anchor_timestamp: 0,
+		anchor_height: 0,
+		_marker: Default::default(),
+	}
+	.assimilate_storage(&mut storage)
+	.unwrap();
+
+	storage.into()
+}
+
+/// Advance to the given block, set the timestamp (in seconds), and run
+/// `on_finalize` for both timestamp and difficulty pallets.
+pub fn run_to_block_at(block: u64, now_secs: u64) {
+	use frame_support::traits::Hooks;
+	System::set_block_number(block);
+	let _ = pallet_timestamp::Pallet::<Test>::set(
+		frame_system::RawOrigin::None.into(),
+		now_secs * 1000,
+	);
+	<pallet_difficulty::Pallet<Test> as Hooks<u64>>::on_finalize(block);
+	// Clear timestamp's per-block DidUpdate flag so the next block can
+	// set it again.
+	<pallet_timestamp::Pallet<Test> as Hooks<u64>>::on_finalize(block);
+}

--- a/pallets/difficulty/src/tests.rs
+++ b/pallets/difficulty/src/tests.rs
@@ -1,0 +1,98 @@
+//! Tests for the fixed-anchor ASERT with break-only re-anchoring.
+
+use crate::{mock::*, AnchorHeight, AnchorTimestamp, CurrentDifficulty, LastBlockTimestamp};
+use sp_core::U256;
+
+/// Bring the chain past the auto-init block. Returns the timestamp used.
+fn bootstrap(start_secs: u64) -> u64 {
+	run_to_block_at(1, start_secs);
+	start_secs
+}
+
+#[test]
+fn normal_block_keeps_difficulty() {
+	new_test_ext().execute_with(|| {
+		let t0 = bootstrap(10_000);
+		let initial = CurrentDifficulty::<Test>::get();
+
+		run_to_block_at(2, t0 + 20);
+		let after = CurrentDifficulty::<Test>::get();
+
+		let diff = if after > initial { after - initial } else { initial - after };
+		assert!(diff * U256::from(100u64) < initial, "drift too large: {initial:?} -> {after:?}");
+	});
+}
+
+#[test]
+fn slow_block_decreases_difficulty() {
+	new_test_ext().execute_with(|| {
+		let t0 = bootstrap(10_000);
+		let before = CurrentDifficulty::<Test>::get();
+
+		run_to_block_at(2, t0 + 40);
+		let after = CurrentDifficulty::<Test>::get();
+		assert!(after < before, "slow block must lower difficulty: {before:?} -> {after:?}");
+	});
+}
+
+#[test]
+fn anchor_unchanged_during_normal_operation() {
+	new_test_ext().execute_with(|| {
+		let t0 = bootstrap(10_000);
+		let anchor_h = AnchorHeight::<Test>::get();
+		let anchor_ts = AnchorTimestamp::<Test>::get();
+
+		for i in 2u64..=6 {
+			run_to_block_at(i, t0 + 20 * (i - 1));
+		}
+
+		assert_eq!(AnchorHeight::<Test>::get(), anchor_h, "anchor height must not move");
+		assert_eq!(AnchorTimestamp::<Test>::get(), anchor_ts, "anchor timestamp must not move");
+	});
+}
+
+#[test]
+fn break_reanchors_to_recovery_block() {
+	new_test_ext().execute_with(|| {
+		let t0 = bootstrap(10_000);
+
+		run_to_block_at(2, t0 + 20);
+		run_to_block_at(3, t0 + 40);
+
+		// Block 4 arrives 1 hour after block 3 — interruption.
+		let recovery_ts = t0 + 40 + 3_600;
+		run_to_block_at(4, recovery_ts);
+
+		assert_eq!(AnchorHeight::<Test>::get(), 4, "anchor must move to recovery block");
+		assert_eq!(AnchorTimestamp::<Test>::get(), recovery_ts);
+		assert_eq!(LastBlockTimestamp::<Test>::get(), recovery_ts);
+	});
+}
+
+#[test]
+fn break_realtime_decays() {
+	new_test_ext().execute_with(|| {
+		let t0 = bootstrap(10_000);
+		let on_schedule = crate::Pallet::<Test>::realtime_difficulty(t0 + 20);
+		let after_outage = crate::Pallet::<Test>::realtime_difficulty(t0 + 86_400);
+
+		assert!(
+			after_outage < on_schedule,
+			"realtime difficulty must decay during interruption: {on_schedule:?} vs {after_outage:?}"
+		);
+	});
+}
+
+#[test]
+fn small_gap_does_not_reanchor() {
+	new_test_ext().execute_with(|| {
+		let t0 = bootstrap(10_000);
+		let anchor_h = AnchorHeight::<Test>::get();
+
+		// Block 2 arrives 100s after block 1 — slow but well under the
+		// 1800s break threshold.
+		run_to_block_at(2, t0 + 100);
+
+		assert_eq!(AnchorHeight::<Test>::get(), anchor_h, "moderate gap must not re-anchor");
+	});
+}

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -28,6 +28,7 @@ parameter_types! {
 
 	pub const TargetBlockTime: u64 = 20;
 	pub const DifficultyHalflife: u64 = 1800;
+	pub const DifficultyBreakThresholdSecs: u64 = 1800;
 
 	/// We allow for 2 seconds of compute with a 6 second average block time.
 	pub RuntimeBlockWeights: BlockWeights = BlockWeights::with_sensible_defaults(
@@ -144,6 +145,7 @@ impl pallet_sudo::Config for Runtime {
 impl pallet_difficulty::Config for Runtime {
 	type TargetBlockTime = TargetBlockTime;
 	type Halflife = DifficultyHalflife;
+	type BreakThresholdSecs = DifficultyBreakThresholdSecs;
 }
 
 parameter_types! {


### PR DESCRIPTION
- **During healthy block production**: keep ASERT's fixed-anchor semantics. The anchor stays put; each block's target is computed directly against the anchor using `(Δt, Δh)`. With `Δt ≈ T_target`, the ASERT exponent ≈ 0, so difficulty barely moves.
- **On interruption detection**: at the end of `on_finalize`, if the gap from the parent block `gap > T_break`, advance the anchor onto the current block. The new anchor's `(target, ts, height)` is the current block's `(next_target, now_secs, current_height)`.

Effects:

- After the recovery block, `Δh` restarts from 0, so the chain no longer carries the "schedule debt" accrued during the long outage. No need to mine many low-difficulty blocks just to grow `Δh` back.
- Miners always read `realtime_difficulty`, which keeps applying ASERT. As wall-clock `Δt` grows during the outage, difficulty decays naturally and the recovery block remains feasible to mine.
- After the re-anchor, if hashrate has returned to the pre-outage level, blocks arrive faster than 20s. ASERT immediately raises the difficulty, and the chain returns to equilibrium within normal fluctuation bounds.

Closes #65 