### PR TITLE
Prevent validator rejoin at cooldown boundary

### DIFF
--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -352,7 +352,7 @@ pub mod pallet {
 
             let now = frame_system::Pallet::<T>::block_number();
             if let Some(deadline) = RejoinCooldown::<T>::get(&who) {
-                if deadline > now {
+                if deadline >= now {
                     return Err(Error::<T>::InCooldown.into());
                 }
                 RejoinCooldown::<T>::remove(&who);


### PR DESCRIPTION
The cooldown validation used `>` instead of `>=`,
which excluded the current block number from the cooldown period
and allowed validator rejoin one block earlier than intended.