### PR TITLE
Set up Zombienet and integration testing

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -107,8 +107,10 @@ runtime-benchmarks = [
 	"solochain-template-runtime/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 ]
-# Enable features that allow the runtime to be tried and debugged. Name might be subject to change
-# in the near future.
+# Enable features for providing test values.
+test-runtime = ["solochain-template-runtime/test-runtime"]
+# Enable features that allow the runtime to be tried and debugged.
+# Name might be subject to change in the near future.
 try-runtime = [
 	"frame-system/try-runtime",
 	"pallet-transaction-payment/try-runtime",

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,6 +1,8 @@
 use sc_service::ChainType;
 use serde_json::json;
-use solochain_template_runtime::WASM_BINARY;
+use solochain_template_runtime::{
+	genesis_config_presets::INTEGRATION_RUNTIME_PRESET, WASM_BINARY,
+};
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::GenericChainSpec;
@@ -35,6 +37,19 @@ pub fn local_chain_spec() -> Result<ChainSpec, String> {
 	.with_id("local_testnet")
 	.with_chain_type(ChainType::Local)
 	.with_genesis_config_preset_name(sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET)
+	.with_properties(chain_properties())
+	.build())
+}
+
+pub fn integration_chain_spec() -> Result<ChainSpec, String> {
+	Ok(ChainSpec::builder(
+		WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
+		None,
+	)
+	.with_name("Integration Testnet")
+	.with_id("integration")
+	.with_chain_type(ChainType::Local)
+	.with_genesis_config_preset_name(INTEGRATION_RUNTIME_PRESET)
 	.with_properties(chain_properties())
 	.build())
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -40,6 +40,7 @@ impl SubstrateCli for Cli {
 		Ok(match id {
 			"dev" => Box::new(chain_spec::development_chain_spec()?),
 			"" | "local" => Box::new(chain_spec::local_chain_spec()?),
+			"integration" => Box::new(chain_spec::integration_chain_spec()?),
 			path =>
 				Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?),
 		})

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -103,6 +103,8 @@ std = [
 	"substrate-wasm-builder",
 ]
 
+test-runtime = []
+
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -15,9 +15,10 @@ use sp_version::RuntimeVersion;
 
 // Local module imports
 use super::{
-	AccountId, Balance, Balances, Block, BlockNumber, DAYS, Hash, Nonce, PalletInfo, Runtime,
+	AccountId, Balance, Balances, Block, BlockNumber, Hash, Nonce, PalletInfo, Runtime,
 	RuntimeCall, RuntimeEvent, RuntimeFreezeReason, RuntimeHoldReason, RuntimeOrigin, RuntimeTask,
 	Session, SessionKeys, System, Validator, EXISTENTIAL_DEPOSIT, UNIT, VERSION,
+	DAYS, MINUTES
 };
 
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
@@ -27,8 +28,6 @@ parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
 
 	pub const TargetBlockTime: u64 = 20;
-	pub const DifficultyHalflife: u64 = 1800;
-	pub const DifficultyBreakThresholdSecs: u64 = 1800;
 
 	/// We allow for 2 seconds of compute with a 6 second average block time.
 	pub RuntimeBlockWeights: BlockWeights = BlockWeights::with_sensible_defaults(
@@ -43,6 +42,18 @@ parameter_types! {
 		)
 		.build();
 	pub const SS58Prefix: u8 = 42;
+}
+
+#[cfg(not(feature = "test-runtime"))]
+parameter_types! {
+	pub const DifficultyHalflife: u64 = 1800;
+	pub const DifficultyBreakThresholdSecs: u64 = 1800;
+}
+
+#[cfg(feature = "test-runtime")]
+parameter_types! {
+	pub const DifficultyHalflife: u64 = 60;
+	pub const DifficultyBreakThresholdSecs: u64 = 1800;
 }
 
 /// The default types are being injected by [`derive_impl`](`frame_support::derive_impl`) from
@@ -204,13 +215,6 @@ impl pallet_session::historical::Config for Runtime {
 	type FullIdentificationOf = UnitIdentification;
 }
 
-parameter_types! {
-	/// Length of a session in blocks (~10 minutes at 6s block time, but our PoW
-	/// targets ~20s, so a session lasts ~10 minutes either way for genesis tests).
-	pub const SessionPeriod: BlockNumber = 30;
-	pub const SessionOffset: BlockNumber = 0;
-}
-
 impl pallet_session::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type ValidatorId = AccountId;
@@ -230,6 +234,13 @@ parameter_types! {
 	pub const ValidatorLockId: frame_support::traits::LockIdentifier = *b"validatr";
 }
 
+#[cfg(not(feature = "test-runtime"))]
+parameter_types! {
+	pub const SessionPeriod: BlockNumber = 10 * MINUTES;
+	pub const SessionOffset: BlockNumber = 0 * MINUTES;
+}
+
+#[cfg(not(feature = "test-runtime"))]
 impl pallet_validator::Config for Runtime {
 	type Currency = Balances;
 	type SessionInterface = ValidatorSessionAdapter;
@@ -242,6 +253,25 @@ impl pallet_validator::Config for Runtime {
 	type RejoinCooldownPeriod = ConstU32<{ 1 * DAYS }>;
 }
 
+#[cfg(feature = "test-runtime")]
+parameter_types! {
+	pub const SessionPeriod: BlockNumber = 3 * MINUTES;
+	pub const SessionOffset: BlockNumber = 0 * MINUTES;
+}
+
+#[cfg(feature = "test-runtime")]
+impl pallet_validator::Config for Runtime {
+	type Currency = Balances;
+	type SessionInterface = ValidatorSessionAdapter;
+	type LockAmount = ConstU128<{ 1 * UNIT }>;
+	type LockDuration = ConstU32<{ 20 * MINUTES }>;
+	type LockId = ValidatorLockId;
+	type MaxValidators = ConstU32<4>;
+	type RenewInterval = ConstU32<{ 10 * MINUTES }>;
+	type OfflineThreshold = ConstU32<1>;
+	type RejoinCooldownPeriod = ConstU32<{ 1 * MINUTES }>;
+}
+
 /// Adapter wiring `pallet_validator::SessionInterface` to `pallet-session`.
 /// Lets validator verify session keys exist before queuing a candidate.
 pub struct ValidatorSessionAdapter;
@@ -251,7 +281,6 @@ impl pallet_validator::SessionInterface<AccountId> for ValidatorSessionAdapter {
 		pallet_session::NextKeys::<Runtime>::contains_key(who)
 	}
 }
-
 /// `ValidatorSetWithIdentification` adapter over `pallet-session`.
 ///
 /// `pallet-im-online` requires its `ValidatorSet` to also expose an

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -33,11 +33,29 @@ fn testnet_genesis(
 	root: AccountId,
 	initial_validators: Vec<(AccountId, GrandpaId, ImOnlineId)>,
 ) -> Value {
+	testnet_genesis_with_extra_keys(endowed_accounts, root, initial_validators, Vec::new())
+}
+
+fn testnet_genesis_with_extra_keys(
+	endowed_accounts: Vec<AccountId>,
+	root: AccountId,
+	initial_validators: Vec<(AccountId, GrandpaId, ImOnlineId)>,
+	extra_session_keys: Vec<(AccountId, GrandpaId, ImOnlineId)>,
+) -> Value {
 	let total_supply: u128 = 1_000_000_000 * UNIT;
 	let balance_per_account = total_supply / endowed_accounts.len() as u128;
 	let initial_difficulty = U256::from(1_000_000u64);
 	let validator_accounts: Vec<AccountId> =
 		initial_validators.iter().map(|(a, _, _)| a.clone()).collect();
+	let mut session_keys: Vec<(AccountId, AccountId, SessionKeys)> = initial_validators
+		.into_iter()
+		.map(|(account, grandpa, im_online)| {
+			(account.clone(), account, SessionKeys { grandpa, im_online })
+		})
+		.collect();
+	for (account, grandpa, im_online) in extra_session_keys.into_iter() {
+		session_keys.push((account.clone(), account, SessionKeys { grandpa, im_online }));
+	}
 	build_struct_json_patch!(RuntimeGenesisConfig {
 		balances: BalancesConfig {
 			balances: endowed_accounts
@@ -53,14 +71,7 @@ fn testnet_genesis(
 			anchor_timestamp: 0,
 			anchor_height: 0,
 		},
-		session: SessionConfig {
-			keys: initial_validators
-				.into_iter()
-				.map(|(account, grandpa, im_online)| {
-					(account.clone(), account, SessionKeys { grandpa, im_online })
-				})
-				.collect::<Vec<_>>(),
-		},
+		session: SessionConfig { keys: session_keys },
 		validator: ValidatorConfig {
 			initial_validators: validator_accounts,
 			..Default::default()
@@ -134,11 +145,62 @@ pub fn local_config_genesis() -> Value {
 	)
 }
 
+pub fn integration_config_genesis() -> Value {
+	testnet_genesis_with_extra_keys(
+		vec![
+			Sr25519Keyring::Alice.to_account_id(),
+			Sr25519Keyring::Bob.to_account_id(),
+			Sr25519Keyring::Charlie.to_account_id(),
+			Sr25519Keyring::Dave.to_account_id(),
+			Sr25519Keyring::Eve.to_account_id(),
+			Sr25519Keyring::Ferdie.to_account_id(),
+			Sr25519Keyring::AliceStash.to_account_id(),
+			Sr25519Keyring::BobStash.to_account_id(),
+		],
+		Sr25519Keyring::Alice.to_account_id(),
+		vec![
+			(
+				Sr25519Keyring::Alice.to_account_id(),
+				Ed25519Keyring::Alice.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Alice),
+			),
+			(
+				Sr25519Keyring::Bob.to_account_id(),
+				Ed25519Keyring::Bob.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Bob),
+			),
+			(
+				Sr25519Keyring::Charlie.to_account_id(),
+				Ed25519Keyring::Charlie.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Charlie),
+			),
+		],
+		// Pre-register session keys for Dave and Eve so they can be
+		// promoted to active validators at runtime via `validator.lock()`
+		// without first calling `session.set_keys()`.
+		vec![
+			(
+				Sr25519Keyring::Dave.to_account_id(),
+				Ed25519Keyring::Dave.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Dave),
+			),
+			(
+				Sr25519Keyring::Eve.to_account_id(),
+				Ed25519Keyring::Eve.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Eve),
+			),
+		],
+	)
+}
+
+pub const INTEGRATION_RUNTIME_PRESET: &str = "integration";
+
 /// Provides the JSON representation of predefined genesis config for given `id`.
 pub fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
 	let patch = match id.as_ref() {
 		sp_genesis_builder::DEV_RUNTIME_PRESET => development_config_genesis(),
 		sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET => local_config_genesis(),
+		INTEGRATION_RUNTIME_PRESET => integration_config_genesis(),
 		_ => return None,
 	};
 	Some(
@@ -153,5 +215,6 @@ pub fn preset_names() -> Vec<PresetId> {
 	vec![
 		PresetId::from(sp_genesis_builder::DEV_RUNTIME_PRESET),
 		PresetId::from(sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET),
+		PresetId::from(INTEGRATION_RUNTIME_PRESET),
 	]
 }

--- a/tests/integration/.gitignore
+++ b/tests/integration/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.pids/
+logs/
+integration-raw.json

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,112 @@
+# Multi-Node Integration & Zombienet Tests
+
+End-to-end test harness for the crypto-node multi-node network. Drives a 5-node topology with [zombienet](https://github.com/paritytech/zombienet) and exercises PoW production, GRANDPA finality, validator lifecycle (lock/exit), difficulty adjustment, and network-partition recovery.
+
+## Topology (`zombienet.toml`)
+
+| Node    | Role            | Initial validator | Mines | Notes                           |
+| ------- | --------------- | ----------------: | :---: | ------------------------------- |
+| alice   | validator+miner |               yes |  yes  | bootnode                        |
+| bob     | validator+miner |               yes |  yes  |                                 |
+| charlie | validator+miner |               yes |  yes  |                                 |
+| dave    | miner only      |      no (standby) |  yes  | locks at runtime in scenario 01 |
+| eve     | full node       |                no |  no   | observer                        |
+
+Ports are dynamically allocated by zombienet; `js-script` blocks read the WebSocket endpoint from `networkInfo.nodesByName[<name>].wsUri`.
+
+## Runtime parameters (`test-runtime` feature)
+
+The node binary used by this harness MUST be compiled with `--features test-runtime`. Otherwise session/lock/cooldown/difficulty timing cannot be observed within scenario timeouts.
+
+With `TargetBlockTime = 20s` (so `MINUTES = 3` blocks) the derived constants are:
+
+| Constant                         | test-runtime |
+| -------------------------------- | -----------: |
+| `SessionPeriod`                  |       3 mins |
+| `LockAmount`                     |       1 UNIT |
+| `LockDuration`                   |      30 mins |
+| `RenewInterval`                  |      25 mins |
+| `RejoinCooldownPeriod`           |       5 mins |
+| `OfflineThreshold`               |            1 |
+| `MaxValidators`                  |            4 |
+| `DifficultyHalflife`             |          60s |
+| `DifficultyBreakThresholdSecs`   |        1800s |
+
+## Prerequisites
+
+```bash
+# Node.js (>= 18; tested with v24) and npm
+apt install curl unzip
+curl -o- https://fnm.vercel.app/install | bash
+fnm install 24
+node -v # Should print "v24.15.0" or newer.
+npm -v # Should print "11.12.1" or newer.
+
+# zombienet binary (linux x86_64 example, tested with v1.3.138)
+sudo curl -L -o /usr/local/bin/zombienet \
+  https://github.com/paritytech/zombienet/releases/download/v1.3.138/zombienet-linux-x64
+sudo chmod +x /usr/local/bin/zombienet
+zombienet version
+```
+
+## Quick start
+
+```bash
+cd tests/integration
+
+# 1. install JS deps (used by js-script blocks)
+npm install
+
+# 2. build node with test-runtime AND pre-generate the raw chainspec.
+#    Re-run after every change to runtime/ or the integration preset.
+bash scripts/build-node.sh                # release; PROFILE=debug for debug
+
+# 3. run all scenarios (auto-creates /tmp/zn-creds.cfg if missing)
+bash scripts/run-all.sh
+# or individually (note `-p native` is implied by zombienet.toml):
+zombienet -p native test scenarios/00-basic-and-finality.zndsl
+zombienet -p native test scenarios/01-validator-lifecycle.zndsl
+zombienet -p native test scenarios/02-validator-mass-offline.zndsl
+zombienet -p native test scenarios/03-hashrate-fluctuation.zndsl
+zombienet -p native test scenarios/04-network-partition.zndsl
+zombienet -p native test scenarios/05-validator-offline-kick.zndsl
+zombienet -p native test scenarios/06-max-validators-capacity.zndsl
+zombienet -p native test scenarios/07-equivocation-placeholder.zndsl
+zombienet -p native test scenarios/99-evm-placeholder.zndsl
+
+# 4. (optional) spawn the network without a test for manual exploration
+zombienet -p native spawn zombienet.toml
+```
+
+> Each scenario file declares `Creds: /tmp/zn-creds.cfg`. The native
+> provider does not consume the file but zombienet still requires the
+> header. `scripts/run-all.sh` creates an empty placeholder automatically;
+> if you invoke `zombienet test` directly, run `touch /tmp/zn-creds.cfg`
+> first.
+
+## Scenario coverage
+
+| Scenario file             | Verifies                                                                                                                                                                                                                                                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 00-basic-and-finality     | All 5 nodes start and peer up; PoW chain advances and converges to one canonical hash on every node; GRANDPA finalized number progresses; the canonical block at alice's finalized height is identical on every node (fork-choice respects finality).                                                         |
+| 01-validator-lifecycle    | Dave (initially not a validator) submits `validator.lock()`; after one session rotation Dave appears in `session.validators()` on every node and the GRANDPA authority set grows. Dave then submits `validator.request_exit()`; he is removed from every node's validator set and finality keeps progressing. |
+| 02-validator-mass-offline | Taking 1/3 of validators offline (via real process restart) does not stall finality. Pausing 2/3 stalls finality but PoW block production continues. Resuming all validators restores finality.                                                                                                               |
+| 03-hashrate-fluctuation   | After a long warm-up that lets ASERT climb to a difficulty that throttles the combined 4-miner hashrate near the 20s target, pausing 3 of 4 miners forces alice solo, ASERT lowers `pallet_difficulty.currentDifficulty`, alice keeps producing blocks, and resuming the miners restores finality.            |
+| 04-network-partition      | Isolating bob from the rest (via real process restart) and then healing the split causes the minority side to reorg to the canonical chain, no conflicting finalized blocks exist, all nodes agree on the canonical hash, and finality continues progressing.                                                 |
+| 05-validator-offline-kick | Pausing bob causes ImOnline to detect the missing heartbeat and pallet-validator to kick him after the threshold. After he is removed from `session.validators` and his process is resumed, GRANDPA finality continues on the reduced set.                                                                    |
+| 06-max-validators-capacity| Capacity check: with `MaxValidators = 4` and 4 already-active validators, an additional `validator.lock()` from eve is rejected at the candidate-promotion stage and the active set stays at 4.                                                                                                               |
+| 07-equivocation-placeholder | Placeholder pending a proper GRANDPA equivocation-injection harness.                                                                                                                                                                                                                                       |
+| 99-evm-placeholder        | Placeholder until Frontier (pallet-evm + pallet-ethereum + Ethereum-compatible RPC) is integrated into the runtime.                                                                                                                                                                                           |
+
+## Known limitations
+
+* zombienet `<node>: pause` (SIGSTOP) freezes the process while keeping its TCP sockets open, so GRANDPA peers wait for the paused node's votes until round timeouts elapse and finality stalls (~10 min/block). Whenever a sub-scenario asserts on finality during the outage, it must use `<node>: restart after N seconds` (a real SIGTERM + re-spawn) instead. `pause` is still acceptable when the offline window only verifies non-finality properties (e.g. PoW continues, ImOnline kicks).
+* Scenario 03 needs a long warm-up (~5 minutes / 60 blocks) so the ASERT controller actually throttles the combined 4-miner hashrate near the target before miners are paused. Without this warm-up, alice solo can still meet the target on her own and ASERT keeps raising difficulty.
+* zombienet's bundled `@polkadot/util` (13.x) emits a "multiple versions installed" warning on stderr because our `tests/integration/node_modules` ships 14.x. The warning is harmless and originates inside the zombienet binary itself.
+* EVM and equivocation scenarios are placeholders pending Frontier integration and an equivocation-injection harness.
+* Long-soak runs are not automated; wrap `bash scripts/run-all.sh` in a loop or extend a scenario with longer timeouts as needed.
+* Scenarios 01, 02, 05 can be timing-sensitive: they assume PoW blocks land within ~20s and that ImOnline does not kick a validator within the test window. On slow hardware or under heavy load the difficulty / heartbeat dynamics can stretch the validator-rotation steps past the assertion deadlines. If a run flakes, retry; if it flakes consistently, raise the per-step `within ... seconds` budget in the corresponding `.zndsl` file.
+
+## Cleanup
+
+zombienet writes node data under its own tmp directory; spawned processes terminate when the test exits. If a run is interrupted, force-clean with `pkill -f solochain-template-node`.

--- a/tests/integration/js-scripts/check-difficulty-drop.js
+++ b/tests/integration/js-scripts/check-difficulty-drop.js
@@ -1,0 +1,49 @@
+// Sample `pallet_difficulty.currentDifficulty` over a configurable window.
+// Assert the minimum observed difficulty drops below the initial value AND
+// that the alice best block keeps advancing. Run AFTER one or more miners
+// have been paused so the network's effective hashrate falls.
+//   args[0] = window in seconds (default 300)
+const { connectAll, disconnectAll, bestNumber, sleep } = require("./lib");
+
+async function run(_zombie, networkInfo, args) {
+    const windowMs = (args && args[0] ? Number(args[0]) : 300) * 1000;
+    const apis = await connectAll(networkInfo, ["alice"]);
+    const aliceApi = apis[0];
+    try {
+        const startBest = await bestNumber(aliceApi);
+        const startDiff = (await aliceApi.query.difficulty.currentDifficulty()).toBigInt();
+        console.log(`  start: best=${startBest} difficulty=${startDiff}`);
+
+        const deadline = Date.now() + windowMs;
+        let minDiff = startDiff;
+        let lastBest = startBest;
+        let progressed = false;
+        while (Date.now() < deadline) {
+            await sleep(10_000);
+            const b = await bestNumber(aliceApi);
+            const d = (await aliceApi.query.difficulty.currentDifficulty()).toBigInt();
+            if (d < minDiff) minDiff = d;
+            if (b > lastBest) progressed = true;
+            lastBest = b;
+            console.log(`  obs: best=${b} difficulty=${d}`);
+            if (minDiff < startDiff && b > startBest + 2) break;
+        }
+        if (!progressed) {
+            console.error(`  block production stalled at #${lastBest}`);
+            return 0;
+        }
+        if (minDiff >= startDiff) {
+            console.error(`  difficulty did not drop (start=${startDiff} min=${minDiff})`);
+            return 0;
+        }
+        console.log(`  difficulty dropped from ${startDiff} to ${minDiff}; best advanced ${startBest} -> ${lastBest}`);
+        return 1;
+    } catch (e) {
+        console.error(`  ${e.message}`);
+        return 0;
+    } finally {
+        await disconnectAll(apis);
+    }
+}
+
+module.exports = { run };

--- a/tests/integration/js-scripts/check-finality-progress.js
+++ b/tests/integration/js-scripts/check-finality-progress.js
@@ -1,0 +1,46 @@
+// Assert that finality has advanced by at least N blocks within an internal
+// time window, AND that all nodes agree on the finalized block hash at the
+// minimum common finalized height.
+//   args[0] = N (default 4)
+//   args[1] = window in seconds (default 300)
+const { tryConnectAll, disconnectAll, finalizedNumber, waitForFinalizedAdvance } = require("./lib");
+
+const NODES = ["alice", "bob", "charlie", "dave", "eve"];
+
+async function run(_zombie, networkInfo, args) {
+    const advance = args && args[0] ? Number(args[0]) : 4;
+    const windowMs = (args && args[1] ? Number(args[1]) : 300) * 1000;
+    // Use tolerant connect so paused nodes (mass-offline scenario) don't hang.
+    const pairs = await tryConnectAll(networkInfo, NODES, 5_000);
+    const live = pairs.filter(([_, api]) => api !== null);
+    const apis = live.map(([_, api]) => api);
+    if (apis.length === 0) {
+        console.error("  no reachable nodes");
+        return 0;
+    }
+    try {
+        await waitForFinalizedAdvance(apis[0], advance, windowMs);
+        const fins = await Promise.all(apis.map(finalizedNumber));
+        for (let i = 0; i < live.length; i++) console.log(`  ${live[i][0]} finalized=${fins[i]}`);
+        const common = Math.min(...fins);
+        const hashes = await Promise.all(
+            apis.map(async (api) => (await api.rpc.chain.getBlockHash(common)).toHex())
+        );
+        const ref = hashes[0];
+        for (let i = 0; i < live.length; i++) {
+            if (hashes[i] !== ref) {
+                console.error(`  finalized hash mismatch at #${common}: ${live[0][0]}=${ref} ${live[i][0]}=${hashes[i]}`);
+                return 0;
+            }
+        }
+        console.log(`  all ${live.length} reachable nodes finalized same hash at #${common}`);
+        return 1;
+    } catch (e) {
+        console.error(`  ${e.message}`);
+        return 0;
+    } finally {
+        await disconnectAll(apis);
+    }
+}
+
+module.exports = { run };

--- a/tests/integration/js-scripts/check-fork-finality.js
+++ b/tests/integration/js-scripts/check-fork-finality.js
@@ -1,0 +1,38 @@
+// Assert "fork choice respects finality" invariant on the live network:
+// for every node, the canonical block at alice.finalized must equal
+// alice.finalizedHash. A divergence implies a node has accepted a chain
+// branch that conflicts with finality.
+const { connectAll, disconnectAll, finalizedNumber, bestNumber } = require("./lib");
+
+const NODES = ["alice", "bob", "charlie", "dave", "eve"];
+
+async function run(_zombie, networkInfo) {
+    const apis = await connectAll(networkInfo, NODES);
+    try {
+        const finNum = await finalizedNumber(apis[0]);
+        const finHash = (await apis[0].rpc.chain.getBlockHash(finNum)).toHex();
+        console.log(`  alice finalized #${finNum} = ${finHash}`);
+
+        let ok = true;
+        for (let i = 0; i < NODES.length; i++) {
+            const best = await bestNumber(apis[i]);
+            if (best < finNum) {
+                console.error(`  ${NODES[i]} best=${best} below finalized ${finNum}`);
+                ok = false;
+                continue;
+            }
+            const h = (await apis[i].rpc.chain.getBlockHash(finNum)).toHex();
+            if (h !== finHash) {
+                console.error(`  ${NODES[i]} canonical hash at #${finNum} != alice's finalized`);
+                ok = false;
+            } else {
+                console.log(`  ${NODES[i]} best=${best} contains finalized ${finNum}`);
+            }
+        }
+        return ok ? 1 : 0;
+    } finally {
+        await disconnectAll(apis);
+    }
+}
+
+module.exports = { run };

--- a/tests/integration/js-scripts/check-network-agreement.js
+++ b/tests/integration/js-scripts/check-network-agreement.js
@@ -1,0 +1,33 @@
+// Assert that all 5 nodes agree on the canonical block hash at the given
+// height. The height is supplied via args[0]; if omitted, picks the lowest
+// best number across the network. Returns 1 on agreement, 0 on mismatch.
+const { connectAll, disconnectAll, bestNumber } = require("./lib");
+
+const NODES = ["alice", "bob", "charlie", "dave", "eve"];
+
+async function run(_zombie, networkInfo, args) {
+    const apis = await connectAll(networkInfo, NODES);
+    try {
+        const heights = await Promise.all(apis.map(bestNumber));
+        const target = args && args[0] ? Number(args[0]) : Math.min(...heights);
+        if (Number.isNaN(target) || target < 0) {
+            console.error(`bad target height arg: ${args && args[0]}`);
+            return 0;
+        }
+        const hashes = await Promise.all(
+            apis.map(async (api) => (await api.rpc.chain.getBlockHash(target)).toHex())
+        );
+        const ref = hashes[0];
+        let ok = true;
+        for (let i = 0; i < NODES.length; i++) {
+            const tag = hashes[i] === ref ? "ok" : "MISMATCH";
+            console.log(`  ${NODES[i].padEnd(8)} #${target} = ${hashes[i]}  [${tag}]`);
+            if (hashes[i] !== ref) ok = false;
+        }
+        return ok ? 1 : 0;
+    } finally {
+        await disconnectAll(apis);
+    }
+}
+
+module.exports = { run };

--- a/tests/integration/js-scripts/lib.js
+++ b/tests/integration/js-scripts/lib.js
@@ -1,0 +1,128 @@
+// Shared CommonJS helpers for zombienet js-script blocks.
+//
+// Every js-script in this directory receives `(zombie, networkInfo, args)`
+// from zombienet, where `networkInfo.nodesByName[<name>].wsUri` is the
+// dynamically allocated WebSocket endpoint. These helpers wrap that pattern
+// and expose a small set of common operations against any node.
+
+const { ApiPromise, WsProvider } = require("@polkadot/api");
+const { Keyring } = require("@polkadot/keyring");
+const { cryptoWaitReady } = require("@polkadot/util-crypto");
+
+async function connect(networkInfo, nodeName) {
+    const info = networkInfo.nodesByName[nodeName];
+    if (!info) throw new Error(`unknown node: ${nodeName}`);
+    const provider = new WsProvider(info.wsUri);
+    const api = await ApiPromise.create({ provider, throwOnConnect: true, noInitWarn: true });
+    return api;
+}
+
+// Connect with a hard timeout; returns null if the node is unreachable
+// (e.g. paused via SIGSTOP in the validator-mass-offline scenario).
+async function tryConnect(networkInfo, nodeName, timeoutMs = 5000) {
+    return await Promise.race([
+        connect(networkInfo, nodeName).catch(() => null),
+        new Promise((r) => setTimeout(() => r(null), timeoutMs)),
+    ]);
+}
+
+async function connectAll(networkInfo, names) {
+    return Promise.all(names.map((n) => connect(networkInfo, n)));
+}
+
+// Like `connectAll`, but tolerant of nodes that are paused / unreachable.
+// Returns a `[name, api|null]` map preserving the original order.
+async function tryConnectAll(networkInfo, names, timeoutMs = 5000) {
+    return Promise.all(
+        names.map(async (n) => [n, await tryConnect(networkInfo, n, timeoutMs)])
+    );
+}
+
+async function disconnectAll(apis) {
+    for (const api of apis) {
+        try { await api.disconnect(); } catch (_) {}
+    }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function bestNumber(api) {
+    const h = await api.rpc.chain.getHeader();
+    return h.number.toNumber();
+}
+
+async function finalizedNumber(api) {
+    const hash = await api.rpc.chain.getFinalizedHead();
+    const h = await api.rpc.chain.getHeader(hash);
+    return h.number.toNumber();
+}
+
+async function sessionIndex(api) {
+    return (await api.query.session.currentIndex()).toNumber();
+}
+
+async function sessionValidators(api) {
+    const set = await api.query.session.validators();
+    return set.map((id) => id.toString());
+}
+
+async function waitForFinalizedAdvance(api, by, maxMs) {
+    const start = await finalizedNumber(api);
+    const deadline = Date.now() + maxMs;
+    while (Date.now() < deadline) {
+        const cur = await finalizedNumber(api);
+        if (cur >= start + by) return cur;
+        await sleep(2000);
+    }
+    throw new Error(`finalized only advanced ${(await finalizedNumber(api)) - start}/${by} in ${maxMs}ms`);
+}
+
+async function waitForSessionRotations(api, n, maxMs) {
+    const start = await sessionIndex(api);
+    const deadline = Date.now() + maxMs;
+    while (Date.now() < deadline) {
+        const cur = await sessionIndex(api);
+        if (cur >= start + n) return cur;
+        await sleep(3000);
+    }
+    throw new Error(`session only rotated ${(await sessionIndex(api)) - start}/${n} in ${maxMs}ms`);
+}
+
+let _keyring;
+async function keyring() {
+    if (_keyring) return _keyring;
+    await cryptoWaitReady();
+    _keyring = new Keyring({ type: "sr25519", ss58Format: 42 });
+    return _keyring;
+}
+
+async function pair(uri) {
+    const k = await keyring();
+    return k.addFromUri(uri);
+}
+
+function sendAndWait(api, signer, extrinsic) {
+    return new Promise((resolve, reject) => {
+        extrinsic
+            .signAndSend(signer, ({ status, dispatchError, events }) => {
+                if (dispatchError) {
+                    let msg = dispatchError.toString();
+                    if (dispatchError.isModule) {
+                        const decoded = api.registry.findMetaError(dispatchError.asModule);
+                        msg = `${decoded.section}.${decoded.name}: ${decoded.docs.join(" ")}`;
+                    }
+                    return reject(new Error(`extrinsic failed: ${msg}`));
+                }
+                if (status.isInBlock || status.isFinalized) resolve({ status, events });
+            })
+            .catch(reject);
+    });
+}
+
+module.exports = {
+    connect, connectAll, tryConnect, tryConnectAll, disconnectAll,
+    sleep,
+    bestNumber, finalizedNumber, sessionIndex, sessionValidators,
+    waitForFinalizedAdvance, waitForSessionRotations,
+    keyring, pair, sendAndWait,
+};

--- a/tests/integration/js-scripts/lock-and-join-dave.js
+++ b/tests/integration/js-scripts/lock-and-join-dave.js
@@ -1,0 +1,56 @@
+// Submit `validator.lock()` from Dave on the dave node. Then wait until
+// Dave appears in `session.validators()` on every node and in
+// `grandpa.authorities()` on alice. Returns 1 on success.
+//
+// Dave's session keys are pre-registered at genesis by the `integration`
+// preset (see `runtime/src/genesis_config_presets.rs`), so no
+// `session.set_keys()` call is required here.
+const {
+    connectAll, disconnectAll, pair, sendAndWait, sessionValidators, sleep,
+} = require("./lib");
+
+const NODES = ["alice", "bob", "charlie", "dave", "eve"];
+
+async function run(_zombie, networkInfo) {
+    const apis = await connectAll(networkInfo, NODES);
+    const daveApi = apis[3];
+    try {
+        const dave = await pair("//Dave");
+        const startSet = await sessionValidators(daveApi);
+        if (startSet.includes(dave.address)) {
+            console.log(`  Dave (${dave.address}) already a validator; nothing to do`);
+            return 1;
+        }
+        const baselineGrandpa = (await daveApi.query.grandpa.authorities()).length;
+        console.log(`  pre: validators=${startSet.length} grandpa=${baselineGrandpa}`);
+
+        await sendAndWait(daveApi, dave, daveApi.tx.validator.lock());
+        console.log(`  validator.lock() included`);
+
+        const deadline = Date.now() + 600_000;
+        let joined = false;
+        while (Date.now() < deadline) {
+            const ok = await Promise.all(apis.map(async (a) => (await sessionValidators(a)).includes(dave.address)));
+            if (ok.every(Boolean)) { joined = true; break; }
+            await sleep(3000);
+        }
+        if (!joined) {
+            console.error(`  Dave never appeared in session.validators on every node`);
+            return 0;
+        }
+        const finalGrandpa = (await daveApi.query.grandpa.authorities()).length;
+        console.log(`  post: validators=${(await sessionValidators(daveApi)).length} grandpa=${finalGrandpa}`);
+        if (finalGrandpa <= baselineGrandpa) {
+            console.error(`  grandpa authorities did not grow (${baselineGrandpa} -> ${finalGrandpa})`);
+            return 0;
+        }
+        return 1;
+    } catch (e) {
+        console.error(`  ${e.message}`);
+        return 0;
+    } finally {
+        await disconnectAll(apis);
+    }
+}
+
+module.exports = { run };

--- a/tests/integration/js-scripts/lock-eve-expect-too-many.js
+++ b/tests/integration/js-scripts/lock-eve-expect-too-many.js
@@ -1,0 +1,68 @@
+// Verify capacity-rejection on `validator.lock()`.
+//
+// Pre-conditions (set up by the .zndsl that drives this script):
+//   * alice/bob/charlie active at genesis (3 / MaxValidators=4)
+//   * dave already joined as 4th -> the active+pending set is now full
+//
+// This script attempts `validator.lock()` from Eve and expects it to fail
+// with `validator.TooManyValidators`. Note that we do NOT need to call
+// `session.set_keys` for Eve first because the capacity check fires
+// BEFORE the SessionKeysNotRegistered check (see pallet `lock` body).
+//
+// Returns 1 on the expected failure, 0 on unexpected success or wrong
+// error variant.
+
+const { connect, disconnectAll, pair } = require("./lib");
+
+async function run(_zombie, networkInfo) {
+    const eveApi = await connect(networkInfo, "eve");
+    try {
+        const eve = await pair("//Eve");
+        const validators = await eveApi.query.session.validators();
+        const lockedBefore = await eveApi.query.validator.validatorLocks(eve.address);
+        console.log(`  active=${validators.length} eve_locked=${!lockedBefore.isNone}`);
+
+        // signAndSend manually so we can introspect the dispatch error.
+        const result = await new Promise((resolve, reject) => {
+            eveApi.tx.validator
+                .lock()
+                .signAndSend(eve, ({ status, dispatchError }) => {
+                    if (dispatchError) {
+                        if (dispatchError.isModule) {
+                            const decoded = eveApi.registry.findMetaError(dispatchError.asModule);
+                            return resolve({
+                                ok: false,
+                                section: decoded.section,
+                                name: decoded.name,
+                            });
+                        }
+                        return resolve({ ok: false, raw: dispatchError.toString() });
+                    }
+                    if (status.isInBlock || status.isFinalized) {
+                        return resolve({ ok: true });
+                    }
+                })
+                .catch(reject);
+        });
+
+        if (result.ok) {
+            const validatorsNow = await eveApi.query.session.validators();
+            console.error(`  expected TooManyValidators, but extrinsic succeeded`);
+            console.error(`  current validators (${validatorsNow.length}): ${validatorsNow.map(v => v.toString()).join(", ")}`);
+            return 0;
+        }
+        if (result.section !== "validator" || result.name !== "TooManyValidators") {
+            console.error(`  expected validator.TooManyValidators, got ${result.section}.${result.name || result.raw}`);
+            return 0;
+        }
+        console.log(`  got expected error: validator.TooManyValidators`);
+        return 1;
+    } catch (e) {
+        console.error(`  ${e.message}`);
+        return 0;
+    } finally {
+        await disconnectAll([eveApi]);
+    }
+}
+
+module.exports = { run };

--- a/tests/integration/js-scripts/request-exit-dave.js
+++ b/tests/integration/js-scripts/request-exit-dave.js
@@ -1,0 +1,52 @@
+// Submit `validator.request_exit()` from Dave. Wait for Dave to disappear
+// from the active set on every node and assert finality keeps progressing.
+const {
+    connectAll, disconnectAll, pair, sendAndWait, sessionValidators,
+    finalizedNumber, sleep,
+} = require("./lib");
+
+const NODES = ["alice", "bob", "charlie", "dave", "eve"];
+
+async function run(_zombie, networkInfo) {
+    const apis = await connectAll(networkInfo, NODES);
+    const aliceApi = apis[0];
+    const daveApi = apis[3];
+    try {
+        const dave = await pair("//Dave");
+        const set = await sessionValidators(daveApi);
+        if (!set.includes(dave.address)) {
+            console.error(`  Dave not currently a validator; run lock-and-join first`);
+            return 0;
+        }
+        const startFin = await finalizedNumber(aliceApi);
+
+        await sendAndWait(daveApi, dave, daveApi.tx.validator.requestExit());
+        console.log(`  validator.request_exit() included`);
+
+        const deadline = Date.now() + 600_000;
+        let removed = false;
+        while (Date.now() < deadline) {
+            const out = await Promise.all(apis.map(async (a) => !(await sessionValidators(a)).includes(dave.address)));
+            if (out.every(Boolean)) { removed = true; break; }
+            await sleep(3000);
+        }
+        if (!removed) {
+            console.error(`  Dave still in some node's session.validators after timeout`);
+            return 0;
+        }
+        const endFin = await finalizedNumber(aliceApi);
+        if (endFin <= startFin) {
+            console.error(`  finality stalled across exit: ${startFin} -> ${endFin}`);
+            return 0;
+        }
+        console.log(`  removed; finality continued ${startFin} -> ${endFin}`);
+        return 1;
+    } catch (e) {
+        console.error(`  ${e.message}`);
+        return 0;
+    } finally {
+        await disconnectAll(apis);
+    }
+}
+
+module.exports = { run };

--- a/tests/integration/js-scripts/wait-for-offline-kick.js
+++ b/tests/integration/js-scripts/wait-for-offline-kick.js
@@ -1,0 +1,84 @@
+// Wait until a given validator is kicked due to ImOnline-driven offline
+// detection. Returns 1 on success, 0 on timeout/mismatch.
+//
+// Usage: js-script wait-for-offline-kick.js with "<account-uri>"
+//   <account-uri> defaults to "//Bob".
+//
+// Pipeline being verified (test-runtime config):
+//   * SessionPeriod ~ 1 min, OfflineThreshold = 1
+//   * pause(target) -> target stops sending im_online heartbeats
+//   * end of session N: ImOnline emits SomeOffline, our adapter calls
+//     note_offline -> OfflineThisSession[target] = ()
+//   * end of session N+1: process_offline_counters sees was_offline,
+//     count = 1 >= threshold -> kick + RejoinCooldown
+//   * end of session N+2: removed from session.validators
+
+const {
+    connect, disconnectAll, pair,
+    sessionValidators, sessionIndex, sleep,
+} = require("./lib");
+
+const POLL_MS = 4000;
+const DEFAULT_TARGET = "//Bob";
+
+async function run(_zombie, networkInfo, args) {
+    const targetUri = (args && args[0]) || DEFAULT_TARGET;
+    const observer = await connect(networkInfo, "alice");
+    try {
+        const target = await pair(targetUri);
+        const startSet = await sessionValidators(observer);
+        if (!startSet.includes(target.address)) {
+            console.error(`  target ${targetUri} (${target.address}) is not currently a validator`);
+            return 0;
+        }
+        const startSession = await sessionIndex(observer);
+        console.log(`  baseline: session=${startSession} validators=${startSet.length} target=${target.address}`);
+
+        // The full pipeline takes ~3 sessions of slack, so we wait up to
+        // 8 to absorb PoW jitter. Outer zndsl timeout caps this anyway.
+        const deadline = Date.now() + 8 * 60 * 1000;
+        let kicked = false;
+        let kickedSession = null;
+        while (Date.now() < deadline) {
+            const cur = await sessionValidators(observer);
+            if (!cur.includes(target.address)) {
+                kicked = true;
+                kickedSession = await sessionIndex(observer);
+                break;
+            }
+            await sleep(POLL_MS);
+        }
+        if (!kicked) {
+            console.error(`  ${target.address} still in session.validators after timeout`);
+            return 0;
+        }
+        console.log(`  ${target.address} removed from session.validators at session=${kickedSession} (Δ=${kickedSession - startSession})`);
+
+        // Confirm the on-chain kick reason matches: status should be Kicked
+        // and there should be a RejoinCooldown deadline set.
+        const lock = await observer.query.validator.validatorLocks(target.address);
+        if (lock.isNone) {
+            console.error(`  validatorLocks entry missing for ${target.address}`);
+            return 0;
+        }
+        const status = lock.unwrap().status.toString();
+        if (status !== "Kicked") {
+            console.error(`  expected status=Kicked, got status=${status}`);
+            return 0;
+        }
+        const cooldown = await observer.query.validator.rejoinCooldown(target.address);
+        if (cooldown.isNone) {
+            console.error(`  RejoinCooldown not set for ${target.address}`);
+            return 0;
+        }
+        console.log(`  status=Kicked, RejoinCooldown until block ${cooldown.unwrap().toNumber()}`);
+        return 1;
+    } catch (e) {
+        console.error(`  ${e.message}`);
+        return 0;
+    } finally {
+        await disconnectAll([observer]);
+    }
+}
+
+module.exports = { run };

--- a/tests/integration/package-lock.json
+++ b/tests/integration/package-lock.json
@@ -1,0 +1,942 @@
+{
+  "name": "crypto-node-integration",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "crypto-node-integration",
+      "version": "0.1.0",
+      "dependencies": {
+        "@polkadot/api": "^16.5.6",
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot-api/json-rpc-provider": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider/-/json-rpc-provider-0.0.1.tgz",
+      "integrity": "sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/json-rpc-provider-proxy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.1.0.tgz",
+      "integrity": "sha512-8GSFE5+EF73MCuLQm8tjrbCqlgclcHBSRaswvXziJ0ZW7iw3UEMsKkkKvELayWyBuOPa2T5i1nj6gFOeIsqvrg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/metadata-builders": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.3.2.tgz",
+      "integrity": "sha512-TKpfoT6vTb+513KDzMBTfCb/ORdgRnsS3TDFpOhAhZ08ikvK+hjHMt5plPiAX/OWkm1Wc9I3+K6W0hX5Ab7MVg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
+      }
+    },
+    "node_modules/@polkadot-api/observable-client": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.3.2.tgz",
+      "integrity": "sha512-HGgqWgEutVyOBXoGOPp4+IAq6CNdK/3MfQJmhCJb8YaJiaK4W6aRGrdQuQSTPHfERHCARt9BrOmEvTXAT257Ug==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/metadata-builders": "0.3.2",
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
+      },
+      "peerDependencies": {
+        "@polkadot-api/substrate-client": "0.1.4",
+        "rxjs": ">=7.8.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-bindings": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.6.0.tgz",
+      "integrity": "sha512-lGuhE74NA1/PqdN7fKFdE5C1gNYX357j1tWzdlPXI0kQ7h3kN0zfxNOpPUN7dIrPcOFZ6C0tRRVrBylXkI6xPw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@noble/hashes": "^1.3.1",
+        "@polkadot-api/utils": "0.1.0",
+        "@scure/base": "^1.1.1",
+        "scale-ts": "^1.6.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-client": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.1.4.tgz",
+      "integrity": "sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "0.0.1",
+        "@polkadot-api/utils": "0.1.0"
+      }
+    },
+    "node_modules/@polkadot-api/utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.1.0.tgz",
+      "integrity": "sha512-MXzWZeuGxKizPx2Xf/47wx9sr/uxKw39bVJUptTJdsaQn/TGq+z310mHzf1RCGvC1diHM8f593KrnDgc9oNbJA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot/api": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-16.5.6.tgz",
+      "integrity": "sha512-5h/X3pY8WpqGk4XTaiIUjKD6Pnk8k4bJ6EIwPKLP8/kfFWKSOenpN6ggZxANr+Qj+RgXrp4TxJVcuhXSiBh9Sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api-augment": "16.5.6",
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/api-derive": "16.5.6",
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/rpc-provider": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/types-known": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "eventemitter3": "^5.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-16.5.6.tgz",
+      "integrity": "sha512-bunJF1c3nIuDtU6iwa+reTt9U47Y8iOC8Gw7PfANlZmLJmO/XVXnWc3JJLM+g9ESDn2raHJELeWBFVOXQrbtUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-base": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-16.5.6.tgz",
+      "integrity": "sha512-eBLIv86ZZY4t5OrobVoGC+QXbErOGlBpI2rJI5OMvTNPoVvtEoI++u+wwRScjkOZaUhXyQikd+0Uv71qr3xnsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-derive": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-16.5.6.tgz",
+      "integrity": "sha512-cHdvPvhYFch18uPTcuOZJ8VceOfercod2fi4xCnHJAmattzlgj9qCgnOoxdmBS9GZ403ZyRHOjBuUwZy/IsUWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api": "16.5.6",
+        "@polkadot/api-augment": "16.5.6",
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/keyring": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
+      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/networks": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.3.tgz",
+      "integrity": "sha512-/VqTLUDn+Wm8S2L/yaGFddo3oW4vRYav0Rg4pLg/semMZLaN8PJ6h927ucn9JyWdH82QfZfyiIPORt0ZF3isyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "14.0.3",
+        "@substrate/ss58-registry": "^1.51.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-16.5.6.tgz",
+      "integrity": "sha512-vlrNvl2VtU09jZV/AvH7jBb/cNUO+dWu8Xj9pId5ctSUnZHm8o8wRk9ekyieKP57OUoKMd8+VScwMKd624SxTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-core": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-16.5.6.tgz",
+      "integrity": "sha512-l6od++WlvKH4mw5mtsIh2AhiBs3H+TtdOoUHVLCx/R9il7+gl+arltzZ8vBuffyh/O+uQ36lI8yUoD1g4gi1tA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/rpc-provider": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-provider": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-16.5.6.tgz",
+      "integrity": "sha512-46sHIjKYr4aSzBCfbyqtCwuP8MMJ3jOp0xx9eggOGbKyP8Z0j0Cp+1nNkZUYzehcdGjjrmCxCbQp17wc6cj4zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-support": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "@polkadot/x-fetch": "^14.0.3",
+        "@polkadot/x-global": "^14.0.3",
+        "@polkadot/x-ws": "^14.0.3",
+        "eventemitter3": "^5.0.1",
+        "mock-socket": "^9.3.1",
+        "nock": "^13.5.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@substrate/connect": "0.8.11"
+      }
+    },
+    "node_modules/@polkadot/types": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-16.5.6.tgz",
+      "integrity": "sha512-X/sfMHJS4RkRhnsc4CQqzUy7BM/s2y71TrBFHPYAjs2q/rbZ/BwvBk70SrUiSa0+iRRn3RewbBZm+AB8CbkdKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-16.5.6.tgz",
+      "integrity": "sha512-QN5UrluUZCVgknUDW0gps/FRQ13Qgm24w53pCd2HgD0nmTtXDt9D4psjWwx5JkGTkUAvpzFWwN41bkxAeCiV6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-codec": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.5.6.tgz",
+      "integrity": "sha512-3tzUv1LZOL97IlQmko4dqbfRC0cg9IQ2QAHRVoDIWsXrVovp1V3kPdP0o6e3I8T2XB9IlbabK91v+ZiIxhGMZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/x-bigint": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-create": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-16.5.6.tgz",
+      "integrity": "sha512-g7g3hrjpz4KgqQqei9PU0JY9fsFHBmThWALZk5pWB32vyDyDcXZiyhH3agDhqfmzQiolTW2FuvcNJxgS634J1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-known": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-16.5.6.tgz",
+      "integrity": "sha512-c78NcVO3LIvi4xzxB39WewE+80I4jOYUtPBaB4AzSMespEwIr92VTeX3KzFWuutxDXLSPqeVfXhaAhBB0NssiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/networks": "^14.0.3",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-support": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-16.5.6.tgz",
+      "integrity": "sha512-Hqpa/hCvXZXUTUiJMAE55UXpzAeCVLaFlzzXQXLkne0vhmv3/JkWcBnX755a/b9+C4b3MKEz2i0tSKLsa3DldA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util-crypto": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
+      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "14.0.3",
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-randomvalues": "14.0.3",
+        "@scure/base": "^1.1.7",
+        "@scure/sr25519": "^0.2.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/wasm-bridge": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.5.4.tgz",
+      "integrity": "sha512-6xaJVvoZbnbgpQYXNw9OHVNWjXmtcoPcWh7hlwx3NpfiLkkjljj99YS+XGZQlq7ks2fVCg7FbfknkNb8PldDaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.5.4.tgz",
+      "integrity": "sha512-1seyClxa7Jd7kQjfnCzTTTfYhTa/KUTDUaD3DMHBk5Q4ZUN1D1unJgX+v1aUeXSPxmzocdZETPJJRZjhVOqg9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.5.4",
+        "@polkadot/wasm-crypto-asmjs": "7.5.4",
+        "@polkadot/wasm-crypto-init": "7.5.4",
+        "@polkadot/wasm-crypto-wasm": "7.5.4",
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-asmjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.5.4.tgz",
+      "integrity": "sha512-ZYwxQHAJ8pPt6kYk9XFmyuFuSS+yirJLonvP+DYbxOrARRUHfN4nzp4zcZNXUuaFhpbDobDSFn6gYzye6BUotA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-init": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.5.4.tgz",
+      "integrity": "sha512-U6s4Eo2rHs2n1iR01vTz/sOQ7eOnRPjaCsGWhPV+ZC/20hkVzwPAhiizu/IqMEol4tO2yiSheD4D6bn0KxUJhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.5.4",
+        "@polkadot/wasm-crypto-asmjs": "7.5.4",
+        "@polkadot/wasm-crypto-wasm": "7.5.4",
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-wasm": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.5.4.tgz",
+      "integrity": "sha512-PsHgLsVTu43eprwSvUGnxybtOEuHPES6AbApcs7y5ZbM2PiDMzYbAjNul098xJK/CPtrxZ0ePDFnaQBmIJyTFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-util": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.5.4.tgz",
+      "integrity": "sha512-hqPpfhCpRAqCIn/CYbBluhh0TXmwkJnDRjxrU9Bnqtw9nMNa97D8JuOjdd2pi0rxm+eeLQ/f1rQMp71RMM9t4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-bigint": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.3.tgz",
+      "integrity": "sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-fetch": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-14.0.3.tgz",
+      "integrity": "sha512-695c5aPBPtYcnn2zM+u0mXgyNHINlO0qGlGcJq3/0t5NVRZv5KZhk7NNm6antOay9uUjGG40F/r+LPzDT3QamA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "node-fetch": "^3.3.2",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-global": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
+      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-randomvalues": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
+      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-ws": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-14.0.3.tgz",
+      "integrity": "sha512-tOPdkMye3iuXnuFtdNg5+iSu7Cz9LRL8z5psMuZpUpThMYChGsS2pDFtNvXOKU8ohhO+frY9VdJ9VBg1WL9Iug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/sr25519": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/sr25519/-/sr25519-0.2.0.tgz",
+      "integrity": "sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.2",
+        "@noble/hashes": "~1.8.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@substrate/connect": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.11.tgz",
+      "integrity": "sha512-ofLs1PAO9AtDdPbdyTYj217Pe+lBfTLltdHDs3ds8no0BseoLeAGxpz1mHfi7zB4IxI3YyAiLjH6U8cw4pj4Nw==",
+      "deprecated": "versions below 1.x are no longer maintained",
+      "license": "GPL-3.0-only",
+      "optional": true,
+      "dependencies": {
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.5",
+        "@substrate/light-client-extension-helpers": "^1.0.0",
+        "smoldot": "2.0.26"
+      }
+    },
+    "node_modules/@substrate/connect-extension-protocol": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.2.2.tgz",
+      "integrity": "sha512-t66jwrXA0s5Goq82ZtjagLNd7DPGCNjHeehRlE/gcJmJ+G56C0W+2plqOMRicJ8XGR1/YFnUSEqUFiSNbjGrAA==",
+      "license": "GPL-3.0-only",
+      "optional": true
+    },
+    "node_modules/@substrate/connect-known-chains": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.10.3.tgz",
+      "integrity": "sha512-OJEZO1Pagtb6bNE3wCikc2wrmvEU5x7GxFFLqqbz1AJYYxSlrPCGu4N2og5YTExo4IcloNMQYFRkBGue0BKZ4w==",
+      "license": "GPL-3.0-only",
+      "optional": true
+    },
+    "node_modules/@substrate/light-client-extension-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-1.0.0.tgz",
+      "integrity": "sha512-TdKlni1mBBZptOaeVrKnusMg/UBpWUORNDv5fdCaJklP4RJiFOzBCrzC+CyVI5kQzsXBisZ+2pXm+rIjS38kHg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "^0.0.1",
+        "@polkadot-api/json-rpc-provider-proxy": "^0.1.0",
+        "@polkadot-api/observable-client": "^0.3.0",
+        "@polkadot-api/substrate-client": "^0.1.2",
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.5",
+        "rxjs": "^7.8.1"
+      },
+      "peerDependencies": {
+        "smoldot": "2.x"
+      }
+    },
+    "node_modules/@substrate/ss58-registry": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.51.0.tgz",
+      "integrity": "sha512-TWDurLiPxndFgKjVavCniytBIw+t4ViOi7TYp9h/D0NMmkEc9klFTo+827eyEJ0lELpqO207Ey7uGxUa+BS1jQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@types/bn.js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
+    "node_modules/mock-socket": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nock": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/scale-ts": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/scale-ts/-/scale-ts-1.6.1.tgz",
+      "integrity": "sha512-PBMc2AWc6wSEqJYBDPcyCLUj9/tMKnLX70jLOSndMtcUoLQucP/DM0vnQo1wJAYjTrQiq8iG9rD0q6wFzgjH7g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/smoldot": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.26.tgz",
+      "integrity": "sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==",
+      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
+      "optional": true,
+      "dependencies": {
+        "ws": "^8.8.1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "crypto-node-integration",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Multi-node integration & zombienet harness for crypto-node.",
+  "scripts": {
+    "build:node": "bash scripts/build-node.sh",
+    "test:all": "bash scripts/run-all.sh",
+    "spawn": "zombienet spawn zombienet.toml"
+  },
+  "dependencies": {
+    "@polkadot/api": "^16.5.6",
+    "@polkadot/keyring": "^14.0.3",
+    "@polkadot/util": "^14.0.3",
+    "@polkadot/util-crypto": "^14.0.3"
+  }
+}

