### PR TITLE
Split CI jobs into separate clippy and test stages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "ci"
-          save-if: "false"
       - uses: ./.github/actions/free-disk-space
       - uses: ./.github/actions/ubuntu-dependencies
       - name: Run clippy
@@ -29,9 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "ci"
-          save-if: "false"
       - uses: ./.github/actions/free-disk-space
       - uses: ./.github/actions/ubuntu-dependencies
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  # workflow_dispatch:   # Allows you to run this workflow manually from the Actions tab
   pull_request:
     branches:
       - dev
@@ -11,31 +12,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
+  check:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "ci"
+      - uses: ./.github/actions/free-disk-space
+      - uses: ./.github/actions/ubuntu-dependencies
+      - name: Check compilation
+        run: SKIP_WASM_BUILD=1 cargo check --workspace --locked
+        timeout-minutes: 20
 
-      - if: contains(matrix.os, 'ubuntu')
-        uses: ./.github/actions/free-disk-space
-      - if: contains(matrix.os, 'ubuntu')
-        uses: ./.github/actions/ubuntu-dependencies
-      - if: contains(matrix.os, 'macos')
-        uses: ./.github/actions/macos-dependencies
-
-      - name: Build
-        run: cargo build
-        timeout-minutes: 30
-
+  clippy:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "ci"
+          save-if: "false"
+      - uses: ./.github/actions/free-disk-space
+      - uses: ./.github/actions/ubuntu-dependencies
       - name: Run clippy
-        run: |
-          SKIP_WASM_BUILD=1 cargo clippy --all-targets --locked --workspace --quiet
+        run: SKIP_WASM_BUILD=1 cargo clippy --all-targets --locked --workspace --quiet
         timeout-minutes: 15
 
-      - name: Run the tests
-        run: SKIP_WASM_BUILD=1 cargo test
+  test:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "ci"
+          save-if: "false"
+      - uses: ./.github/actions/free-disk-space
+      - uses: ./.github/actions/ubuntu-dependencies
+      - name: Run tests
+        run: SKIP_WASM_BUILD=1 cargo test --workspace --locked
         timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
 name: CI
 
 on:
-  # workflow_dispatch:   # Allows you to run this workflow manually from the Actions tab
   pull_request:
     branches:
-      - dev
       - master
 
 concurrency:
@@ -12,24 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "ci"
-      - uses: ./.github/actions/free-disk-space
-      - uses: ./.github/actions/ubuntu-dependencies
-      - name: Check compilation
-        run: SKIP_WASM_BUILD=1 cargo check --workspace --locked
-        timeout-minutes: 20
-      - name: Pre-compile tests
-        run: SKIP_WASM_BUILD=1 cargo test --no-run --workspace --locked
-        timeout-minutes: 20
-
   clippy:
-    needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +25,6 @@ jobs:
         timeout-minutes: 15
 
   test:
-    needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Check compilation
         run: SKIP_WASM_BUILD=1 cargo check --workspace --locked
         timeout-minutes: 20
+      - name: Pre-compile tests
+        run: SKIP_WASM_BUILD=1 cargo test --no-run --workspace --locked
+        timeout-minutes: 20
 
   clippy:
     needs: check


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI restructured: combined build replaced by separate lint (Clippy) and test jobs, each with 15-minute timeouts.
  * Pull-request CI scope narrowed to the main integration branch to reduce unnecessary runs.
  * Caching behavior adjusted to streamline execution and avoid persisting between runs.
  * Removed prior platform-specific dependency logic from the workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/motoZ-crypto/crypto-node/pull/83)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->