### PR TITLE
Integrate Frontier Ethereum-compatible JSON-RPC layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-take"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,7 +870,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "hash-db",
  "log",
@@ -877,7 +886,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -1749,6 +1758,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b530783809a55cb68d070e0de60cfbb3db0dc94c8850dd5725411422bedcf6bb"
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.24.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -1998,7 +2022,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2008,7 +2032,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2530,6 +2554,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,6 +2676,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -2961,6 +2994,174 @@ dependencies = [
 ]
 
 [[package]]
+name = "fc-api"
+version = "1.0.0-dev"
+source = "git+https://github.com/polkadot-evm/frontier?branch=stable2603#baf505d8feeaaa0ba636a003faa49e4ad897b592"
+dependencies = [
+ "async-trait",
+ "fp-storage",
+ "parity-scale-codec",
+ "sp-core",
+ "sp-runtime",
+]
+
+[[package]]
+name = "fc-consensus"
+version = "2.0.0-dev"
+source = "git+https://github.com/polkadot-evm/frontier?branch=stable2603#baf505d8feeaaa0ba636a003faa49e4ad897b592"
+dependencies = [
+ "async-trait",
+ "fp-consensus",
+ "fp-rpc",
+ "sc-consensus",
+ "sp-api",
+ "sp-block-builder",
+ "sp-consensus",
+ "sp-runtime",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "fc-db"
+version = "2.0.0-dev"
+source = "git+https://github.com/polkadot-evm/frontier?branch=stable2603#baf505d8feeaaa0ba636a003faa49e4ad897b592"
+dependencies = [
+ "async-trait",
+ "ethereum",
+ "fc-api",
+ "fc-storage",
+ "fp-consensus",
+ "fp-rpc",
+ "fp-storage",
+ "futures",
+ "kvdb-rocksdb",
+ "log",
+ "parity-db 0.5.5",
+ "parity-scale-codec",
+ "parking_lot 0.12.5",
+ "sc-client-api",
+ "sc-client-db",
+ "smallvec",
+ "sp-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-database",
+ "sp-runtime",
+ "sqlx",
+ "tokio",
+]
+
+[[package]]
+name = "fc-mapping-sync"
+version = "2.0.0-dev"
+source = "git+https://github.com/polkadot-evm/frontier?branch=stable2603#baf505d8feeaaa0ba636a003faa49e4ad897b592"
+dependencies = [
+ "ethereum-types",
+ "fc-db",
+ "fc-storage",
+ "fp-consensus",
+ "fp-rpc",
+ "futures",
+ "futures-timer",
+ "log",
+ "parking_lot 0.12.5",
+ "sc-client-api",
+ "sc-utils",
+ "sp-api",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-runtime",
+ "tokio",
+]
+
+[[package]]
+name = "fc-rpc"
+version = "2.0.0-dev"
+source = "git+https://github.com/polkadot-evm/frontier?branch=stable2603#baf505d8feeaaa0ba636a003faa49e4ad897b592"
+dependencies = [
+ "ethereum",
+ "ethereum-types",
+ "evm",
+ "fc-api",
+ "fc-mapping-sync",
+ "fc-rpc-core",
+ "fc-storage",
+ "fp-evm",
+ "fp-rpc",
+ "fp-storage",
+ "futures",
+ "hex",
+ "jsonrpsee",
+ "libsecp256k1",
+ "log",
+ "pallet-evm",
+ "parity-scale-codec",
+ "prometheus",
+ "rand 0.9.1",
+ "rlp",
+ "sc-client-api",
+ "sc-consensus-aura",
+ "sc-network",
+ "sc-network-sync",
+ "sc-rpc",
+ "sc-service",
+ "sc-transaction-pool-api",
+ "sc-utils",
+ "schnellru",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-aura",
+ "sp-core",
+ "sp-externalities",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-storage",
+ "sp-timestamp",
+ "sp-trie",
+ "substrate-prometheus-endpoint",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "fc-rpc-core"
+version = "1.1.0-dev"
+source = "git+https://github.com/polkadot-evm/frontier?branch=stable2603#baf505d8feeaaa0ba636a003faa49e4ad897b592"
+dependencies = [
+ "ethereum",
+ "ethereum-types",
+ "jsonrpsee",
+ "rlp",
+ "rustc-hex",
+ "serde",
+ "serde_json",
+ "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2603)",
+]
+
+[[package]]
+name = "fc-storage"
+version = "1.0.0-dev"
+source = "git+https://github.com/polkadot-evm/frontier?branch=stable2603#baf505d8feeaaa0ba636a003faa49e4ad897b592"
+dependencies = [
+ "ethereum",
+ "ethereum-types",
+ "fp-rpc",
+ "fp-storage",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sp-api",
+ "sp-io",
+ "sp-runtime",
+ "sp-storage",
+]
+
+[[package]]
 name = "fdlimit"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3049,6 +3250,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,6 +3271,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fork-tree"
@@ -3190,7 +3417,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "46.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3384,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "46.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -3425,7 +3652,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3445,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.3.0",
@@ -3457,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3467,7 +3694,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "46.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3593,6 +3820,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -3945,6 +4183,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -5498,6 +5745,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5873,7 +6131,7 @@ dependencies = [
  "c2-chacha",
  "curve25519-dalek",
  "either",
- "hashlink",
+ "hashlink 0.8.4",
  "lioness",
  "log",
  "parking_lot 0.12.5",
@@ -6071,6 +6329,23 @@ name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "netlink-packet-core"
@@ -6343,7 +6618,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6402,10 +6677,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -6944,6 +7256,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "parity-db"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b63063d738c6e39a9e29e0821fc7293f1d862e75bac6e39bcea131b44c03ade"
+dependencies = [
+ "ahash 0.8.12",
+ "blake2 0.10.6",
+ "crc32fast",
+ "fs2",
+ "hex",
+ "libc",
+ "log",
+ "lz4",
+ "memmap2 0.9.5",
+ "parking_lot 0.12.5",
+ "rand 0.9.1",
+ "siphasher 1.0.1",
+ "snap",
+ "winapi",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7236,7 +7570,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7361,7 +7695,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
@@ -7378,7 +7712,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "bitvec",
  "bounded-collections",
@@ -7918,8 +8252,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -7938,8 +8272,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -7971,7 +8305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7984,7 +8318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8628,7 +8962,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -8656,7 +8990,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.3",
- "security-framework",
+ "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
@@ -8711,6 +9045,12 @@ dependencies = [
  "pin-project",
  "static_assertions",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
@@ -8936,7 +9276,7 @@ dependencies = [
  "kvdb-rocksdb",
  "linked-hash-map",
  "log",
- "parity-db",
+ "parity-db 0.4.13",
  "parity-scale-codec",
  "parking_lot 0.12.5",
  "sc-client-api",
@@ -8972,6 +9312,37 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-state-machine",
+ "substrate-prometheus-endpoint",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "sc-consensus-aura"
+version = "0.56.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
+dependencies = [
+ "async-trait",
+ "fork-tree",
+ "futures",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.5",
+ "sc-block-builder",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-consensus-slots",
+ "sc-telemetry",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-aura",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -9711,7 +10082,7 @@ dependencies = [
  "futures",
  "itertools 0.11.0",
  "log",
- "parity-db",
+ "parity-db 0.4.13",
  "parking_lot 0.12.5",
  "sc-client-api",
  "sc-keystore",
@@ -10158,6 +10529,19 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
@@ -10261,6 +10645,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -10633,12 +11029,22 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "cumulus-primitives-proof-size-hostfunction",
+ "fc-api",
+ "fc-consensus",
+ "fc-db",
+ "fc-mapping-sync",
+ "fc-rpc",
+ "fc-rpc-core",
+ "fc-storage",
+ "fp-evm",
+ "fp-rpc",
  "frame-benchmarking-cli",
  "frame-metadata-hash-extension",
  "frame-system",
  "futures",
  "jsonrpsee",
  "log",
+ "pallet-ethereum",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc",
  "parity-scale-codec",
@@ -10651,6 +11057,7 @@ dependencies = [
  "sc-consensus-pow",
  "sc-executor",
  "sc-network",
+ "sc-network-sync",
  "sc-offchain",
  "sc-rpc",
  "sc-service",
@@ -10739,7 +11146,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "docify",
  "hash-db",
@@ -10761,7 +11168,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -10775,7 +11182,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10787,7 +11194,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "28.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -10801,7 +11208,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10921,7 +11328,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10932,7 +11339,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "ark-vrf",
  "array-bytes 6.2.3",
@@ -10993,7 +11400,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -11006,7 +11413,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2603)",
@@ -11026,7 +11433,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "proc-macro-warning",
  "proc-macro2",
@@ -11037,7 +11444,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -11047,7 +11454,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11059,7 +11466,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -11072,7 +11479,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "bytes",
  "docify",
@@ -11108,7 +11515,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -11128,7 +11535,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.12.3"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -11189,7 +11596,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "backtrace",
  "regex",
@@ -11208,7 +11615,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "46.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "binary-merkle-tree",
  "bytes",
@@ -11239,7 +11646,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -11257,7 +11664,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "Inflector",
  "expander",
@@ -11284,7 +11691,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -11297,7 +11704,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "hash-db",
  "log",
@@ -11343,12 +11750,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 
 [[package]]
 name = "sp-storage"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11360,7 +11767,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11372,7 +11779,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -11408,7 +11815,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "ahash 0.8.12",
  "foldhash",
@@ -11433,7 +11840,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11451,7 +11858,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -11463,7 +11870,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -11475,7 +11882,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -11497,6 +11904,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spinning_top"
@@ -11515,6 +11925,111 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener 5.4.0",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.3",
+ "hashlink 0.10.0",
+ "indexmap",
+ "log",
+ "memchr",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "serde",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-sqlite",
+ "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -11541,7 +12056,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-xcm"
 version = "22.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
@@ -11687,7 +12202,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -11737,7 +12252,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.7"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -13495,7 +14010,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -14031,7 +14546,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053814b17eaec60093c024572ce8f47042a572"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ sc-consensus-grandpa-rpc = { git = "https://github.com/paritytech/polkadot-sdk",
 sc-consensus-pow = { path = "./consensus/sc-consensus-pow", default-features = false }
 sc-executor = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 sc-network = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
+sc-network-sync = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 sc-offchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 sc-rpc = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 sc-service = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
@@ -109,6 +110,15 @@ fp-evm = { git = "https://github.com/polkadot-evm/frontier", branch = "stable260
 fp-rpc = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2603", default-features = false }
 fp-self-contained = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2603", default-features = false, features = ["serde"] }
 ethereum = { version = "0.18.2", default-features = false }
+
+# Frontier client (node-only) crates.
+fc-api = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2603" }
+fc-consensus = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2603" }
+fc-db = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2603", features = ["rocksdb"] }
+fc-mapping-sync = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2603" }
+fc-rpc = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2603" }
+fc-rpc-core = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2603" }
+fc-storage = { git = "https://github.com/polkadot-evm/frontier", branch = "stable2603" }
 
 [profile.release]
 opt-level = 3

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -50,6 +50,8 @@ cumulus-primitives-proof-size-hostfunction.default-features = true
 cumulus-primitives-proof-size-hostfunction.workspace = true
 sc-network.default-features = true
 sc-network.workspace = true
+sc-network-sync.default-features = true
+sc-network-sync.workspace = true
 sc-offchain.default-features = true
 sc-offchain.workspace = true
 sc-rpc.default-features = true
@@ -92,6 +94,18 @@ sp-timestamp.workspace = true
 substrate-frame-rpc-system.default-features = true
 substrate-frame-rpc-system.workspace = true
 sha256pow.workspace = true
+
+# Frontier (Ethereum compatibility) — node-side RPC stack.
+fc-api.workspace = true
+fc-consensus.workspace = true
+fc-db.workspace = true
+fc-mapping-sync.workspace = true
+fc-rpc.workspace = true
+fc-rpc-core.workspace = true
+fc-storage.workspace = true
+fp-rpc = { workspace = true, default-features = true }
+fp-evm = { workspace = true, default-features = true }
+pallet-ethereum = { workspace = true, default-features = true }
 
 [build-dependencies]
 substrate-build-script-utils.default-features = true

--- a/node/src/eth.rs
+++ b/node/src/eth.rs
@@ -1,0 +1,125 @@
+//! Frontier (Ethereum compatibility) node-side helpers.
+//!
+//! Hosts the Frontier KV mapping database and the background tasks that keep
+//! it in sync with the Substrate canonical chain (mapping-sync, filter-pool
+//! cleanup, fee-history cache).
+
+use std::{
+	collections::BTreeMap,
+	path::PathBuf,
+	sync::{Arc, Mutex},
+	time::Duration,
+};
+
+use futures::{future, prelude::*};
+use sc_client_api::BlockchainEvents;
+use sc_network_sync::SyncingService;
+use sc_service::{Configuration, TaskManager};
+
+use fc_rpc::EthTask;
+use fc_rpc_core::types::{FeeHistoryCache, FeeHistoryCacheLimit, FilterPool};
+use fc_storage::StorageOverride;
+
+use solochain_template_runtime::opaque::Block;
+
+use crate::service::{FullBackend, FullClient};
+
+/// Default fee-history cache capacity (in blocks).
+pub const DEFAULT_FEE_HISTORY_LIMIT: u64 = 2048;
+/// Default filter retention (in blocks) before being garbage-collected.
+const FILTER_RETAIN_THRESHOLD: u64 = 100;
+
+/// Frontier backend type alias for this node.
+pub type FrontierBackend = fc_db::Backend<Block, FullClient>;
+
+/// Returns the on-disk directory used for the Frontier KV database.
+pub fn db_config_dir(config: &Configuration) -> PathBuf {
+	config.base_path.config_dir(config.chain_spec.id())
+}
+
+/// Eagerly-built Frontier components shared between `new_partial`/`new_full`.
+pub struct FrontierPartialComponents {
+	/// Pool of active `eth_*` filters tracked by the node.
+	pub filter_pool: Option<FilterPool>,
+	/// LRU cache feeding `eth_feeHistory`.
+	pub fee_history_cache: FeeHistoryCache,
+	/// Maximum number of blocks retained in the fee-history cache.
+	pub fee_history_cache_limit: FeeHistoryCacheLimit,
+}
+
+/// Build the in-memory Frontier components used by both partial and full setup.
+pub fn new_frontier_partial() -> FrontierPartialComponents {
+	FrontierPartialComponents {
+		filter_pool: Some(Arc::new(Mutex::new(BTreeMap::new()))),
+		fee_history_cache: Arc::new(Mutex::new(BTreeMap::new())),
+		fee_history_cache_limit: DEFAULT_FEE_HISTORY_LIMIT,
+	}
+}
+
+/// Spawn the background tasks required by the Frontier RPC layer.
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_frontier_tasks(
+	task_manager: &TaskManager,
+	client: Arc<FullClient>,
+	backend: Arc<FullBackend>,
+	frontier_backend: Arc<FrontierBackend>,
+	filter_pool: Option<FilterPool>,
+	storage_override: Arc<dyn StorageOverride<Block>>,
+	fee_history_cache: FeeHistoryCache,
+	fee_history_cache_limit: FeeHistoryCacheLimit,
+	sync: Arc<SyncingService<Block>>,
+	pubsub_notification_sinks: Arc<
+		fc_mapping_sync::EthereumBlockNotificationSinks<
+			fc_mapping_sync::EthereumBlockNotification<Block>,
+		>,
+	>,
+) {
+	// Mapping-sync worker keeps the Frontier DB aligned with the Substrate chain.
+	match &*frontier_backend {
+		fc_db::Backend::KeyValue(kv) => {
+			task_manager.spawn_essential_handle().spawn(
+				"frontier-mapping-sync-worker",
+				Some("frontier"),
+				fc_mapping_sync::kv::MappingSyncWorker::new(
+					client.import_notification_stream(),
+					Duration::new(6, 0),
+					client.clone(),
+					backend,
+					storage_override.clone(),
+					kv.clone(),
+					3,
+					0u32,
+					None,
+					fc_mapping_sync::SyncStrategy::Normal,
+					sync,
+					pubsub_notification_sinks,
+				)
+				.for_each(|()| future::ready(())),
+			);
+		}
+		fc_db::Backend::Sql(_) => {
+			// SQL backend is not supported by this node.
+		}
+	}
+
+	// Periodic GC for `eth_*` filters.
+	if let Some(filter_pool) = filter_pool {
+		task_manager.spawn_essential_handle().spawn(
+			"frontier-filter-pool",
+			Some("frontier"),
+			EthTask::filter_pool_task(client.clone(), filter_pool, FILTER_RETAIN_THRESHOLD),
+		);
+	}
+
+	// Fee-history cache maintenance.
+	task_manager.spawn_essential_handle().spawn(
+		"frontier-fee-history",
+		Some("frontier"),
+		EthTask::fee_history_task(
+			client,
+			storage_override,
+			fee_history_cache,
+			fee_history_cache_limit,
+		),
+	);
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -6,6 +6,7 @@ mod benchmarking;
 mod chain_spec;
 mod cli;
 mod command;
+mod eth;
 mod rpc;
 mod service;
 

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -118,7 +118,7 @@ where
 {
 	type EstimateGasAdapter = ();
 	type RuntimeStorageOverride =
-		fc_rpc::frontier_backend_client::SystemAccountId20StorageOverride<Block, C, BE>;
+		fc_rpc::frontier_backend_client::SystemAccountId32StorageOverride<Block, C, BE>;
 }
 
 /// Instantiate all full RPC extensions (Substrate + GRANDPA + Ethereum).

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -5,27 +5,47 @@
 
 #![warn(missing_docs)]
 
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use jsonrpsee::RpcModule;
+
 use sc_consensus_grandpa::{
 	FinalityProofProvider, GrandpaJustificationStream, SharedAuthoritySet, SharedVoterState,
 };
+use sc_network::service::traits::NetworkService;
+use sc_network_sync::SyncingService;
 use sc_rpc::SubscriptionTaskExecutor;
 use sc_transaction_pool_api::TransactionPool;
-use solochain_template_runtime::{opaque::Block, AccountId, Balance, Nonce};
-use sp_api::ProvideRuntimeApi;
+
+use sp_api::{CallApiAt, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
+use sp_core::H256;
+use sp_inherents::CreateInherentDataProviders;
 use sp_runtime::traits::Block as BlockT;
+
+use sc_client_api::{
+	backend::{Backend, StorageProvider},
+	client::BlockchainEvents,
+	AuxStore, UsageProvider,
+};
+
+use fc_rpc::{EthBlockDataCacheTask, EthConfig};
+use fc_rpc_core::types::{FeeHistoryCache, FeeHistoryCacheLimit, FilterPool};
+use fc_storage::StorageOverride;
+use fp_rpc::{ConvertTransaction, ConvertTransactionRuntimeApi, EthereumRuntimeRPCApi};
+
+use solochain_template_runtime::{opaque::Block, AccountId, Balance, Nonce};
 
 /// Dependencies for GRANDPA RPC.
 pub struct GrandpaDeps<B> {
 	/// Voting round info.
 	pub shared_voter_state: SharedVoterState,
 	/// Authority set info.
-	pub shared_authority_set:
-		SharedAuthoritySet<<Block as BlockT>::Hash, <<Block as BlockT>::Header as sp_runtime::traits::Header>::Number>,
+	pub shared_authority_set: SharedAuthoritySet<
+		<Block as BlockT>::Hash,
+		<<Block as BlockT>::Header as sp_runtime::traits::Header>::Number,
+	>,
 	/// Receives notifications about justification events from GRANDPA.
 	pub justification_stream: GrandpaJustificationStream<Block>,
 	/// Executor to drive the subscription manager in the GRANDPA RPC handler.
@@ -34,36 +54,111 @@ pub struct GrandpaDeps<B> {
 	pub finality_provider: Arc<FinalityProofProvider<B, Block>>,
 }
 
-/// Full client dependencies.
-pub struct FullDeps<C, P, B> {
+/// Extra dependencies for Ethereum-compatibility RPCs.
+pub struct EthDeps<C, P, CT, CIDP> {
 	/// The client instance to use.
 	pub client: Arc<C>,
 	/// Transaction pool instance.
 	pub pool: Arc<P>,
-	/// GRANDPA specific dependencies.
-	pub grandpa: GrandpaDeps<B>,
+	/// Optional Substrate ↔ Ethereum transaction converter.
+	pub converter: Option<CT>,
+	/// Whether the local node is an authority/miner.
+	pub is_authority: bool,
+	/// Whether to enable the dev signer.
+	pub enable_dev_signer: bool,
+	/// Network service handle.
+	pub network: Arc<dyn NetworkService>,
+	/// Chain syncing service.
+	pub sync: Arc<SyncingService<Block>>,
+	/// Frontier backend (KV).
+	pub frontier_backend: Arc<dyn fc_api::Backend<Block>>,
+	/// Ethereum data access overrides.
+	pub storage_override: Arc<dyn StorageOverride<Block>>,
+	/// Cache for Ethereum block data.
+	pub block_data_cache: Arc<EthBlockDataCacheTask<Block>>,
+	/// `eth_*` filter pool.
+	pub filter_pool: Option<FilterPool>,
+	/// Fee history cache.
+	pub fee_history_cache: FeeHistoryCache,
+	/// Fee history cache size limit.
+	pub fee_history_cache_limit: FeeHistoryCacheLimit,
+	/// Maximum number of logs returned by a single query.
+	pub max_past_logs: u32,
+	/// Maximum block range allowed in `eth_getLogs`.
+	pub max_block_range: u32,
+	/// `eth_call` / `eth_estimateGas` gas-limit multiplier.
+	pub execute_gas_limit_multiplier: u64,
+	/// Allow RPC submission of unprotected legacy transactions.
+	pub rpc_allow_unprotected_txs: bool,
+	/// Mandated parent hashes (used by some L2 deployments).
+	pub forced_parent_hashes: Option<BTreeMap<H256, H256>>,
+	/// Inherent data provider factory used for pending state queries.
+	pub pending_create_inherent_data_providers: CIDP,
 }
 
-/// Instantiate all full RPC extensions.
-pub fn create_full<C, P, B>(
-	deps: FullDeps<C, P, B>,
+/// Full client dependencies.
+pub struct FullDeps<C, P, B, CT, CIDP> {
+	/// The client instance to use.
+	pub client: Arc<C>,
+	/// Transaction pool instance.
+	pub pool: Arc<P>,
+	/// GRANDPA-specific dependencies.
+	pub grandpa: GrandpaDeps<B>,
+	/// Ethereum-compatibility dependencies.
+	pub eth: EthDeps<C, P, CT, CIDP>,
+}
+
+/// Default `EthConfig` impl bound to the node's client/backend.
+pub struct DefaultEthConfig<C, BE>(std::marker::PhantomData<(C, BE)>);
+
+impl<C, BE> EthConfig<Block, C> for DefaultEthConfig<C, BE>
+where
+	C: StorageProvider<Block, BE> + Sync + Send + 'static,
+	BE: Backend<Block> + 'static,
+{
+	type EstimateGasAdapter = ();
+	type RuntimeStorageOverride =
+		fc_rpc::frontier_backend_client::SystemAccountId20StorageOverride<Block, C, BE>;
+}
+
+/// Instantiate all full RPC extensions (Substrate + GRANDPA + Ethereum).
+pub fn create_full<C, P, B, BE, CT, CIDP>(
+	deps: FullDeps<C, P, B, CT, CIDP>,
+	subscription_task_executor: SubscriptionTaskExecutor,
+	pubsub_notification_sinks: Arc<
+		fc_mapping_sync::EthereumBlockNotificationSinks<
+			fc_mapping_sync::EthereumBlockNotification<Block>,
+		>,
+	>,
 ) -> Result<RpcModule<()>, Box<dyn std::error::Error + Send + Sync>>
 where
-	C: ProvideRuntimeApi<Block>,
+	C: CallApiAt<Block> + ProvideRuntimeApi<Block>,
 	C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError> + 'static,
+	C: BlockchainEvents<Block> + AuxStore + UsageProvider<Block> + StorageProvider<Block, BE>,
 	C: Send + Sync + 'static,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: BlockBuilder<Block>,
-	P: TransactionPool + 'static,
+	C::Api: ConvertTransactionRuntimeApi<Block>,
+	C::Api: EthereumRuntimeRPCApi<Block>,
+	P: TransactionPool<Block = Block, Hash = <Block as BlockT>::Hash> + 'static,
 	B: sc_client_api::Backend<Block> + Send + Sync + 'static,
+	BE: Backend<Block> + 'static,
+	CT: ConvertTransaction<<Block as BlockT>::Extrinsic> + Send + Sync + 'static,
+	CIDP: CreateInherentDataProviders<Block, ()> + Send + 'static,
 {
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
 	use sc_consensus_grandpa_rpc::{Grandpa, GrandpaApiServer};
 	use substrate_frame_rpc_system::{System, SystemApiServer};
 
+	use fc_rpc::{
+		Eth, EthApiServer, EthDevSigner, EthFilter, EthFilterApiServer, EthPubSub,
+		EthPubSubApiServer, EthSigner, LogsJournal, LogsJournalConfig, Net, NetApiServer, Web3,
+		Web3ApiServer,
+	};
+
 	let mut module = RpcModule::new(());
-	let FullDeps { client, pool, grandpa } = deps;
+	let FullDeps { client, pool, grandpa, eth } = deps;
 	let GrandpaDeps {
 		shared_voter_state,
 		shared_authority_set,
@@ -72,8 +167,8 @@ where
 		finality_provider,
 	} = grandpa;
 
-	module.merge(System::new(client.clone(), pool).into_rpc())?;
-	module.merge(TransactionPayment::new(client).into_rpc())?;
+	module.merge(System::new(client.clone(), pool.clone()).into_rpc())?;
+	module.merge(TransactionPayment::new(client.clone()).into_rpc())?;
 	module.merge(
 		Grandpa::new(
 			subscription_executor,
@@ -84,6 +179,97 @@ where
 		)
 		.into_rpc(),
 	)?;
+
+	let EthDeps {
+		client: eth_client,
+		pool: eth_pool,
+		converter,
+		is_authority,
+		enable_dev_signer,
+		network,
+		sync,
+		frontier_backend,
+		storage_override,
+		block_data_cache,
+		filter_pool,
+		fee_history_cache,
+		fee_history_cache_limit,
+		max_past_logs,
+		max_block_range,
+		execute_gas_limit_multiplier,
+		rpc_allow_unprotected_txs,
+		forced_parent_hashes,
+		pending_create_inherent_data_providers,
+	} = eth;
+
+	let mut signers = Vec::<Box<dyn EthSigner>>::new();
+	if enable_dev_signer {
+		signers.push(Box::new(EthDevSigner::new()));
+	}
+
+	let logs_journal = Arc::new(LogsJournal::with_config(
+		subscription_task_executor.clone(),
+		storage_override.clone(),
+		pubsub_notification_sinks.clone(),
+		LogsJournalConfig::default(),
+	));
+
+	module.merge(
+		Eth::<Block, C, P, CT, BE, CIDP, DefaultEthConfig<C, BE>>::new(
+			eth_client.clone(),
+			eth_pool.clone(),
+			converter,
+			sync.clone(),
+			signers,
+			storage_override.clone(),
+			frontier_backend.clone(),
+			is_authority,
+			block_data_cache.clone(),
+			fee_history_cache,
+			fee_history_cache_limit,
+			execute_gas_limit_multiplier,
+			rpc_allow_unprotected_txs,
+			forced_parent_hashes,
+			pending_create_inherent_data_providers,
+			// PoW chain: no consensus data provider needed for `pending` queries.
+			None,
+		)
+		.replace_config::<DefaultEthConfig<C, BE>>()
+		.into_rpc(),
+	)?;
+
+	if let Some(filter_pool) = filter_pool {
+		module.merge(
+			EthFilter::new(
+				eth_client.clone(),
+				frontier_backend.clone(),
+				eth_pool.clone(),
+				filter_pool,
+				500_usize,
+				max_past_logs,
+				max_block_range,
+				block_data_cache.clone(),
+				logs_journal.clone(),
+			)
+			.into_rpc(),
+		)?;
+	}
+
+	module.merge(
+		EthPubSub::new(
+			eth_pool,
+			eth_client.clone(),
+			sync,
+			subscription_task_executor,
+			storage_override,
+			pubsub_notification_sinks,
+			logs_journal,
+		)
+		.into_rpc(),
+	)?;
+
+	module.merge(Net::new(eth_client.clone(), network, true).into_rpc())?;
+	module.merge(Web3::new(eth_client).into_rpc())?;
 
 	Ok(module)
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -245,7 +245,7 @@ pub fn new_full<
 	fc_mapping_sync::set_max_pending_notifications_per_subscriber(512);
 	let pubsub_notification_sinks: fc_mapping_sync::EthereumBlockNotificationSinks<
 		fc_mapping_sync::EthereumBlockNotification<Block>,
-	> = Default::default();
+	> = fc_mapping_sync::EthereumBlockNotificationSinks::default();
 	let pubsub_notification_sinks = Arc::new(pubsub_notification_sinks);
 
 	// Use the Ethereum-style subscription id provider.

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -11,14 +11,23 @@ use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sha256pow::Sha256DoubleHashAlgorithm;
 use solochain_template_runtime::{self, apis::RuntimeApi, opaque::Block, AccountId};
 use sp_core::U256;
-use std::{sync::Arc, time::Duration};
+use std::{path::Path, sync::Arc, time::Duration};
 
-pub(crate) type FullClient = sc_service::TFullClient<
+use fc_storage::{StorageOverride, StorageOverrideHandler};
+
+use crate::eth::{
+	db_config_dir, new_frontier_partial, spawn_frontier_tasks, FrontierBackend,
+	FrontierPartialComponents,
+};
+
+/// Full client type.
+pub type FullClient = sc_service::TFullClient<
 	Block,
 	RuntimeApi,
 	sc_executor::WasmExecutor<HostFunctions>,
 >;
-type FullBackend = sc_service::TFullBackend<Block>;
+/// Full backend type.
+pub type FullBackend = sc_service::TFullBackend<Block>;
 type FullSelectChain = LongestChain<FullBackend, Block>;
 
 /// Host functions exposed to the runtime.
@@ -44,6 +53,8 @@ pub type Service = sc_service::PartialComponents<
 		GrandpaBlockImport<FullBackend, Block, FullClient, FullSelectChain>,
 		LinkHalf<Block, FullClient, FullSelectChain>,
 		Option<Telemetry>,
+		FrontierBackend,
+		Arc<dyn StorageOverride<Block>>,
 	),
 >;
 
@@ -114,6 +125,16 @@ pub fn new_partial(config: &Configuration) -> Result<Service, ServiceError> {
 		config.prometheus_registry(),
 	)?;
 
+	// Frontier KV backend + storage override (used by Eth-RPC and mapping-sync).
+	let storage_override: Arc<dyn StorageOverride<Block>> = Arc::new(
+		StorageOverrideHandler::<Block, FullClient, FullBackend>::new(client.clone()),
+	);
+	let frontier_backend = FrontierBackend::KeyValue(Arc::new(fc_db::kv::Backend::open(
+		Arc::clone(&client),
+		&config.database,
+		Path::new(&db_config_dir(config)),
+	)?));
+
 	Ok(sc_service::PartialComponents {
 		client,
 		backend,
@@ -122,7 +143,7 @@ pub fn new_partial(config: &Configuration) -> Result<Service, ServiceError> {
 		keystore_container,
 		select_chain,
 		transaction_pool,
-		other: (grandpa_block_import, grandpa_link, telemetry),
+		other: (grandpa_block_import, grandpa_link, telemetry, frontier_backend, storage_override),
 	})
 }
 
@@ -130,7 +151,7 @@ pub fn new_partial(config: &Configuration) -> Result<Service, ServiceError> {
 pub fn new_full<
 	N: sc_network::NetworkBackend<Block, <Block as sp_runtime::traits::Block>::Hash>,
 >(
-	config: Configuration,
+	mut config: Configuration,
 	miner_account: Option<AccountId>,
 ) -> Result<TaskManager, ServiceError> {
 	let sc_service::PartialComponents {
@@ -141,7 +162,7 @@ pub fn new_full<
 		keystore_container,
 		select_chain,
 		transaction_pool,
-		other: (grandpa_block_import, grandpa_link, mut telemetry),
+		other: (grandpa_block_import, grandpa_link, mut telemetry, frontier_backend, storage_override),
 	} = new_partial(&config)?;
 
 	let mut net_config = sc_network::config::FullNetworkConfiguration::<
@@ -217,6 +238,21 @@ pub fn new_full<
 		Some(shared_authority_set.clone()),
 	);
 
+	// ---------- Frontier (Ethereum-compatible RPC) wiring ----------
+	let FrontierPartialComponents { filter_pool, fee_history_cache, fee_history_cache_limit } =
+		new_frontier_partial();
+
+	fc_mapping_sync::set_max_pending_notifications_per_subscriber(512);
+	let pubsub_notification_sinks: fc_mapping_sync::EthereumBlockNotificationSinks<
+		fc_mapping_sync::EthereumBlockNotification<Block>,
+	> = Default::default();
+	let pubsub_notification_sinks = Arc::new(pubsub_notification_sinks);
+
+	// Use the Ethereum-style subscription id provider.
+	config.rpc.id_provider = Some(Box::new(fc_rpc::EthereumSubIdProvider));
+
+	let frontier_backend = Arc::new(frontier_backend);
+
 	let rpc_extensions_builder = {
 		let client = client.clone();
 		let pool = transaction_pool.clone();
@@ -225,7 +261,53 @@ pub fn new_full<
 		let justification_stream = justification_stream.clone();
 		let finality_proof_provider = finality_proof_provider.clone();
 
+		let network = network.clone();
+		let sync_service = sync_service.clone();
+		let filter_pool = filter_pool.clone();
+		let fee_history_cache = fee_history_cache.clone();
+		let storage_override = storage_override.clone();
+		let frontier_backend = frontier_backend.clone();
+		let pubsub_notification_sinks = pubsub_notification_sinks.clone();
+
+		let block_data_cache = Arc::new(fc_rpc::EthBlockDataCacheTask::new(
+			task_manager.spawn_handle(),
+			storage_override.clone(),
+			50,
+			50,
+			prometheus_registry.clone(),
+		));
+
+		// PoW chain: pending state inherents are just timestamp.
+		let pending_create_inherent_data_providers = move |_, ()| async move {
+			Ok(sp_timestamp::InherentDataProvider::from_system_time())
+		};
+
 		Box::new(move |subscription_executor: sc_rpc::SubscriptionTaskExecutor| {
+			let eth_deps = crate::rpc::EthDeps::<_, _, fp_rpc::NoTransactionConverter, _> {
+				client: client.clone(),
+				pool: pool.clone(),
+				converter: None,
+				is_authority,
+				enable_dev_signer: false,
+				network: network.clone(),
+				sync: sync_service.clone(),
+				frontier_backend: match &*frontier_backend {
+					fc_db::Backend::KeyValue(b) => b.clone() as Arc<dyn fc_api::Backend<Block>>,
+					fc_db::Backend::Sql(b) => b.clone() as Arc<dyn fc_api::Backend<Block>>,
+				},
+				storage_override: storage_override.clone(),
+				block_data_cache: block_data_cache.clone(),
+				filter_pool: filter_pool.clone(),
+				fee_history_cache: fee_history_cache.clone(),
+				fee_history_cache_limit,
+				max_past_logs: 10_000,
+				max_block_range: 1024,
+				execute_gas_limit_multiplier: 10,
+				rpc_allow_unprotected_txs: false,
+				forced_parent_hashes: None,
+				pending_create_inherent_data_providers,
+			};
+
 			let deps = crate::rpc::FullDeps {
 				client: client.clone(),
 				pool: pool.clone(),
@@ -233,11 +315,13 @@ pub fn new_full<
 					shared_voter_state: shared_voter_state.clone(),
 					shared_authority_set: shared_authority_set.clone(),
 					justification_stream: justification_stream.clone(),
-					subscription_executor,
+					subscription_executor: subscription_executor.clone(),
 					finality_provider: finality_proof_provider.clone(),
 				},
+				eth: eth_deps,
 			};
-			crate::rpc::create_full(deps).map_err(Into::into)
+			crate::rpc::create_full(deps, subscription_executor, pubsub_notification_sinks.clone())
+				.map_err(Into::into)
 		})
 	};
 
@@ -248,7 +332,7 @@ pub fn new_full<
 		task_manager: &mut task_manager,
 		transaction_pool: transaction_pool.clone(),
 		rpc_builder: rpc_extensions_builder,
-		backend,
+		backend: backend.clone(),
 		system_rpc_tx,
 		tx_handler_controller,
 		sync_service: sync_service.clone(),
@@ -256,6 +340,20 @@ pub fn new_full<
 		telemetry: telemetry.as_mut(),
 		tracing_execute_block: None,
 	})?;
+
+	// Spawn the Frontier mapping-sync / filter-pool / fee-history background tasks.
+	spawn_frontier_tasks(
+		&task_manager,
+		client.clone(),
+		backend,
+		frontier_backend,
+		filter_pool,
+		storage_override,
+		fee_history_cache,
+		fee_history_cache_limit,
+		sync_service.clone(),
+		pubsub_notification_sinks,
+	);
 
 	// GRANDPA voter / observer.
 	let grandpa_config = sc_consensus_grandpa::Config {

--- a/scripts/h160-to-ss58.sh
+++ b/scripts/h160-to-ss58.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# h160-to-ss58.sh
+#
+# Convert an Ethereum H160 address to the Substrate AccountId32 / SS58 address
+# used by this runtime's pallet-evm `HashedAddressMapping<BlakeTwo256>`.
+#
+# Mapping rule:
+#     account32 = blake2_256("evm:" ++ h160_bytes)
+#
+# Default SS58 prefix: 42 (this runtime's `SS58Prefix`).
+#
+# Usage:
+#     scripts/h160-to-ss58.sh <0xH160> [ss58_prefix]
+#
+# Examples:
+#     scripts/h160-to-ss58.sh 0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac
+#     scripts/h160-to-ss58.sh 0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac 42
+
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "Usage: $0 <0xH160> [ss58_prefix]" >&2
+    exit 1
+fi
+
+H160_RAW="${1#0x}"
+SS58_PREFIX="${2:-42}"
+
+if [[ ! "$H160_RAW" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    echo "Error: H160 must be 40 hex chars (with optional 0x prefix)" >&2
+    exit 1
+fi
+
+PUBKEY_HEX=$(python3 - "$H160_RAW" <<'PY'
+import sys, hashlib
+h160 = bytes.fromhex(sys.argv[1])
+print(hashlib.blake2b(b"evm:" + h160, digest_size=32).hexdigest())
+PY
+)
+
+echo "H160:               0x${H160_RAW,,}"
+echo "AccountId32 (hex):  0x${PUBKEY_HEX}"
+
+if command -v subkey >/dev/null 2>&1; then
+    SS58=$(subkey inspect --network "${SS58_PREFIX}" "0x${PUBKEY_HEX}" 2>/dev/null \
+        | awk -F': *' '/SS58 Address/ {print $2; exit}')
+    if [[ -n "${SS58:-}" ]]; then
+        echo "SS58 (prefix=${SS58_PREFIX}): ${SS58}"
+        exit 0
+    fi
+fi
+
+# Fallback: derive SS58 in pure Python (no subkey required).
+python3 - "$PUBKEY_HEX" "$SS58_PREFIX" <<'PY'
+import sys, hashlib
+
+PUBKEY = bytes.fromhex(sys.argv[1])
+PREFIX = int(sys.argv[2])
+
+# SS58 prefix encoding (single or two-byte form).
+if PREFIX < 64:
+    prefix_bytes = bytes([PREFIX])
+elif PREFIX < 16384:
+    lo = ((PREFIX & 0b1111_1100) >> 2) | 0b0100_0000
+    hi = (PREFIX >> 8) | ((PREFIX & 0b0000_0011) << 6)
+    prefix_bytes = bytes([lo, hi])
+else:
+    raise SystemExit("ss58 prefix out of range")
+
+payload = prefix_bytes + PUBKEY
+checksum = hashlib.blake2b(b"SS58PRE" + payload, digest_size=64).digest()[:2]
+raw = payload + checksum
+
+ALPHABET = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+n = int.from_bytes(raw, "big")
+out = bytearray()
+while n > 0:
+    n, r = divmod(n, 58)
+    out.append(ALPHABET[r])
+for b in raw:
+    if b == 0:
+        out.append(ALPHABET[0])
+    else:
+        break
+print(f"SS58 (prefix={PREFIX}): {out[::-1].decode()}")
+PY


### PR DESCRIPTION
## Summary

Integrates Frontier's Ethereum-compatible JSON-RPC into the PoW node so that MetaMask and other Ethereum tooling can interact with this chain through the standard `eth_*` / `net_*` / `web3_*` namespaces.

## Changes

- **Cargo.toml**: enable `rocksdb` feature on `fc-db`; expose `sc-network-sync` to the node crate.
- **node/src/eth.rs** *(new)*: KV-backed `FrontierBackend` plumbing (`db_config_dir`, `new_frontier_partial`, `spawn_frontier_tasks` for mapping-sync / filter-pool / fee-history).
- **node/src/rpc.rs**: generic `create_full` with `EthDeps`; registers `Eth`, `EthFilter`, `EthPubSub`, `Net` and `Web3` modules alongside the existing System / TransactionPayment / Grandpa modules.
- **node/src/service.rs**:
  - opens the KV `FrontierBackend` in `new_partial`,
  - builds pubsub sinks, storage override, `EthBlockDataCacheTask` and a timestamp-only `pending_create_inherent_data_providers` in `new_full`,
  - spawns the frontier tasks alongside the PoW worker.
- **node/src/main.rs**: registers the new `eth` module.

`fp_rpc::NoTransactionConverter` is used because this runtime does not expose a `TransactionConverter` struct. Pending-state inherents are timestamp-only since this is a PoW chain (no Aura).

Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ethereum (EVM) compatibility: Frontier-compatible RPC endpoints, pub/sub support, and background tasks for filters, mapping-sync, and fee-history.
  * New CLI tool to convert Ethereum H160 addresses to native SS58 addresses.

* **Chores**
  * Updated workspace and node dependencies to enable Frontier/EVM functionality.
  * Refactored service and RPC initialization to integrate Frontier components and runtime pieces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/motoZ-crypto/crypto-node/pull/84)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->