--- a/tests/integration/scenarios/00-basic-and-finality.zndsl
+++ b/tests/integration/scenarios/00-basic-and-finality.zndsl
@@ -1,0 +1,31 @@
+Description: Basic startup, PoW production, GRANDPA finality, and fork-choice respects finality
+Network: ../zombienet.toml
+Creds: /tmp/zn-creds.cfg
+
+# === PoW production & propagation ===
+
+alice: is up within 60 seconds
+bob: is up within 60 seconds
+charlie: is up within 60 seconds
+dave: is up within 60 seconds
+eve: is up within 60 seconds
+
+alice: reports peers count is at least 4 within 180 seconds
+
+# Wait for at least 6 PoW blocks then verify every node agrees on the
+# canonical hash at the lowest common height.
+alice: reports block height is at least 6 within 240 seconds
+bob: reports block height is at least 4 within 300 seconds
+charlie: reports block height is at least 4 within 300 seconds
+dave: reports block height is at least 4 within 300 seconds
+eve: reports block height is at least 4 within 300 seconds
+
+alice: js-script ../js-scripts/check-network-agreement.js return is 1 within 60 seconds
+
+# === GRANDPA voting & finalization ===
+
+alice: js-script ../js-scripts/check-finality-progress.js with "4" return is 1 within 360 seconds
+
+# === Fork-choice respects finality invariant ===
+
+alice: js-script ../js-scripts/check-fork-finality.js return is 1 within 60 seconds

