### PR TITLE
Spawn GRANDPA observer task for non-validator nodes

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -1,0 +1,24 @@
+## Some notes
+
+### GRANDPA
+
+GRANDPA is wired in unconditionally.
+
+Upstream gates the entire GRANDPA stack behind an `enable_grandpa` flag (`!cli.no_grandpa && role.is_authority()`). When the flag is false, upstream:
+
+* never calls `sc_consensus_grandpa::block_import()` (so no notification stream is created),
+* never registers the `/grandpa/...` gossip protocol on the network,
+* never spawns `run_grandpa_voter`.
+
+We cannot do that here for two reasons:
+
+* **GRANDPA is wrapped by PoW import.**
+  `PowBlockImport::new(grandpa_block_import.clone(), …)` requires a `grandpa_block_import` to exist on every node so that finality justifications attached to incoming PoW blocks are verified consistently.
+  That call has the side effect of registering the GRANDPA gossip protocol and creating the notification service.
+* **The notification service must be drained.**
+  Once the gossip protocol is registered, the network task pushes messages into it.
+  If the receiver end is dropped (the original behaviour for non-authorities) the next push triggers `EssentialTaskClosed` and the node exits.
+
+We therefore **always** spawn `sc_consensus_grandpa::run_grandpa_voter`. Authority nodes pass `keystore = Some(...)` and act as full voters; non-authority nodes pass `keystore = None` and act as observers (follow finality, never vote, never produce equivocation reports). The task name is set accordingly (`grandpa-voter` vs `grandpa-observer`) so the difference is visible in logs and prometheus metrics.
+
+This is intentional: the multi-node integration tests rely on non-validator nodes (`dave`, `eve`) reporting the same finalized hash as the validators, and downstream RPC consumers expect a meaningful `finalized_head` from any full node.

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -259,31 +259,24 @@ pub fn new_full<
 		protocol_name: grandpa_protocol_name,
 	};
 
-	if is_authority {
-		let grandpa_params = sc_consensus_grandpa::GrandpaParams {
-			config: grandpa_config,
-			link: grandpa_link,
-			network,
-			sync: Arc::new(sync_service.clone()),
-			voting_rule: sc_consensus_grandpa::VotingRulesBuilder::default().build(),
-			prometheus_registry: prometheus_registry.clone(),
-			shared_voter_state,
-			telemetry: telemetry.as_ref().map(|x| x.handle()),
-			offchain_tx_pool_factory: OffchainTransactionPoolFactory::new(transaction_pool.clone()),
-			notification_service: grandpa_notification_service,
-		};
+	let grandpa_params = sc_consensus_grandpa::GrandpaParams {
+		config: grandpa_config,
+		link: grandpa_link,
+		network,
+		sync: Arc::new(sync_service.clone()),
+		voting_rule: sc_consensus_grandpa::VotingRulesBuilder::default().build(),
+		prometheus_registry: prometheus_registry.clone(),
+		shared_voter_state,
+		telemetry: telemetry.as_ref().map(|x| x.handle()),
+		offchain_tx_pool_factory: OffchainTransactionPoolFactory::new(transaction_pool.clone()),
+		notification_service: grandpa_notification_service,
+	};
 
-		task_manager.spawn_essential_handle().spawn_blocking(
-			"grandpa-voter",
-			None,
-			sc_consensus_grandpa::run_grandpa_voter(grandpa_params)?,
-		);
-	} else {
-		// Non-validator nodes still need to participate in GRANDPA gossip for sync
-		// of justifications, so we drop the notification service handle. The protocol
-		// itself was registered via `add_notification_protocol` above.
-		drop(grandpa_notification_service);
-	}
+	task_manager.spawn_essential_handle().spawn_blocking(
+		if is_authority { "grandpa-voter" } else { "grandpa-observer" },
+		None,
+		sc_consensus_grandpa::run_grandpa_voter(grandpa_params)?,
+	);
 
 	if let Some(miner_address) = miner_account {
 		let proposer_factory = sc_basic_authorship::ProposerFactory::new(


### PR DESCRIPTION
The non-authority branch of new_full() was dropping the grandpa notification stream returned from the grandpa block import setup. That immediately closed the corresponding essential task and any follow-up grandpa peer dialing failed, leaving full nodes stuck at 0 peers and unable to follow finality.

Mirror the authority branch but pass keystore=None so non-authority nodes participate as observers only (no voting, no equivocation reporting).