--- a/tests/integration/scenarios/01-validator-lifecycle.zndsl
+++ b/tests/integration/scenarios/01-validator-lifecycle.zndsl
@@ -1,0 +1,24 @@
+Description: Validator add/remove via session boundary
+Network: ../zombienet.toml
+Creds: /tmp/zn-creds.cfg
+
+alice: is up within 60 seconds
+bob: is up within 60 seconds
+charlie: is up within 60 seconds
+dave: is up within 60 seconds
+
+# Wait until at least one full session has rotated so we observe a clean
+# transition rather than the genesis seam.
+alice: reports block height is at least 8 within 300 seconds
+
+# Lock Dave -> joins active set at next session -> appears in GRANDPA
+# authorities. Internal timeout is 600s.
+alice: js-script ../js-scripts/lock-and-join-dave.js return is 1 within 700 seconds
+
+# Confirm finality kept progressing across the authority change.
+alice: js-script ../js-scripts/check-finality-progress.js with "2" return is 1 within 180 seconds
+
+# Dave requests exit -> removed at next session -> finality keeps progressing.
+alice: js-script ../js-scripts/request-exit-dave.js return is 1 within 700 seconds
+
+alice: js-script ../js-scripts/check-finality-progress.js with "2" return is 1 within 180 seconds

--- a/tests/integration/scenarios/02-validator-mass-offline.zndsl
+++ b/tests/integration/scenarios/02-validator-mass-offline.zndsl
@@ -1,0 +1,40 @@
+Description: Validator mass offline + GRANDPA continuity
+Network: ../zombienet.toml
+Creds: /tmp/zn-creds.cfg
+
+alice: is up within 60 seconds
+bob: is up within 60 seconds
+charlie: is up within 60 seconds
+
+# Establish baseline finality.
+alice: js-script ../js-scripts/check-finality-progress.js with "2" return is 1 within 180 seconds
+
+# === Stop 1/3 of validators (1 of 3) -> GRANDPA must continue ===
+# We use `restart after N seconds` rather than `pause`/`resume` because
+# zombienet `pause` (SIGSTOP) freezes the process while keeping its TCP
+# sockets open, so GRANDPA peers wait for Bob's votes until round timeouts
+# elapse and finality stalls (~10 min/block). A real process kill closes
+# the sockets immediately and the surviving 2/3 weight finalizes normally.
+# The assertion runs AFTER the 60s outage and verifies finality recovered
+# (or kept progressing) by advancing >= 2 blocks within 60s.
+bob: restart after 60 seconds
+alice: js-script ../js-scripts/check-finality-progress.js with "2" return is 1 within 60 seconds
+
+# === Stop 2/3 of validators -> GRANDPA must stall but PoW must keep
+# producing blocks. We assert the negation: finality does NOT advance by
+# more than 0 within a short window. Mining is verified independently by
+# observing alice best block growth via `reports block height is at least N`.
+# `pause` is acceptable here because we do NOT assert on finality during
+# the outage; we only check that PoW production continues. ===
+bob: pause
+charlie: pause
+sleep 60 seconds
+
+# alice should still be mining new blocks (PoW only requires the chain to
+# advance; no quorum needed). We pick a block that is "current+a few".
+alice: reports block height is at least 30 within 240 seconds
+
+# Bring everyone back; finality should resume.
+bob: resume
+charlie: resume
+alice: js-script ../js-scripts/check-finality-progress.js with "3" return is 1 within 360 seconds

--- a/tests/integration/scenarios/03-hashrate-fluctuation.zndsl
+++ b/tests/integration/scenarios/03-hashrate-fluctuation.zndsl
@@ -1,0 +1,30 @@
+Description: Hashrate fluctuation -> ASERT difficulty decay -> recovery
+Network: ../zombienet.toml
+Creds: /tmp/zn-creds.cfg
+
+alice: is up within 60 seconds
+bob: is up within 60 seconds
+charlie: is up within 60 seconds
+dave: is up within 60 seconds
+
+# Long warm-up so the ASERT controller has time to climb to a difficulty
+# that throttles the combined 4-miner hashrate near the 20s target. With
+# the test-runtime Halflife (60s) the controller responds in ~5 minutes.
+# Pausing miners earlier than this leaves the surviving miner under-loaded
+# and ASERT keeps raising difficulty instead of dropping it.
+alice: reports block height is at least 60 within 900 seconds
+
+# Kill 3 of 4 miners (bob, charlie, dave). Only alice mines, so observed
+# block time becomes ~4x the target -> ASERT must lower difficulty and
+# block production must continue.
+bob: pause
+charlie: pause
+dave: pause
+
+alice: js-script ../js-scripts/check-difficulty-drop.js return is 1 within 360 seconds
+
+# Bring the miners back; finality should resume promptly.
+bob: resume
+charlie: resume
+dave: resume
+alice: js-script ../js-scripts/check-finality-progress.js with "3" return is 1 within 360 seconds

--- a/tests/integration/scenarios/04-network-partition.zndsl
+++ b/tests/integration/scenarios/04-network-partition.zndsl
@@ -1,0 +1,25 @@
+Description: Single-validator isolation + recovery (partition simulated via process kill+restart)
+Network: ../zombienet.toml
+Creds: /tmp/zn-creds.cfg
+
+alice: is up within 60 seconds
+bob: is up within 60 seconds
+charlie: is up within 60 seconds
+dave: is up within 60 seconds
+eve: is up within 60 seconds
+
+alice: js-script ../js-scripts/check-finality-progress.js with "2" return is 1 within 360 seconds
+
+# === Partition simulation: take bob (1/3 of authorities) fully offline
+# for 60 seconds. We use `restart after N seconds` rather than
+# `pause`/`resume` because zombienet `pause` (SIGSTOP) only freezes the
+# process and keeps its TCP sockets open, so GRANDPA peers wait for
+# Bob's votes until round timeouts elapse and finality stalls. A real
+# process kill closes the sockets immediately and the remaining 2/3
+# weight ({alice,charlie}) keeps finalizing.
+bob: restart after 60 seconds
+
+# After bob is back, finality must keep progressing without forks. We
+# verify both convergence on canonical hash and continued advance.
+alice: js-script ../js-scripts/check-network-agreement.js return is 1 within 180 seconds
+alice: js-script ../js-scripts/check-finality-progress.js with "3" return is 1 within 360 seconds

--- a/tests/integration/scenarios/05-validator-offline-kick.zndsl
+++ b/tests/integration/scenarios/05-validator-offline-kick.zndsl
@@ -1,0 +1,37 @@
+Description: Validator goes offline (no heartbeat) and gets kicked + put into RejoinCooldown
+Network: ../zombienet.toml
+Creds: /tmp/zn-creds.cfg
+
+alice: is up within 60 seconds
+bob: is up within 60 seconds
+charlie: is up within 60 seconds
+
+# Establish baseline finality so we know the ImOnline pipeline is healthy
+# before we knock a validator offline.
+alice: js-script ../js-scripts/check-finality-progress.js with "2" return is 1 within 360 seconds
+
+# Pause Bob. Because Bob's `imon` private key only lives in Bob's keystore
+# (--bob loads it locally), no other node can spoof Bob's heartbeats;
+# ImOnline will see no heartbeat from Bob and mark him unresponsive.
+bob: pause
+
+# Wait for the full pipeline:
+#   end-of-session-N    -> imOnline.SomeOffline { offline: [Bob] } -> note_offline
+#   end-of-session-N+1  -> process_offline_counters kicks Bob (threshold=1)
+#   end-of-session-N+2  -> Bob removed from session.validators
+# With test-runtime SessionPeriod = 3 min and PoW target 20s, this takes
+# ~4-8 minutes. The js-script polls with its own 8-min cap.
+alice: js-script ../js-scripts/wait-for-offline-kick.js with "//Bob" return is 1 within 600 seconds
+
+# Resume Bob BEFORE asserting on finality. While Bob's process was paused
+# its TCP sockets stayed open, so even after he is kicked from the active
+# validator set the surviving nodes may keep retrying gossip to him until
+# round timeouts elapse (zombienet `pause` does not simulate a real
+# disconnect; see SKILL.md "3-validator GRANDPA pitfall"). Bringing his
+# process back closes the freeze and lets GRANDPA progress promptly.
+bob: resume
+
+# After Bob is kicked the chain has 2 active validators (alice, charlie),
+# which is enough for GRANDPA finality (2/3 quorum on 2 = 2 > 1). Confirm
+# finality keeps progressing on the reduced set.
+alice: js-script ../js-scripts/check-finality-progress.js with "2" return is 1 within 360 seconds

--- a/tests/integration/scenarios/06-max-validators-capacity.zndsl
+++ b/tests/integration/scenarios/06-max-validators-capacity.zndsl
@@ -1,0 +1,22 @@
+Description: MaxValidators capacity rejection (TooManyValidators)
+Network: ../zombienet.toml
+Creds: /tmp/zn-creds.cfg
+
+alice: is up within 60 seconds
+bob: is up within 60 seconds
+charlie: is up within 60 seconds
+dave: is up within 60 seconds
+eve: is up within 60 seconds
+
+# Wait for clean session boundary so we are not mid-rotation.
+alice: reports block height is at least 8 within 300 seconds
+
+# Lock Dave -> joins active set as the 4th validator -> active = MaxValidators (4).
+# Dave's session keys are pre-registered at genesis (see integration_config_genesis).
+alice: js-script ../js-scripts/lock-and-join-dave.js return is 1 within 700 seconds
+
+# Now try to lock Eve. The active set is full (4 of 4) and Eve is not yet
+# a validator. The pallet checks capacity BEFORE session-keys, so Eve
+# does not need to call session.set_keys first — we expect the
+# `validator.TooManyValidators` error directly.
+alice: js-script ../js-scripts/lock-eve-expect-too-many.js return is 1 within 120 seconds

--- a/tests/integration/scenarios/07-equivocation-placeholder.zndsl
+++ b/tests/integration/scenarios/07-equivocation-placeholder.zndsl
@@ -1,0 +1,34 @@
+Description: GRANDPA equivocation reaction - placeholder; full coverage requires unit tests
+Network: ../zombienet.toml
+Creds: /tmp/zn-creds.cfg
+
+alice: is up within 60 seconds
+
+# Equivocation (a validator signing two conflicting GRANDPA votes in the
+# same round) is hard to construct safely from a black-box integration
+# harness:
+#   * `pallet_validator::note_equivocation` is a Rust function, not a
+#     dispatchable, so we cannot call it from an extrinsic.
+#   * `pallet_grandpa::report_equivocation_unsigned` requires a real,
+#     correctly-encoded `EquivocationProof` plus a `KeyOwnerProof` from
+#     pallet-session/historical, which means actually producing two
+#     conflicting votes from the same authority — this needs either a
+#     forked node binary that maliciously double-signs, or a pre-recorded
+#     proof captured from another chain instance.
+#   * Neither path fits cleanly inside the zombienet harness.
+#
+# Instead, the equivocation reaction (status -> Kicked, RejoinCooldown
+# set, ValidatorKicked { Equivocation } event, removal from active set
+# at next session boundary) is exhaustively covered by the pallet unit
+# tests:
+#   * note_equivocation_kicks_active_validator
+#   * note_equivocation_is_idempotent
+#   * note_equivocation_ignores_non_validator
+#   * equivocation_kick_stops_auto_renewal
+#   * equivocation_lock_released_at_original_expiry
+#   * equivocation_removes_from_active_set_next_session
+#   * equivocation_blocks_relock_during_cooldown
+# (see pallets/validator/src/tests.rs)
+#
+# This scenario currently asserts only that the network comes up cleanly;
+# re-enable it later with a proper proof-injection helper if desired.

--- a/tests/integration/scenarios/99-evm-placeholder.zndsl
+++ b/tests/integration/scenarios/99-evm-placeholder.zndsl
@@ -1,0 +1,11 @@
+Description: EVM smart-contract scenarios - SKIPPED until Frontier (pallet-evm + pallet-ethereum + Ethereum-compatible RPC) is integrated into the runtime
+Network: ../zombienet.toml
+Creds: /tmp/zn-creds.cfg
+
+alice: is up within 60 seconds
+
+# Placeholder. The runtime currently does not include pallet-evm /
+# pallet-ethereum / Frontier RPC, so deploy/call/query cannot be exercised.
+# Re-enable this scenario once those are merged.
+#
+# alice: js-script ../js-scripts/evm-deploy-and-call.js return is 1 within 240 seconds

--- a/tests/integration/scripts/build-node.sh
+++ b/tests/integration/scripts/build-node.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Build the solochain-template-node binary with the `test-runtime` feature.
+# This binary MUST be used by start-network.sh; otherwise session and
+# validator timing constants are too long to observe within the test budget.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+PROFILE="${PROFILE:-release}"
+
+if [[ "$PROFILE" == "release" ]]; then
+  cargo build --release -p solochain-template-node --features test-runtime
+else
+  cargo build -p solochain-template-node --features test-runtime
+fi
+
+BIN="$ROOT/target/$PROFILE/solochain-template-node"
+echo "Built: $BIN"
+"$BIN" --version
+
+# Pre-generate the raw chainspec consumed by zombienet.toml. zombienet
+# would otherwise rebuild a spec from --chain integration on every spawn
+# and overwrite our pre-registered session keys with auto-generated ones.
+SPEC="$ROOT/tests/integration/integration-raw.json"
+echo "Generating raw chainspec at $SPEC"
+"$BIN" build-spec --chain integration --raw --disable-default-bootnode > "$SPEC"
+echo "Raw spec: $(wc -c < "$SPEC") bytes"

--- a/tests/integration/scripts/run-all.sh
+++ b/tests/integration/scripts/run-all.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Run every zombienet scenario in order. Stops on the first failure.
+set -euo pipefail
+HARNESS="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$HARNESS"
+
+# Every scenario uses `Creds: /tmp/zn-creds.cfg` (a zombienet syntactic
+# requirement). Native provider does not actually consume the file; an
+# empty placeholder is enough.
+CREDS="${ZN_CREDS:-/tmp/zn-creds.cfg}"
+[[ -f "$CREDS" ]] || touch "$CREDS"
+
+LOG_DIR="/tmp/zn-run-all-logs"
+rm -rf "$LOG_DIR"
+mkdir -p "$LOG_DIR"
+
+SCENARIOS=(
+    "scenarios/00-basic-and-finality.zndsl"
+    "scenarios/01-validator-lifecycle.zndsl"
+    "scenarios/02-validator-mass-offline.zndsl"
+    "scenarios/03-hashrate-fluctuation.zndsl"
+    "scenarios/04-network-partition.zndsl"
+    "scenarios/05-validator-offline-kick.zndsl"
+    "scenarios/06-max-validators-capacity.zndsl"
+    "scenarios/07-equivocation-placeholder.zndsl"
+    "scenarios/99-evm-placeholder.zndsl"
+)
+
+fail=0
+failed_list=()
+for s in "${SCENARIOS[@]}"; do
+    echo
+    echo "=========================================================="
+    echo ">>> $s"
+    echo "=========================================================="
+    log_file="$LOG_DIR/$(basename "$s" .zndsl).log"
+    if ! zombienet -p native test "$s" 2>&1 | tee "$log_file"; then
+        echo "FAIL: $s"
+        fail=$((fail + 1))
+        failed_list+=("$s")
+    fi
+done
+
+echo
+if [[ $fail -eq 0 ]]; then
+    echo "All scenarios passed."
+else
+    echo "$fail scenario(s) failed:"
+    for f in "${failed_list[@]}"; do
+        echo
+        echo "=========================================================="
+        echo "FAIL: $f"
+        echo "=========================================================="
+        log_file="$LOG_DIR/$(basename "$f" .zndsl).log"
+        # Show failed assertions (❌ lines) with 3 lines of context above each
+        grep -n "❌\|Result:" "$log_file" | head -40 || true
+        echo "--- custom script output ---"
+        grep -v "^[[:space:]]*$" "$log_file" | grep -v "^┌\|^│\|^└" | tail -20 || true
+    done
+    echo
+    echo "Full logs saved to: $LOG_DIR"
+    exit 1
+fi

--- a/tests/integration/zombienet.toml
+++ b/tests/integration/zombienet.toml
@@ -1,0 +1,48 @@
+[settings]
+# Generous default for any "within X seconds" assertion. PoW target is 20s
+# so 600s gives us ~30 blocks of slack.
+timeout = 1000
+provider = "native"
+
+[relaychain]
+chain = "integration"
+chain_spec_path = "integration-raw.json"
+default_command = "../../target/release/solochain-template-node"
+default_args = [
+    "-l=info,sub-libp2p=warn,libp2p_swarm=warn,grandpa=debug,runtime::session=debug,pallet_session=debug",
+]
+
+# === Initial validators (run a miner each so block production stays even). ===
+
+[[relaychain.nodes]]
+  name = "alice"
+  validator = true
+  bootnode = true
+  args = ["--alice", "--miner", "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"]
+
+[[relaychain.nodes]]
+  name = "bob"
+  validator = true
+  args = ["--bob", "--miner", "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"]
+
+[[relaychain.nodes]]
+  name = "charlie"
+  validator = true
+  args = ["--charlie", "--miner", "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y"]
+
+# === Standby account: not an initial validator. Mines so the txpool sees its
+# `validator.lock()` extrinsic, then joins the active set after one session
+# rotation. Used by the validator-join / validator-exit scenarios. ===
+
+[[relaychain.nodes]]
+  name = "dave"
+  validator = false
+  args = ["--dave", "--miner", "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"]
+
+# === Pure observer node, no mining, no validating. Used to confirm
+# block/finalized hash convergence on a node that authored nothing. ===
+
+[[relaychain.nodes]]
+  name = "eve"
+  validator = false
+  args = ["--eve"]


### PR DESCRIPTION
- New 'test-runtime' cargo feature shrinks some parameters from days to seconds so multi-node integration scenarios run in minutes.
- New 'integration' chainspec preset boots Alice/Bob/Charlie as initial validators and pre-registers Dave/Eve session keys in genesis so the join/exit scenarios can be exercised via validator.lock() without first calling session.setKeys.
- tests/integration: zombienet.toml + 7 zndsl scenarios (basic finality, validator lifecycle, mass offline, hashrate fluctuation, partition simulation) plus a placeholder for future EVM integration.

Closes #36 