### PR TITLE
Expose native UNIT as an ERC20 precompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,6 +1481,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,7 +2436,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "unicode-xid",
 ]
 
 [[package]]
@@ -4268,6 +4278,12 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hickory-proto"
@@ -6975,7 +6991,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hash-db",
- "hex-literal",
+ "hex-literal 0.4.1",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
@@ -6994,6 +7010,26 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
+]
+
+[[package]]
+name = "pallet-evm-precompile-balances-erc20"
+version = "0.1.0"
+dependencies = [
+ "fp-evm",
+ "frame-support",
+ "frame-system",
+ "hex-literal 1.1.0",
+ "libsecp256k1",
+ "pallet-balances",
+ "pallet-evm",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "precompile-utils",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7757,7 +7793,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9d053
 dependencies = [
  "bitvec",
  "bounded-collections",
- "hex-literal",
+ "hex-literal 0.4.1",
  "log",
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -8056,14 +8092,14 @@ dependencies = [
 name = "precompile-utils"
 version = "0.1.0"
 dependencies = [
- "derive_more 1.0.0",
+ "derive_more 2.1.1",
  "environmental",
  "evm",
  "fp-evm",
  "frame-support",
  "frame-system",
  "hex",
- "hex-literal",
+ "hex-literal 1.1.0",
  "impl-trait-for-tuples",
  "log",
  "num_enum",
@@ -8105,7 +8141,7 @@ dependencies = [
  "fp-evm",
  "frame-support",
  "frame-system",
- "hex-literal",
+ "hex-literal 1.1.0",
  "pallet-balances",
  "pallet-evm",
  "pallet-timestamp",
@@ -9685,7 +9721,7 @@ name = "sc-informant"
 version = "0.55.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
 dependencies = [
- "console",
+ "console 0.15.11",
  "futures",
  "futures-timer",
  "log",
@@ -10249,7 +10285,7 @@ version = "45.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
 dependencies = [
  "chrono",
- "console",
+ "console 0.15.11",
  "is-terminal",
  "libc",
  "log",
@@ -10933,9 +10969,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.7.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+checksum = "04d93e861ede2e497b47833469b8ec9d5c07fa4c78ce7a00f6eb7dd8168b4b3f"
 dependencies = [
  "bstr",
  "unicode-segmentation",
@@ -10943,11 +10979,11 @@ dependencies = [
 
 [[package]]
 name = "similar-asserts"
-version = "1.7.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
+checksum = "997e6ca38e97437973fc9f7f50a50d1274cacd874341a4960fea90067291038c"
 dependencies = [
- "console",
+ "console 0.16.3",
  "similar",
 ]
 
@@ -11241,6 +11277,7 @@ dependencies = [
  "pallet-ethereum",
  "pallet-evm",
  "pallet-evm-chain-id",
+ "pallet-evm-precompile-balances-erc20",
  "pallet-evm-precompile-bn128",
  "pallet-evm-precompile-modexp",
  "pallet-evm-precompile-sha3fips",
@@ -12198,7 +12235,7 @@ dependencies = [
  "derive-where",
  "environmental",
  "frame-support",
- "hex-literal",
+ "hex-literal 0.4.1",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
@@ -12406,7 +12443,7 @@ dependencies = [
  "array-bytes 6.2.3",
  "build-helper",
  "cargo_metadata",
- "console",
+ "console 0.15.11",
  "filetime",
  "frame-metadata",
  "jobserver",
@@ -14381,6 +14418,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "pallets/difficulty",
     "pallets/reward",
     "pallets/validator",
+    "precompiles/balances-erc20",
     "precompiles/utils",
     "precompiles/utils/macro",
     "precompiles/utils/tests-external",
@@ -43,10 +44,10 @@ codec = { version = "3.7.4", default-features = false, package = "parity-scale-c
 environmental = { version = "1.1.4", default-features = false }
 num_enum = { version = "0.7.6", default-features = false }
 impl-trait-for-tuples = "0.2.3"
-derive_more = { version = "1.0", default-features = false }
+derive_more = { version = "2.1.1", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
-hex-literal = "0.4.1"
-similar-asserts = "1.7.0"
+hex-literal = "1.1.0"
+similar-asserts = "2.0.0"
 evm = { git = "https://github.com/rust-ethereum/evm.git", branch = "v0.x", default-features = false }
 frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 frame-metadata-hash-extension = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }

--- a/precompiles/balances-erc20/Cargo.toml
+++ b/precompiles/balances-erc20/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "pallet-evm-precompile-balances-erc20"
+description = "EVM precompile exposing the native balance pallet as an ERC20 token, with a withdraw helper for arbitrary AccountId32 destinations."
+version = "0.1.0"
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+codec = { features = ["derive"], workspace = true }
+frame-support.workspace = true
+frame-system.workspace = true
+pallet-evm = { workspace = true, features = ["forbid-evm-reentrancy"] }
+pallet-timestamp.workspace = true
+fp-evm.workspace = true
+precompile-utils = { path = "../utils", default-features = false }
+sp-core = { features = ["serde"], workspace = true }
+sp-io.workspace = true
+sp-runtime.workspace = true
+scale-info = { features = ["derive"], workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"fp-evm/std",
+	"pallet-evm/std",
+	"pallet-timestamp/std",
+	"precompile-utils/std",
+	"scale-info/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-runtime/std",
+]
+
+[dev-dependencies]
+hex-literal = "1.1.0"
+libsecp256k1 = "0.7"
+pallet-balances = { workspace = true, default-features = true }
+pallet-timestamp = { workspace = true, default-features = true }
+precompile-utils = { path = "../utils", features = ["std", "testing"] }

--- a/precompiles/balances-erc20/src/eip2612.rs
+++ b/precompiles/balances-erc20/src/eip2612.rs
@@ -1,0 +1,167 @@
+// EIP-2612 permit (gasless approvals) implementation.
+//
+// Spec: https://eips.ethereum.org/EIPS/eip-2612
+//
+// Anyone may submit `permit(...)` on behalf of the owner; we only check
+// that the EIP-712 signature recovers to the owner's address.
+
+use core::marker::PhantomData;
+
+use fp_evm::PrecompileHandle;
+use precompile_utils::prelude::*;
+use sp_core::{Get, H160, H256, U256};
+
+use crate::{Allowances, Erc20Metadata, Nonces, SELECTOR_LOG_APPROVAL};
+
+/// EIP-2612 contract version string used in the EIP-712 domain separator.
+const PERMIT_VERSION: &[u8] = b"1";
+
+pub struct Eip2612<R, Metadata>(PhantomData<(R, Metadata)>);
+
+impl<R, Metadata> Eip2612<R, Metadata>
+where
+	R: pallet_evm::Config + pallet_timestamp::Config<Moment = u64>,
+	Metadata: Erc20Metadata + 'static,
+{
+	pub fn nonces(_handle: &mut impl PrecompileHandle, owner: Address) -> EvmResult<U256> {
+		Ok(Nonces::get(H160::from(owner)))
+	}
+
+	pub fn domain_separator(handle: &mut impl PrecompileHandle) -> EvmResult<H256> {
+		let address = handle.context().address;
+		let chain_id = <R as pallet_evm::Config>::ChainId::get();
+		Ok(H256(compute_domain_separator(address, chain_id, Metadata::NAME.as_bytes())))
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	pub fn permit(
+		handle: &mut impl PrecompileHandle,
+		owner: Address,
+		spender: Address,
+		value: U256,
+		deadline: U256,
+		v: u8,
+		r: H256,
+		s: H256,
+	) -> EvmResult {
+		handle.record_log_costs_manual(3, 32)?;
+
+		let owner: H160 = owner.into();
+		let spender: H160 = spender.into();
+
+		// Deadline is interpreted in seconds (per EIP-2612). Compare with
+		// the current block timestamp (millis) divided by 1000.
+		let now_ms: u64 = pallet_timestamp::Pallet::<R>::get();
+		let now_secs = now_ms.saturating_div(1000);
+		let deadline_secs: u64 = deadline.try_into().unwrap_or(u64::MAX);
+		if now_secs > deadline_secs {
+			return Err(revert("Permit expired"));
+		}
+
+		let nonce = Nonces::get(owner);
+		let address = handle.context().address;
+		let chain_id = <R as pallet_evm::Config>::ChainId::get();
+		let ds = compute_domain_separator(address, chain_id, Metadata::NAME.as_bytes());
+		let struct_hash = compute_permit_struct_hash(owner, spender, value, nonce, deadline);
+		let digest = compute_eip712_digest(&ds, &struct_hash);
+
+		let recovered = ecrecover(&digest, v, &r.0, &s.0).ok_or_else(|| revert("Invalid permit"))?;
+		if recovered != owner {
+			return Err(revert("Invalid permit"));
+		}
+
+		// Bump nonce *before* writing the allowance to make replay impossible.
+		Nonces::insert(owner, nonce.saturating_add(U256::one()));
+		Allowances::insert(owner, spender, value);
+
+		log3(
+			address,
+			SELECTOR_LOG_APPROVAL,
+			owner,
+			spender,
+			solidity::encode_event_data(value),
+		)
+		.record(handle)?;
+
+		Ok(())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EIP-712 helpers
+// ---------------------------------------------------------------------------
+
+/// `keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")`
+fn eip712_domain_typehash() -> [u8; 32] {
+	sp_io::hashing::keccak_256(
+		b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)",
+	)
+}
+
+/// `keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")`
+fn permit_typehash() -> [u8; 32] {
+	sp_io::hashing::keccak_256(
+		b"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)",
+	)
+}
+
+/// Build the EIP-712 domain separator for this precompile instance.
+///
+/// `name` is the ERC20 token name as bytes (e.g. `b"UNIT"`).
+pub fn compute_domain_separator(verifying_contract: H160, chain_id: u64, name: &[u8]) -> [u8; 32] {
+	let mut buf = [0u8; 32 * 5];
+	buf[0..32].copy_from_slice(&eip712_domain_typehash());
+	buf[32..64].copy_from_slice(&sp_io::hashing::keccak_256(name));
+	buf[64..96].copy_from_slice(&sp_io::hashing::keccak_256(PERMIT_VERSION));
+	let cid = U256::from(chain_id).to_big_endian();
+	buf[96..128].copy_from_slice(&cid);
+	// Address is left-padded with 12 zero bytes inside its 32-byte slot.
+	buf[128 + 12..160].copy_from_slice(verifying_contract.as_bytes());
+	sp_io::hashing::keccak_256(&buf)
+}
+
+/// `keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonce, deadline))`
+pub fn compute_permit_struct_hash(
+	owner: H160,
+	spender: H160,
+	value: U256,
+	nonce: U256,
+	deadline: U256,
+) -> [u8; 32] {
+	let mut buf = [0u8; 32 * 6];
+	buf[0..32].copy_from_slice(&permit_typehash());
+	buf[32 + 12..64].copy_from_slice(owner.as_bytes());
+	buf[64 + 12..96].copy_from_slice(spender.as_bytes());
+	buf[96..128].copy_from_slice(&value.to_big_endian());
+	buf[128..160].copy_from_slice(&nonce.to_big_endian());
+	buf[160..192].copy_from_slice(&deadline.to_big_endian());
+	sp_io::hashing::keccak_256(&buf)
+}
+
+/// `keccak256("\x19\x01" || domain_separator || struct_hash)`
+pub fn compute_eip712_digest(domain_separator: &[u8; 32], struct_hash: &[u8; 32]) -> [u8; 32] {
+	let mut buf = [0u8; 2 + 32 + 32];
+	buf[0] = 0x19;
+	buf[1] = 0x01;
+	buf[2..34].copy_from_slice(domain_separator);
+	buf[34..66].copy_from_slice(struct_hash);
+	sp_io::hashing::keccak_256(&buf)
+}
+
+/// Recover the signer address from an EIP-712 digest.
+fn ecrecover(digest: &[u8; 32], v: u8, r: &[u8; 32], s: &[u8; 32]) -> Option<H160> {
+	let recovery_id = match v {
+		27 => 0u8,
+		28 => 1u8,
+		// Some wallets sign with raw 0/1 — accept those too.
+		0 | 1 => v,
+		_ => return None,
+	};
+	let mut sig = [0u8; 65];
+	sig[..32].copy_from_slice(r);
+	sig[32..64].copy_from_slice(s);
+	sig[64] = recovery_id;
+	let pubkey = sp_io::crypto::secp256k1_ecdsa_recover(&sig, digest).ok()?;
+	let hash = sp_io::hashing::keccak_256(&pubkey);
+	Some(H160::from_slice(&hash[12..]))
+}

--- a/precompiles/balances-erc20/src/lib.rs
+++ b/precompiles/balances-erc20/src/lib.rs
@@ -1,0 +1,412 @@
+//! ERC20 facade over the runtime's native balance pallet.
+//!
+//! Deployed at `0x0000000000000000000000000000000000000802` (matching the
+//! Moonbeam / 3Dpass convention). Lets EVM-side users (MetaMask, Solidity
+//! contracts) read and move the chain's native token without leaving the
+//! EVM environment.
+//!
+//! ## Address mapping
+//!
+//! Funds shown by `balanceOf` are the free balance of the substrate account
+//! that the configured [`pallet_evm::Config::AddressMapping`] derives from
+//! the H160 (with the default `HashedAddressMapping`, this is
+//! `blake2_256("evm:" ++ h160)`).
+//!
+//! ## Functions
+//!
+//! Standard ERC20: `name`, `symbol`, `decimals`, `totalSupply`, `balanceOf`,
+//! `transfer`, `allowance`, `approve`, `transferFrom`.
+//!
+//! Bridge helper: `withdraw(bytes32 dest, uint256 amount)` lets an EVM
+//! caller move funds from its mirror substrate account to an arbitrary
+//! `AccountId32` destination.
+//!
+//! WETH9 deposit: a value-bearing call with empty calldata, the explicit
+//! `deposit()` selector, or any unknown selector with attached value, is
+//! treated as a deposit (refund pattern; see `Erc20BalancesPrecompile::deposit`).
+//!
+//! EIP-2612 permit: `nonces`, `DOMAIN_SEPARATOR`, `permit` for gasless
+//! approvals.
+//!
+//! ## Allowances
+//!
+//! Allowances are kept in a precompile-owned storage map keyed under the
+//! pseudo-pallet prefix `EvmBalancesErc20`. They are not part of any pallet
+//! metadata but are deterministic and can be queried by raw state reads.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+mod eip2612;
+
+use core::marker::PhantomData;
+
+use fp_evm::PrecompileHandle;
+use frame_support::{
+	storage::types::{StorageDoubleMap, StorageMap, ValueQuery},
+	traits::{
+		tokens::{currency::Currency, ExistenceRequirement},
+		StorageInstance,
+	},
+	Blake2_128Concat,
+};
+use pallet_evm::AddressMapping;
+use precompile_utils::prelude::*;
+use sp_core::{H160, H256, U256};
+use sp_runtime::traits::Zero;
+
+pub use eip2612::{compute_domain_separator, compute_eip712_digest, compute_permit_struct_hash, Eip2612};
+
+/// Compile-time ERC20 metadata injected by the runtime.
+///
+/// Mirrors Moonbeam's `Erc20Metadata` so a single precompile can serve
+/// multiple ERC20 facades (different name/symbol/decimals) by varying the
+/// `Metadata` type parameter.
+pub trait Erc20Metadata {
+	/// Token name returned by `name()`.
+	const NAME: &'static str;
+	/// Token symbol returned by `symbol()`.
+	const SYMBOL: &'static str;
+	/// Token decimals returned by `decimals()`. Must match the runtime's
+	/// `Balance` decimal layout.
+	const DECIMALS: u8;
+}
+
+/// Selector of the `Transfer(address,address,uint256)` log topic.
+pub const SELECTOR_LOG_TRANSFER: [u8; 32] =
+	keccak256!("Transfer(address,address,uint256)");
+/// Selector of the `Approval(address,address,uint256)` log topic.
+pub const SELECTOR_LOG_APPROVAL: [u8; 32] =
+	keccak256!("Approval(address,address,uint256)");
+/// Selector of the `Deposit(address,uint256)` log topic.
+pub const SELECTOR_LOG_DEPOSIT: [u8; 32] = keccak256!("Deposit(address,uint256)");
+/// Selector of the custom `Withdrawal(address,bytes32,uint256)` log topic.
+///
+/// Differs from the WETH9 `Withdrawal(address,uint256)` topic because our
+/// `withdraw` helper takes a substrate destination rather than implicitly
+/// using `msg.sender`.
+pub const SELECTOR_LOG_WITHDRAWAL: [u8; 32] =
+	keccak256!("Withdrawal(address,bytes32,uint256)");
+
+// Storage prefix for the allowance map. Uses an ad-hoc `StorageInstance`
+// rather than a pallet so we don't need a `construct_runtime!` entry; the
+// map still lives at a deterministic location in state.
+pub struct AllowancesPrefix;
+impl StorageInstance for AllowancesPrefix {
+	const STORAGE_PREFIX: &'static str = "Allowances";
+	fn pallet_prefix() -> &'static str {
+		"EvmBalancesErc20"
+	}
+}
+
+/// `(owner, spender) -> allowance`. ValueQuery returns 0 when missing.
+pub type Allowances = StorageDoubleMap<
+	AllowancesPrefix,
+	Blake2_128Concat,
+	H160,
+	Blake2_128Concat,
+	H160,
+	U256,
+	ValueQuery,
+>;
+
+// Storage prefix for the EIP-2612 nonces map. Same convention as
+// `AllowancesPrefix`: lives under a stable pseudo-pallet prefix so that
+// indexers can read it deterministically.
+pub struct NoncesPrefix;
+impl StorageInstance for NoncesPrefix {
+	const STORAGE_PREFIX: &'static str = "Nonces";
+	fn pallet_prefix() -> &'static str {
+		"EvmBalancesErc20"
+	}
+}
+
+/// `owner -> nonce`. ValueQuery returns 0 for first-time owners.
+pub type Nonces = StorageMap<NoncesPrefix, Blake2_128Concat, H160, U256, ValueQuery>;
+
+type CurrencyOf<R> = <R as pallet_evm::Config>::Currency;
+type AccountIdOf<R> = pallet_evm::AccountIdOf<R>;
+type BalanceOf<R> = <CurrencyOf<R> as Currency<AccountIdOf<R>>>::Balance;
+
+/// EVM precompile exposing native balances as ERC20.
+pub struct Erc20BalancesPrecompile<R, Metadata>(PhantomData<(R, Metadata)>);
+
+#[precompile_utils::precompile]
+impl<R, Metadata> Erc20BalancesPrecompile<R, Metadata>
+where
+	R: pallet_evm::Config + pallet_timestamp::Config<Moment = u64>,
+	Metadata: Erc20Metadata + 'static,
+	CurrencyOf<R>: Currency<AccountIdOf<R>>,
+	AccountIdOf<R>: From<[u8; 32]>,
+	BalanceOf<R>: TryFrom<U256> + Into<U256>,
+{
+	#[precompile::public("name()")]
+	#[precompile::view]
+	fn name(_handle: &mut impl PrecompileHandle) -> EvmResult<UnboundedBytes> {
+		Ok(UnboundedBytes::from(Metadata::NAME.as_bytes()))
+	}
+
+	#[precompile::public("symbol()")]
+	#[precompile::view]
+	fn symbol(_handle: &mut impl PrecompileHandle) -> EvmResult<UnboundedBytes> {
+		Ok(UnboundedBytes::from(Metadata::SYMBOL.as_bytes()))
+	}
+
+	#[precompile::public("decimals()")]
+	#[precompile::view]
+	fn decimals(_handle: &mut impl PrecompileHandle) -> EvmResult<u8> {
+		Ok(Metadata::DECIMALS)
+	}
+
+	#[precompile::public("totalSupply()")]
+	#[precompile::view]
+	fn total_supply(_handle: &mut impl PrecompileHandle) -> EvmResult<U256> {
+		Ok(CurrencyOf::<R>::total_issuance().into())
+	}
+
+	#[precompile::public("balanceOf(address)")]
+	#[precompile::view]
+	fn balance_of(_handle: &mut impl PrecompileHandle, owner: Address) -> EvmResult<U256> {
+		let owner: H160 = owner.into();
+		let account = <R as pallet_evm::Config>::AddressMapping::into_account_id(owner);
+		Ok(CurrencyOf::<R>::free_balance(&account).into())
+	}
+
+	#[precompile::public("allowance(address,address)")]
+	#[precompile::view]
+	fn allowance(
+		_handle: &mut impl PrecompileHandle,
+		owner: Address,
+		spender: Address,
+	) -> EvmResult<U256> {
+		Ok(Allowances::get(H160::from(owner), H160::from(spender)))
+	}
+
+	#[precompile::public("approve(address,uint256)")]
+	fn approve(
+		handle: &mut impl PrecompileHandle,
+		spender: Address,
+		value: U256,
+	) -> EvmResult<bool> {
+		handle.record_log_costs_manual(3, 32)?;
+
+		let spender: H160 = spender.into();
+		let owner = handle.context().caller;
+
+		Allowances::insert(owner, spender, value);
+
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_APPROVAL,
+			owner,
+			spender,
+			solidity::encode_event_data(value),
+		)
+		.record(handle)?;
+
+		Ok(true)
+	}
+
+	#[precompile::public("transfer(address,uint256)")]
+	fn transfer(
+		handle: &mut impl PrecompileHandle,
+		to: Address,
+		value: U256,
+	) -> EvmResult<bool> {
+		handle.record_log_costs_manual(3, 32)?;
+
+		let to: H160 = to.into();
+		let from = handle.context().caller;
+
+		do_transfer::<R>(from, to, value)?;
+
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_TRANSFER,
+			from,
+			to,
+			solidity::encode_event_data(value),
+		)
+		.record(handle)?;
+
+		Ok(true)
+	}
+
+	#[precompile::public("transferFrom(address,address,uint256)")]
+	fn transfer_from(
+		handle: &mut impl PrecompileHandle,
+		from: Address,
+		to: Address,
+		value: U256,
+	) -> EvmResult<bool> {
+		handle.record_log_costs_manual(3, 32)?;
+
+		let from: H160 = from.into();
+		let to: H160 = to.into();
+		let spender = handle.context().caller;
+
+		// If owner == spender, skip the allowance check (matches the
+		// canonical OpenZeppelin ERC20 behaviour).
+		if from != spender {
+			let current = Allowances::get(from, spender);
+			let new_allowance = current
+				.checked_sub(value)
+				.ok_or_else(|| revert("ERC20: insufficient allowance"))?;
+			Allowances::insert(from, spender, new_allowance);
+		}
+
+		do_transfer::<R>(from, to, value)?;
+
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_TRANSFER,
+			from,
+			to,
+			solidity::encode_event_data(value),
+		)
+		.record(handle)?;
+
+		Ok(true)
+	}
+
+	/// `withdraw(bytes32 dest, uint256 amount)` — moves `amount` from the
+	/// caller's mirror account to the substrate account whose 32-byte
+	/// representation is `dest`.
+	#[precompile::public("withdraw(bytes32,uint256)")]
+	fn withdraw(
+		handle: &mut impl PrecompileHandle,
+		dest: H256,
+		value: U256,
+	) -> EvmResult<bool> {
+		handle.record_log_costs_manual(3, 32)?;
+
+		let caller = handle.context().caller;
+		let from = <R as pallet_evm::Config>::AddressMapping::into_account_id(caller);
+		let to: AccountIdOf<R> = dest.0.into();
+
+		let amount_t = u256_to_balance::<R>(value)?;
+		if !amount_t.is_zero() {
+			CurrencyOf::<R>::transfer(&from, &to, amount_t, ExistenceRequirement::AllowDeath)
+				.map_err(|_| revert("ERC20: transfer failed"))?;
+		}
+
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_WITHDRAWAL,
+			caller,
+			dest,
+			solidity::encode_event_data(value),
+		)
+		.record(handle)?;
+
+		Ok(true)
+	}
+
+	/// `deposit()` / fallback / receive — implements the WETH9-style
+	/// pattern where an EVM call carrying value is treated as a deposit.
+	///
+	/// The EVM has already moved `apparent_value` from the caller to this
+	/// precompile's substrate-mapped account before invoking us; we
+	/// immediately refund it so the net balance change is zero and
+	/// `balanceOf(caller)` is left untouched.
+	#[precompile::public("deposit()")]
+	#[precompile::fallback]
+	#[precompile::payable]
+	fn deposit(handle: &mut impl PrecompileHandle) -> EvmResult {
+		let caller = handle.context().caller;
+		let address = handle.context().address;
+		let value = handle.context().apparent_value;
+
+		// A zero-value deposit is a no-op selector mistake; refuse it so
+		// the caller learns rather than silently accepting an empty call.
+		if value.is_zero() {
+			return Err(revert("ERC20: cannot deposit zero"));
+		}
+
+		handle.record_log_costs_manual(2, 32)?;
+
+		let amount_t = u256_to_balance::<R>(value)?;
+		let from = <R as pallet_evm::Config>::AddressMapping::into_account_id(address);
+		let to = <R as pallet_evm::Config>::AddressMapping::into_account_id(caller);
+		CurrencyOf::<R>::transfer(&from, &to, amount_t, ExistenceRequirement::AllowDeath)
+			.map_err(|_| revert("ERC20: deposit refund failed"))?;
+
+		log2(
+			address,
+			SELECTOR_LOG_DEPOSIT,
+			caller,
+			solidity::encode_event_data(value),
+		)
+		.record(handle)?;
+
+		Ok(())
+	}
+
+	// ---------------------------------------------------------------------
+	// EIP-2612 permit
+	// ---------------------------------------------------------------------
+
+	#[precompile::public("nonces(address)")]
+	#[precompile::view]
+	fn eip2612_nonces(handle: &mut impl PrecompileHandle, owner: Address) -> EvmResult<U256> {
+		Eip2612::<R, Metadata>::nonces(handle, owner)
+	}
+
+	#[precompile::public("DOMAIN_SEPARATOR()")]
+	#[precompile::view]
+	fn eip2612_domain_separator(handle: &mut impl PrecompileHandle) -> EvmResult<H256> {
+		Eip2612::<R, Metadata>::domain_separator(handle)
+	}
+
+	#[precompile::public("permit(address,address,uint256,uint256,uint8,bytes32,bytes32)")]
+	#[allow(clippy::too_many_arguments)]
+	fn eip2612_permit(
+		handle: &mut impl PrecompileHandle,
+		owner: Address,
+		spender: Address,
+		value: U256,
+		deadline: U256,
+		v: u8,
+		r: H256,
+		s: H256,
+	) -> EvmResult {
+		Eip2612::<R, Metadata>::permit(handle, owner, spender, value, deadline, v, r, s)
+	}
+}
+
+// --- shared helpers -------------------------------------------------------
+
+pub(crate) fn do_transfer<R>(from: H160, to: H160, amount: U256) -> EvmResult<()>
+where
+	R: pallet_evm::Config,
+	CurrencyOf<R>: Currency<AccountIdOf<R>>,
+	BalanceOf<R>: TryFrom<U256>,
+{
+	let from_acc = <R as pallet_evm::Config>::AddressMapping::into_account_id(from);
+	let to_acc = <R as pallet_evm::Config>::AddressMapping::into_account_id(to);
+	let amount_t = u256_to_balance::<R>(amount)?;
+
+	if amount_t.is_zero() {
+		// Zero-value transfers must succeed without touching balances.
+		return Ok(());
+	}
+
+	CurrencyOf::<R>::transfer(&from_acc, &to_acc, amount_t, ExistenceRequirement::AllowDeath)
+		.map_err(|_| revert("ERC20: transfer failed"))?;
+	Ok(())
+}
+
+pub(crate) fn u256_to_balance<R>(amount: U256) -> EvmResult<BalanceOf<R>>
+where
+	R: pallet_evm::Config,
+	CurrencyOf<R>: Currency<AccountIdOf<R>>,
+	BalanceOf<R>: TryFrom<U256>,
+{
+	BalanceOf::<R>::try_from(amount).map_err(|_| revert("ERC20: amount overflow"))
+}

--- a/precompiles/balances-erc20/src/mock.rs
+++ b/precompiles/balances-erc20/src/mock.rs
@@ -1,0 +1,195 @@
+//! Test runtime + `PrecompileSet` wiring for the balances-erc20 precompile.
+//!
+//! Uses `precompile_utils::testing::PrecompilesTester` (via `prepare_test`)
+//! to drive the precompile, mirroring the test harness layout used by
+//! Moonbeam.
+
+use frame_support::{
+	construct_runtime, derive_impl, parameter_types,
+	traits::{ConstU128, ConstU64, FindAuthor},
+	weights::Weight,
+};
+use pallet_evm::{
+	EnsureAddressNever, EnsureAddressRoot, FrameSystemAccountProvider, HashedAddressMapping,
+	SubstrateBlockHashMapping,
+};
+use precompile_utils::precompile_set::{AddressU64, PrecompileAt, PrecompileSetBuilder};
+use sp_core::{H160, U256};
+use sp_runtime::{traits::BlakeTwo256, AccountId32, BuildStorage};
+
+use crate::{Erc20BalancesPrecompile, Erc20Metadata};
+
+pub type AccountId = AccountId32;
+pub type Balance = u128;
+pub type Block = frame_system::mocking::MockBlock<Runtime>;
+
+/// Test metadata mirroring the runtime's native UNIT token.
+pub struct NativeErc20Metadata;
+impl Erc20Metadata for NativeErc20Metadata {
+	const NAME: &'static str = "UNIT";
+	const SYMBOL: &'static str = "UNIT";
+	const DECIMALS: u8 = 18;
+}
+
+/// Auto-generated PCall enum (one variant per `#[precompile::public]`
+/// method) makes type-safe call construction in tests trivial.
+pub type PCall = crate::Erc20BalancesPrecompileCall<Runtime, NativeErc20Metadata>;
+
+construct_runtime!(
+	pub enum Runtime {
+		System: frame_system,
+		Timestamp: pallet_timestamp,
+		Balances: pallet_balances,
+		Evm: pallet_evm,
+	}
+);
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Runtime {
+	type Block = Block;
+	type AccountId = AccountId;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type Lookup = sp_runtime::traits::IdentityLookup<AccountId>;
+}
+
+parameter_types! {
+	pub const MinimumPeriod: u64 = 1;
+}
+
+impl pallet_timestamp::Config for Runtime {
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+impl pallet_balances::Config for Runtime {
+	type Balance = Balance;
+	type ExistentialDeposit = ConstU128<1>;
+	type AccountStore = System;
+}
+
+const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
+const BLOCK_STORAGE_LIMIT: u64 = 40 * 1024;
+
+parameter_types! {
+	pub BlockGasLimit: U256 = U256::from(u64::MAX);
+	pub const WeightPerGas: Weight = Weight::from_parts(20_000, 0);
+	pub GasLimitPovSizeRatio: u64 = {
+		let l = BlockGasLimit::get().min(u64::MAX.into()).low_u64();
+		l.saturating_div(MAX_POV_SIZE)
+	};
+	pub GasLimitStorageGrowthRatio: u64 = {
+		let l = BlockGasLimit::get().min(u64::MAX.into()).low_u64();
+		l.saturating_div(BLOCK_STORAGE_LIMIT)
+	};
+	pub PrecompilesValue: Precompiles<Runtime> = Precompiles::new();
+}
+
+/// `FindAuthor` returns the zero address — block-author irrelevant for the
+/// precompile under test.
+pub struct AuthorZero;
+impl FindAuthor<H160> for AuthorZero {
+	fn find_author<'a, I>(_d: I) -> Option<H160>
+	where
+		I: 'a + IntoIterator<Item = (sp_runtime::ConsensusEngineId, &'a [u8])>,
+	{
+		Some(H160::zero())
+	}
+}
+
+/// Address recorded as `code_address` and `address` in the EVM context.
+/// Matches the runtime's deployment slot (`0x0000000000000000000000000000000000000802`).
+pub const PRECOMPILE_ADDRESS: H160 = H160(hex_literal::hex!(
+	"0000000000000000000000000000000000000802"
+));
+
+/// Numeric form of [`PRECOMPILE_ADDRESS`] used by `AddressU64<2050>`.
+pub const PRECOMPILE_ADDR_U64: u64 = 0x802;
+
+/// Concrete instantiation under test.
+pub type Precompiles<R> = PrecompileSetBuilder<
+	R,
+	(PrecompileAt<AddressU64<PRECOMPILE_ADDR_U64>, Erc20BalancesPrecompile<R, NativeErc20Metadata>>,),
+>;
+
+/// New PrecompileSet instance for use with `prepare_test`.
+pub fn precompiles() -> Precompiles<Runtime> {
+	PrecompilesValue::get()
+}
+
+impl pallet_evm::Config for Runtime {
+	type AccountProvider = FrameSystemAccountProvider<Self>;
+	type FeeCalculator = ();
+	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
+	type WeightPerGas = WeightPerGas;
+	type BlockHashMapping = SubstrateBlockHashMapping<Self>;
+	type CallOrigin = EnsureAddressRoot<AccountId>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
+	type WithdrawOrigin = EnsureAddressNever<AccountId>;
+	type AddressMapping = HashedAddressMapping<BlakeTwo256>;
+	type Currency = Balances;
+	type PrecompilesType = Precompiles<Self>;
+	type PrecompilesValue = PrecompilesValue;
+	type ChainId = ConstU64<1>;
+	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
+	type Runner = pallet_evm::runner::stack::Runner<Self>;
+	type OnChargeTransaction = ();
+	type OnCreate = ();
+	type FindAuthor = AuthorZero;
+	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitStorageGrowthRatio;
+	type Timestamp = Timestamp;
+	type WeightInfo = ();
+}
+
+// -- ExtBuilder ------------------------------------------------------------
+
+#[derive(Default)]
+pub struct ExtBuilder {
+	balances: alloc::vec::Vec<(AccountId, Balance)>,
+}
+
+impl ExtBuilder {
+	pub fn with_balances(mut self, b: alloc::vec::Vec<(AccountId, Balance)>) -> Self {
+		self.balances = b;
+		self
+	}
+
+	pub fn build(self) -> sp_io::TestExternalities {
+		let mut t = frame_system::GenesisConfig::<Runtime>::default()
+			.build_storage()
+			.expect("default genesis builds");
+		pallet_balances::GenesisConfig::<Runtime> {
+			balances: self.balances,
+			..Default::default()
+		}
+		.assimilate_storage(&mut t)
+		.expect("balances genesis assimilates");
+		let mut ext = sp_io::TestExternalities::new(t);
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
+}
+
+/// Mirror account derived from an EVM caller via the runtime's
+/// `AddressMapping`.
+pub fn mirror(addr: H160) -> AccountId {
+	use pallet_evm::AddressMapping;
+	HashedAddressMapping::<BlakeTwo256>::into_account_id(addr)
+}
+
+/// Convenience H160 generator: low byte = `i`.
+pub fn h160(i: u8) -> H160 {
+	let mut bytes = [0u8; 20];
+	bytes[19] = i;
+	H160(bytes)
+}
+
+/// Convenience AccountId32 generator: every byte = `i`.
+pub fn aid(i: u8) -> AccountId {
+	AccountId32::from([i; 32])
+}

--- a/precompiles/balances-erc20/src/tests.rs
+++ b/precompiles/balances-erc20/src/tests.rs
@@ -1,0 +1,900 @@
+//! Unit tests for the balances-erc20 precompile.
+//!
+//! Uses `precompile_utils::testing::PrecompilesTester` (`prepare_test`
+//! chain API) to drive the precompile, mirroring the layout used by
+//! Moonbeam's tests.
+
+use frame_support::traits::Get;
+use libsecp256k1::{Message, PublicKey, SecretKey};
+use precompile_utils::{prelude::*, solidity, testing::*};
+use sp_core::{H160, H256, U256};
+
+use crate::{
+	compute_domain_separator, compute_eip712_digest, compute_permit_struct_hash, mock::*,
+	Allowances, Erc20Metadata, Nonces, SELECTOR_LOG_APPROVAL, SELECTOR_LOG_DEPOSIT,
+	SELECTOR_LOG_TRANSFER, SELECTOR_LOG_WITHDRAWAL,
+};
+
+const ALICE: H160 = H160(hex_literal::hex!("1000000000000000000000000000000000000001"));
+const BOB: H160 = H160(hex_literal::hex!("1000000000000000000000000000000000000002"));
+const CHARLIE: H160 = H160(hex_literal::hex!("1000000000000000000000000000000000000003"));
+
+// --- read methods ---------------------------------------------------------
+
+#[test]
+fn get_metadata_name() {
+	ExtBuilder::default().build().execute_with(|| {
+		precompiles()
+			.prepare_test(ALICE, PRECOMPILE_ADDRESS, PCall::name {})
+			.execute_returns(UnboundedBytes::from(NativeErc20Metadata::NAME.as_bytes()));
+	});
+}
+
+#[test]
+fn get_metadata_symbol() {
+	ExtBuilder::default().build().execute_with(|| {
+		precompiles()
+			.prepare_test(ALICE, PRECOMPILE_ADDRESS, PCall::symbol {})
+			.execute_returns(UnboundedBytes::from(NativeErc20Metadata::SYMBOL.as_bytes()));
+	});
+}
+
+#[test]
+fn get_metadata_decimals() {
+	ExtBuilder::default().build().execute_with(|| {
+		precompiles()
+			.prepare_test(ALICE, PRECOMPILE_ADDRESS, PCall::decimals {})
+			.execute_returns(NativeErc20Metadata::DECIMALS);
+	});
+}
+
+#[test]
+fn get_total_supply_single_account() {
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 1_000), (mirror(BOB), 500)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(ALICE, PRECOMPILE_ADDRESS, PCall::total_supply {})
+				.execute_returns(U256::from(1_500u64));
+		});
+}
+
+#[test]
+fn get_balances_known_user() {
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 7_777)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					BOB,
+					PRECOMPILE_ADDRESS,
+					PCall::balance_of { owner: Address(ALICE) },
+				)
+				.execute_returns(U256::from(7_777u64));
+		});
+}
+
+// --- transfer ------------------------------------------------------------
+
+#[test]
+fn transfer_moves_funds_and_emits_log() {
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 1_000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::transfer { to: Address(BOB), value: 400u64.into() },
+				)
+				.expect_log(log3(
+					PRECOMPILE_ADDRESS,
+					SELECTOR_LOG_TRANSFER,
+					ALICE,
+					BOB,
+					solidity::encode_event_data(U256::from(400u64)),
+				))
+				.execute_returns(true);
+
+			assert_eq!(Balances::free_balance(mirror(ALICE)), 600);
+			assert_eq!(Balances::free_balance(mirror(BOB)), 400);
+		});
+}
+
+#[test]
+fn transfer_with_zero_amount_succeeds_without_balance_change() {
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 100)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::transfer { to: Address(BOB), value: U256::zero() },
+				)
+				.execute_returns(true);
+			assert_eq!(Balances::free_balance(mirror(ALICE)), 100);
+			assert_eq!(Balances::free_balance(mirror(BOB)), 0);
+		});
+}
+
+#[test]
+fn transfer_reverts_on_insufficient_balance() {
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 10)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::transfer { to: Address(BOB), value: 1_000u64.into() },
+				)
+				.execute_reverts(|out| out == b"ERC20: transfer failed");
+			assert_eq!(Balances::free_balance(mirror(ALICE)), 10);
+		});
+}
+
+#[test]
+fn transfer_reverts_on_overflowing_amount() {
+	ExtBuilder::default().build().execute_with(|| {
+		// `Balance` is `u128`; values exceeding `u128::MAX` cannot convert.
+		let amount = U256::from(u128::MAX) + U256::one();
+		precompiles()
+			.prepare_test(
+				ALICE,
+				PRECOMPILE_ADDRESS,
+				PCall::transfer { to: Address(BOB), value: amount },
+			)
+			.execute_reverts(|out| out == b"ERC20: amount overflow");
+	});
+}
+
+// --- approve / allowance / transferFrom ----------------------------------
+
+#[test]
+fn approve_sets_allowance_and_emits_log() {
+	ExtBuilder::default().build().execute_with(|| {
+		precompiles()
+			.prepare_test(
+				ALICE,
+				PRECOMPILE_ADDRESS,
+				PCall::approve { spender: Address(BOB), value: 123u64.into() },
+			)
+			.expect_log(log3(
+				PRECOMPILE_ADDRESS,
+				SELECTOR_LOG_APPROVAL,
+				ALICE,
+				BOB,
+				solidity::encode_event_data(U256::from(123u64)),
+			))
+			.execute_returns(true);
+		assert_eq!(Allowances::get(ALICE, BOB), U256::from(123u64));
+	});
+}
+
+#[test]
+fn allowance_query_returns_stored_value() {
+	ExtBuilder::default().build().execute_with(|| {
+		Allowances::insert(ALICE, BOB, U256::from(99u64));
+		precompiles()
+			.prepare_test(
+				CHARLIE,
+				PRECOMPILE_ADDRESS,
+				PCall::allowance { owner: Address(ALICE), spender: Address(BOB) },
+			)
+			.execute_returns(U256::from(99u64));
+	});
+}
+
+#[test]
+fn transfer_from_consumes_allowance() {
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 1_000)])
+		.build()
+		.execute_with(|| {
+			Allowances::insert(ALICE, BOB, U256::from(500u64));
+			precompiles()
+				.prepare_test(
+					BOB,
+					PRECOMPILE_ADDRESS,
+					PCall::transfer_from {
+						from: Address(ALICE),
+						to: Address(CHARLIE),
+						value: 400u64.into(),
+					},
+				)
+				.execute_returns(true);
+			assert_eq!(Allowances::get(ALICE, BOB), U256::from(100u64));
+			assert_eq!(Balances::free_balance(mirror(ALICE)), 600);
+			assert_eq!(Balances::free_balance(mirror(CHARLIE)), 400);
+		});
+}
+
+#[test]
+fn transfer_from_reverts_on_insufficient_allowance() {
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 1_000)])
+		.build()
+		.execute_with(|| {
+			Allowances::insert(ALICE, BOB, U256::from(100u64));
+			precompiles()
+				.prepare_test(
+					BOB,
+					PRECOMPILE_ADDRESS,
+					PCall::transfer_from {
+						from: Address(ALICE),
+						to: Address(CHARLIE),
+						value: 200u64.into(),
+					},
+				)
+				.execute_reverts(|out| out == b"ERC20: insufficient allowance");
+			assert_eq!(Allowances::get(ALICE, BOB), U256::from(100u64));
+			assert_eq!(Balances::free_balance(mirror(ALICE)), 1_000);
+		});
+}
+
+#[test]
+fn transfer_from_with_self_skips_allowance() {
+	// When `from == spender`, the precompile does not consult the
+	// allowance map (matches OpenZeppelin's reference behaviour).
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 1_000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::transfer_from {
+						from: Address(ALICE),
+						to: Address(BOB),
+						value: 700u64.into(),
+					},
+				)
+				.execute_returns(true);
+			assert_eq!(Allowances::get(ALICE, ALICE), U256::zero());
+			assert_eq!(Balances::free_balance(mirror(BOB)), 700);
+		});
+}
+
+// --- withdraw bridge ------------------------------------------------------
+
+#[test]
+fn withdraw_moves_funds_to_substrate_account_and_emits_log() {
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 1_000)])
+		.build()
+		.execute_with(|| {
+			let dest_acc = aid(7);
+			let dest_bytes: [u8; 32] = dest_acc.clone().into();
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::withdraw { dest: H256(dest_bytes), value: 300u64.into() },
+				)
+				.expect_log(log3(
+					PRECOMPILE_ADDRESS,
+					SELECTOR_LOG_WITHDRAWAL,
+					ALICE,
+					H256(dest_bytes),
+					solidity::encode_event_data(U256::from(300u64)),
+				))
+				.execute_returns(true);
+			assert_eq!(Balances::free_balance(mirror(ALICE)), 700);
+			assert_eq!(Balances::free_balance(&dest_acc), 300);
+		});
+}
+
+#[test]
+fn withdraw_with_zero_amount_does_not_move_funds() {
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 100)])
+		.build()
+		.execute_with(|| {
+			let dest_acc = aid(8);
+			let dest_bytes: [u8; 32] = dest_acc.clone().into();
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::withdraw { dest: H256(dest_bytes), value: U256::zero() },
+				)
+				.execute_returns(true);
+			assert_eq!(Balances::free_balance(mirror(ALICE)), 100);
+			assert_eq!(Balances::free_balance(&dest_acc), 0);
+		});
+}
+
+#[test]
+fn withdraw_reverts_on_insufficient_balance() {
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 10)])
+		.build()
+		.execute_with(|| {
+			let dest_bytes: [u8; 32] = aid(9).into();
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::withdraw { dest: H256(dest_bytes), value: 100u64.into() },
+				)
+				.execute_reverts(|out| out == b"ERC20: transfer failed");
+		});
+}
+
+// --- selector dispatch / fallback ----------------------------------------
+
+#[test]
+fn empty_input_reverts() {
+	// Empty input is routed to the fallback (deposit); without value it reverts.
+	ExtBuilder::default().build().execute_with(|| {
+		precompiles()
+			.prepare_test(ALICE, PRECOMPILE_ADDRESS, alloc::vec::Vec::<u8>::new())
+			.execute_reverts(|out| out == b"ERC20: cannot deposit zero");
+	});
+}
+
+#[test]
+fn unknown_selector_reverts() {
+	// Unknown selectors fall through to deposit (#[precompile::fallback]);
+	// without value they revert with the deposit's reason.
+	ExtBuilder::default().build().execute_with(|| {
+		precompiles()
+			.prepare_test(ALICE, PRECOMPILE_ADDRESS, vec![0xde, 0xad, 0xbe, 0xef])
+			.execute_reverts(|out| out == b"ERC20: cannot deposit zero");
+	});
+}
+
+#[test]
+fn balance_of_with_short_args_reverts() {
+	ExtBuilder::default().build().execute_with(|| {
+		// Selector present but no 32-byte address argument.
+		let mut input = compute_selector("balanceOf(address)").to_be_bytes().to_vec();
+		input.extend_from_slice(&[0u8; 16]);
+		precompiles()
+			.prepare_test(ALICE, PRECOMPILE_ADDRESS, input)
+			.execute_reverts(|_| true);
+	});
+}
+
+#[test]
+fn balance_of_with_dirty_padding_returns_truncated() {
+	// The Solidity ABI silently truncates the high 12 bytes of an address
+	// word; `Address` codec follows that convention.
+	ExtBuilder::default().build().execute_with(|| {
+		let mut bad = [0u8; 32];
+		bad[0] = 1;
+		bad[12..].copy_from_slice(BOB.as_bytes());
+		let mut input = compute_selector("balanceOf(address)").to_be_bytes().to_vec();
+		input.extend_from_slice(&bad);
+		precompiles()
+			.prepare_test(ALICE, PRECOMPILE_ADDRESS, input)
+			.execute_returns(U256::zero());
+	});
+}
+
+#[test]
+fn unknown_selector_without_value_still_reverts() {
+	ExtBuilder::default().build().execute_with(|| {
+		precompiles()
+			.prepare_test(ALICE, PRECOMPILE_ADDRESS, vec![0xde, 0xad, 0xbe, 0xef])
+			.execute_reverts(|_| true);
+	});
+}
+
+// --- Moonbeam-style scenarios --------------------------------------------
+
+#[test]
+fn selectors_match_erc20_spec() {
+	// The macro-generated dispatcher uses these canonical selectors;
+	// pin the values so a refactor cannot drift.
+	assert_eq!(compute_selector("balanceOf(address)"), 0x70a08231);
+	assert_eq!(compute_selector("totalSupply()"), 0x18160ddd);
+	assert_eq!(compute_selector("approve(address,uint256)"), 0x095ea7b3);
+	assert_eq!(compute_selector("allowance(address,address)"), 0xdd62ed3e);
+	assert_eq!(compute_selector("transfer(address,uint256)"), 0xa9059cbb);
+	assert_eq!(
+		compute_selector("transferFrom(address,address,uint256)"),
+		0x23b872dd
+	);
+	assert_eq!(compute_selector("name()"), 0x06fdde03);
+	assert_eq!(compute_selector("symbol()"), 0x95d89b41);
+	assert_eq!(compute_selector("decimals()"), 0x313ce567);
+	// Withdraw uses a non-standard signature (bytes32 destination), so its
+	// selector deliberately differs from the WETH-style `withdraw(uint256)`
+	// (`0xf3fef3a3`).
+	assert_eq!(compute_selector("withdraw(bytes32,uint256)"), 0x040cf020);
+
+	// Pin the canonical event topic hashes used by indexers.
+	assert_eq!(
+		SELECTOR_LOG_TRANSFER,
+		hex_literal::hex!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")
+	);
+	assert_eq!(
+		SELECTOR_LOG_APPROVAL,
+		hex_literal::hex!("8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925")
+	);
+	assert_eq!(
+		SELECTOR_LOG_WITHDRAWAL,
+		hex_literal::hex!("4206db6775563d1043abfcf27cd0ecd19fcc464be574a1487fc95b24957a671a")
+	);
+}
+
+#[test]
+fn balance_of_unknown_user_returns_zero() {
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 1_000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::balance_of { owner: Address(BOB) },
+				)
+				.execute_returns(U256::zero());
+		});
+}
+
+#[test]
+fn total_supply_with_two_accounts() {
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 1_000), (mirror(BOB), 2_500)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(ALICE, PRECOMPILE_ADDRESS, PCall::total_supply {})
+				.execute_returns(U256::from(3_500u64));
+		});
+}
+
+#[test]
+fn approve_saturating_max_uint256() {
+	// `approve(spender, MAX)` round-trips since both on-chain and
+	// Solidity sides use U256.
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 1_000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::approve { spender: Address(BOB), value: U256::MAX },
+				)
+				.execute_returns(true);
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::allowance { owner: Address(ALICE), spender: Address(BOB) },
+				)
+				.execute_returns(U256::MAX);
+		});
+}
+
+#[test]
+fn transfer_updates_both_balances() {
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 1_000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::transfer { to: Address(BOB), value: 400u64.into() },
+				)
+				.execute_returns(true);
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::balance_of { owner: Address(ALICE) },
+				)
+				.execute_returns(U256::from(600u64));
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::balance_of { owner: Address(BOB) },
+				)
+				.execute_returns(U256::from(400u64));
+		});
+}
+
+#[test]
+fn transfer_from_updates_both_balances_and_allowance_remainder() {
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 1_000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::approve { spender: Address(BOB), value: 500u64.into() },
+				)
+				.execute_returns(true);
+			precompiles()
+				.prepare_test(
+					BOB,
+					PRECOMPILE_ADDRESS,
+					PCall::transfer_from {
+						from: Address(ALICE),
+						to: Address(BOB),
+						value: 400u64.into(),
+					},
+				)
+				.execute_returns(true);
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::balance_of { owner: Address(ALICE) },
+				)
+				.execute_returns(U256::from(600u64));
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::balance_of { owner: Address(BOB) },
+				)
+				.execute_returns(U256::from(400u64));
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::allowance { owner: Address(ALICE), spender: Address(BOB) },
+				)
+				.execute_returns(U256::from(100u64));
+		});
+}
+
+#[test]
+fn withdraw_does_not_change_caller_native_balance_when_amount_zero() {
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 1_000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::withdraw { dest: H256::zero(), value: U256::zero() },
+				)
+				.execute_returns(true);
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::balance_of { owner: Address(ALICE) },
+				)
+				.execute_returns(U256::from(1_000u64));
+		});
+}
+
+// --- deposit (WETH-style) tests --------------------------------------------
+
+#[test]
+fn deposit_with_value_refunds_caller_and_emits_log() {
+	// Simulate the EVM's pre-transfer by funding both Alice and the
+	// precompile so the post-state matches a real EVM call.
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 500), (mirror(PRECOMPILE_ADDRESS), 500)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(ALICE, PRECOMPILE_ADDRESS, PCall::deposit {})
+				.with_value(U256::from(500u64))
+				.expect_log(log2(
+					PRECOMPILE_ADDRESS,
+					SELECTOR_LOG_DEPOSIT,
+					ALICE,
+					solidity::encode_event_data(U256::from(500u64)),
+				))
+				.execute_returns(());
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::balance_of { owner: Address(ALICE) },
+				)
+				.execute_returns(U256::from(1_000u64));
+		});
+}
+
+#[test]
+fn deposit_via_empty_calldata_receive_refunds_caller() {
+	// Empty calldata + value triggers receive() which routes to deposit
+	// via the macro's fallback handler.
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 750), (mirror(PRECOMPILE_ADDRESS), 250)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(ALICE, PRECOMPILE_ADDRESS, alloc::vec::Vec::<u8>::new())
+				.with_value(U256::from(250u64))
+				.expect_log(log2(
+					PRECOMPILE_ADDRESS,
+					SELECTOR_LOG_DEPOSIT,
+					ALICE,
+					solidity::encode_event_data(U256::from(250u64)),
+				))
+				.execute_returns(());
+		});
+}
+
+#[test]
+fn deposit_via_unknown_selector_with_value_falls_back_to_deposit() {
+	// Unknown selector + value triggers fallback() which routes to deposit.
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 900), (mirror(PRECOMPILE_ADDRESS), 100)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(ALICE, PRECOMPILE_ADDRESS, vec![0x01, 0x23, 0x45, 0x67])
+				.with_value(U256::from(100u64))
+				.expect_log(log2(
+					PRECOMPILE_ADDRESS,
+					SELECTOR_LOG_DEPOSIT,
+					ALICE,
+					solidity::encode_event_data(U256::from(100u64)),
+				))
+				.execute_returns(());
+		});
+}
+
+#[test]
+fn deposit_with_zero_value_reverts() {
+	ExtBuilder::default()
+		.with_balances(vec![(mirror(ALICE), 1_000)])
+		.build()
+		.execute_with(|| {
+			precompiles()
+				.prepare_test(ALICE, PRECOMPILE_ADDRESS, PCall::deposit {})
+				.execute_reverts(|out| out == b"ERC20: cannot deposit zero");
+			precompiles()
+				.prepare_test(
+					ALICE,
+					PRECOMPILE_ADDRESS,
+					PCall::balance_of { owner: Address(ALICE) },
+				)
+				.execute_returns(U256::from(1_000u64));
+		});
+}
+
+// --- EIP-2612 permit ------------------------------------------------------
+
+/// Deterministic test secret. Yields a fixed address used by the permit tests.
+fn permit_test_secret() -> SecretKey {
+	SecretKey::parse(&[0xCDu8; 32]).expect("valid secret")
+}
+
+/// Address corresponding to `permit_test_secret()`.
+fn permit_test_address(sk: &SecretKey) -> H160 {
+	let pk = PublicKey::from_secret_key(sk);
+	// 65-byte uncompressed (0x04 || X || Y); strip the leading byte.
+	let serialized = pk.serialize();
+	let hash = sp_io::hashing::keccak_256(&serialized[1..]);
+	H160::from_slice(&hash[12..])
+}
+
+fn sign_permit(
+	sk: &SecretKey,
+	owner: H160,
+	spender: H160,
+	value: U256,
+	nonce: U256,
+	deadline: U256,
+) -> (u8, [u8; 32], [u8; 32]) {
+	let chain_id = <Runtime as pallet_evm::Config>::ChainId::get();
+	let ds = compute_domain_separator(PRECOMPILE_ADDRESS, chain_id, NativeErc20Metadata::NAME.as_bytes());
+	let sh = compute_permit_struct_hash(owner, spender, value, nonce, deadline);
+	let digest = compute_eip712_digest(&ds, &sh);
+	let msg = Message::parse(&digest);
+	let (sig, rec_id) = libsecp256k1::sign(&msg, sk);
+	let bytes = sig.serialize();
+	let mut r = [0u8; 32];
+	let mut s = [0u8; 32];
+	r.copy_from_slice(&bytes[..32]);
+	s.copy_from_slice(&bytes[32..]);
+	(rec_id.serialize() + 27, r, s)
+}
+
+#[test]
+fn nonces_returns_zero_for_unknown_owner() {
+	ExtBuilder::default().build().execute_with(|| {
+		precompiles()
+			.prepare_test(
+				ALICE,
+				PRECOMPILE_ADDRESS,
+				PCall::eip2612_nonces { owner: Address(ALICE) },
+			)
+			.execute_returns(U256::zero());
+	});
+}
+
+#[test]
+fn domain_separator_matches_expected() {
+	ExtBuilder::default().build().execute_with(|| {
+		let chain_id = <Runtime as pallet_evm::Config>::ChainId::get();
+		let expected = H256(compute_domain_separator(PRECOMPILE_ADDRESS, chain_id, NativeErc20Metadata::NAME.as_bytes()));
+		precompiles()
+			.prepare_test(ALICE, PRECOMPILE_ADDRESS, PCall::eip2612_domain_separator {})
+			.execute_returns(expected);
+	});
+}
+
+#[test]
+fn permit_valid_sets_allowance_and_bumps_nonce() {
+	ExtBuilder::default().build().execute_with(|| {
+		Timestamp::set_timestamp(1_000); // 1 second
+		let sk = permit_test_secret();
+		let owner = permit_test_address(&sk);
+		let spender = BOB;
+		let value = U256::from(500u64);
+		let deadline = U256::from(10_000u64);
+		let (v, r, s) = sign_permit(&sk, owner, spender, value, U256::zero(), deadline);
+		// Anyone (CHARLIE) submits the permit on the owner's behalf.
+		precompiles()
+			.prepare_test(
+				CHARLIE,
+				PRECOMPILE_ADDRESS,
+				PCall::eip2612_permit {
+					owner: Address(owner),
+					spender: Address(spender),
+					value,
+					deadline,
+					v,
+					r: H256(r),
+					s: H256(s),
+				},
+			)
+			.expect_log(log3(
+				PRECOMPILE_ADDRESS,
+				SELECTOR_LOG_APPROVAL,
+				owner,
+				spender,
+				solidity::encode_event_data(value),
+			))
+			.execute_returns(());
+		assert_eq!(Allowances::get(owner, spender), value);
+		assert_eq!(Nonces::get(owner), U256::one());
+	});
+}
+
+#[test]
+fn permit_invalid_nonce_reverts() {
+	ExtBuilder::default().build().execute_with(|| {
+		Timestamp::set_timestamp(1_000);
+		let sk = permit_test_secret();
+		let owner = permit_test_address(&sk);
+		// Sign with nonce=1 but on-chain nonce is 0.
+		let (v, r, s) = sign_permit(&sk, owner, BOB, 500u64.into(), U256::one(), 10_000u64.into());
+		precompiles()
+			.prepare_test(
+				CHARLIE,
+				PRECOMPILE_ADDRESS,
+				PCall::eip2612_permit {
+					owner: Address(owner),
+					spender: Address(BOB),
+					value: 500u64.into(),
+					deadline: 10_000u64.into(),
+					v,
+					r: H256(r),
+					s: H256(s),
+				},
+			)
+			.execute_reverts(|out| out == b"Invalid permit");
+		assert_eq!(Nonces::get(owner), U256::zero());
+	});
+}
+
+#[test]
+fn permit_invalid_signature_reverts() {
+	ExtBuilder::default().build().execute_with(|| {
+		Timestamp::set_timestamp(1_000);
+		let sk = permit_test_secret();
+		let owner = permit_test_address(&sk);
+		let (v, mut r, s) =
+			sign_permit(&sk, owner, BOB, 500u64.into(), U256::zero(), 10_000u64.into());
+		// Corrupt one byte of `r`.
+		r[0] ^= 0xFF;
+		precompiles()
+			.prepare_test(
+				CHARLIE,
+				PRECOMPILE_ADDRESS,
+				PCall::eip2612_permit {
+					owner: Address(owner),
+					spender: Address(BOB),
+					value: 500u64.into(),
+					deadline: 10_000u64.into(),
+					v,
+					r: H256(r),
+					s: H256(s),
+				},
+			)
+			.execute_reverts(|out| out == b"Invalid permit");
+	});
+}
+
+#[test]
+fn permit_expired_deadline_reverts() {
+	ExtBuilder::default().build().execute_with(|| {
+		// `now_ms / 1000 = 10` > deadline `5` → expired.
+		Timestamp::set_timestamp(10_000);
+		let sk = permit_test_secret();
+		let owner = permit_test_address(&sk);
+		let (v, r, s) = sign_permit(&sk, owner, BOB, 500u64.into(), U256::zero(), 5u64.into());
+		precompiles()
+			.prepare_test(
+				CHARLIE,
+				PRECOMPILE_ADDRESS,
+				PCall::eip2612_permit {
+					owner: Address(owner),
+					spender: Address(BOB),
+					value: 500u64.into(),
+					deadline: 5u64.into(),
+					v,
+					r: H256(r),
+					s: H256(s),
+				},
+			)
+			.execute_reverts(|out| out == b"Permit expired");
+	});
+}
+
+#[test]
+fn permit_expired_deadline_millisecond_boundary() {
+	ExtBuilder::default().build().execute_with(|| {
+		// 1001ms / 1000 = 1, equals deadline 1, NOT greater — allowed.
+		Timestamp::set_timestamp(1_001);
+		let sk = permit_test_secret();
+		let owner = permit_test_address(&sk);
+		let (v, r, s) = sign_permit(&sk, owner, BOB, 500u64.into(), U256::zero(), 1u64.into());
+		precompiles()
+			.prepare_test(
+				CHARLIE,
+				PRECOMPILE_ADDRESS,
+				PCall::eip2612_permit {
+					owner: Address(owner),
+					spender: Address(BOB),
+					value: 500u64.into(),
+					deadline: 1u64.into(),
+					v,
+					r: H256(r),
+					s: H256(s),
+				},
+			)
+			.execute_returns(());
+	});
+}
+
+#[test]
+fn check_allowance_not_existing() {
+	// Querying allowance for an owner/spender pair that was never set
+	// returns zero (no revert).
+	ExtBuilder::default().build().execute_with(|| {
+		precompiles()
+			.prepare_test(
+				ALICE,
+				PRECOMPILE_ADDRESS,
+				PCall::allowance { owner: Address(ALICE), spender: Address(BOB) },
+			)
+			.execute_returns(U256::zero());
+	});
+}
+
+// Suppress unused-import warning for `h160` (kept as a generic helper
+// in `mock.rs` even though no current test uses it directly).
+#[allow(dead_code)]
+fn _silence() {
+	let _ = h160(0);
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -42,6 +42,7 @@ pallet-evm-precompile-bn128.workspace = true
 pallet-evm-precompile-modexp.workspace = true
 pallet-evm-precompile-sha3fips.workspace = true
 pallet-evm-precompile-simple.workspace = true
+pallet-evm-precompile-balances-erc20.workspace = true
 fp-evm.workspace = true
 fp-rpc.workspace = true
 fp-self-contained = { workspace = true, features = ["serde"] }
@@ -104,6 +105,7 @@ std = [
 	"pallet-evm-precompile-modexp/std",
 	"pallet-evm-precompile-sha3fips/std",
 	"pallet-evm-precompile-simple/std",
+	"pallet-evm-precompile-balances-erc20/std",
 	"fp-evm/std",
 	"fp-rpc/std",
 	"fp-self-contained/std",

--- a/runtime/src/configs/evm.rs
+++ b/runtime/src/configs/evm.rs
@@ -20,6 +20,7 @@ use pallet_evm::{
 	PrecompileHandle, PrecompileResult, PrecompileSet,
 };
 use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
+use pallet_evm_precompile_balances_erc20::{Erc20BalancesPrecompile, Erc20Metadata};
 use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_simple::{ECRecover, Identity, Ripemd160, Sha256};
 use sp_core::{H160, U256};
@@ -83,13 +84,25 @@ impl FindAuthor<H160> for EvmFindAuthorZero {
 	}
 }
 
-/// Precompile set covering the standard Ethereum precompiles 1-8.
+/// ERC20 metadata for the native UNIT token, injected into the
+/// `balances-erc20` precompile.
+pub struct NativeErc20Metadata;
+impl Erc20Metadata for NativeErc20Metadata {
+	const NAME: &'static str = "UNIT";
+	const SYMBOL: &'static str = "UNIT";
+	const DECIMALS: u8 = 18;
+}
+
+/// Precompile set covering the standard Ethereum precompiles 1-8 plus the
+/// chain-specific `balances-erc20` precompile at `0x0000…0802`, which
+/// exposes the native balance pallet through an ERC20 interface and adds a
+/// `withdraw(bytes32,uint256)` helper for EVM -> Substrate transfers.
 ///
-/// The chain does not yet expose any chain-specific precompiles; addresses
-/// 9 and above are unallocated. `ECRecover`, `SHA256`, `RIPEMD160` and
-/// `Identity` use [`pallet_evm_precompile_simple`]; modexp uses
+/// `ECRecover`, `SHA256`, `RIPEMD160` and `Identity` use
+/// [`pallet_evm_precompile_simple`]; modexp uses
 /// [`pallet_evm_precompile_modexp`]; the bn128 curve precompiles use
-/// [`pallet_evm_precompile_bn128`].
+/// [`pallet_evm_precompile_bn128`]; the chain-specific ERC20 facade comes
+/// from [`pallet_evm_precompile_balances_erc20`].
 pub struct FrontierPrecompiles<R>(PhantomData<R>);
 
 impl<R> FrontierPrecompiles<R>
@@ -99,7 +112,7 @@ where
 	pub fn new() -> Self {
 		Self(PhantomData)
 	}
-	pub fn used_addresses() -> [H160; 8] {
+	pub fn used_addresses() -> [H160; 9] {
 		[
 			hash(1),
 			hash(2),
@@ -109,6 +122,7 @@ where
 			hash(6),
 			hash(7),
 			hash(8),
+			hash(0x0802),
 		]
 	}
 }
@@ -124,7 +138,11 @@ where
 
 impl<R> PrecompileSet for FrontierPrecompiles<R>
 where
-	R: pallet_evm::Config,
+	R: pallet_evm::Config + pallet_timestamp::Config<Moment = u64>,
+	pallet_evm::AccountIdOf<R>: From<[u8; 32]>,
+	<<R as pallet_evm::Config>::Currency as frame_support::traits::Currency<
+		pallet_evm::AccountIdOf<R>,
+	>>::Balance: TryFrom<U256> + Into<U256>,
 {
 	fn execute(&self, handle: &mut impl PrecompileHandle) -> Option<PrecompileResult> {
 		match handle.code_address() {
@@ -136,6 +154,7 @@ where
 			a if a == hash(6) => Some(Bn128Add::execute(handle)),
 			a if a == hash(7) => Some(Bn128Mul::execute(handle)),
 			a if a == hash(8) => Some(Bn128Pairing::execute(handle)),
+			a if a == hash(0x0802) => Some(Erc20BalancesPrecompile::<R, NativeErc20Metadata>::execute(handle)),
 			_ => None,
 		}
 	}

--- a/runtime/tests/evm.rs
+++ b/runtime/tests/evm.rs
@@ -110,6 +110,111 @@ fn deploy_minimal_contract_succeeds() {
 }
 
 #[test]
+fn balances_erc20_precompile_balance_of_and_transfer_via_runner() {
+	// End-to-end smoke test for the `balances-erc20` precompile wired at
+	// 0x0802 in the runtime: drive a real `Runner::call` through Frontier's
+	// stack and assert that
+	//   1) `balanceOf(caller)` returns the funded native balance, and
+	//   2) `transfer(other, value)` moves native funds across the
+	//      `AddressMapping` mirror accounts.
+	new_test_ext().execute_with(|| {
+		let caller = H160::from_low_u64_be(0xC1A1);
+		let other = H160::from_low_u64_be(0xB0B0);
+		let caller_acc =
+			<Runtime as pallet_evm::Config>::AddressMapping::into_account_id(caller);
+		let other_acc =
+			<Runtime as pallet_evm::Config>::AddressMapping::into_account_id(other);
+
+		let initial: u128 = 7_500 * UNIT;
+		Balances::set_balance(&caller_acc, initial);
+
+		let precompile = H160::from_low_u64_be(0x0802);
+		let max_fee_per_gas = U256::from(2_000_000_000u64); // 2 gwei
+
+		// --- balanceOf(caller) ------------------------------------------------
+		// Selector = keccak256("balanceOf(address)")[..4] = 0x70a08231.
+		let mut data = vec![0x70, 0xa0, 0x82, 0x31];
+		data.extend_from_slice(&[0u8; 12]);
+		data.extend_from_slice(caller.as_bytes());
+
+		let res = <Runtime as pallet_evm::Config>::Runner::call(
+			caller,
+			precompile,
+			data,
+			U256::zero(),
+			1_000_000,
+			Some(max_fee_per_gas),
+			None,
+			None,
+			Vec::new(),
+			Vec::new(),
+			true,
+			true,
+			None,
+			None,
+			None,
+			<Runtime as pallet_evm::Config>::config(),
+		)
+		.expect("balanceOf call must dispatch without runtime error");
+		assert!(
+			res.exit_reason.is_succeed(),
+			"balanceOf must succeed: {:?}",
+			res.exit_reason
+		);
+		assert_eq!(res.value.len(), 32, "balanceOf returns one ABI word");
+		let returned = U256::from_big_endian(&res.value);
+		// EVM withholds `gas_limit * gas_price` from the caller's mirror
+		// account before the precompile body executes, so `balanceOf`
+		// observes the pre-refund balance — strictly less than initial,
+		// but within one UNIT of it.
+		let initial_u = U256::from(initial);
+		assert!(returned < initial_u, "gas must have been withheld");
+		assert!(initial_u - returned < U256::from(UNIT), "withheld gas under 1 UNIT");
+
+		// --- transfer(other, 1_000 * UNIT) ------------------------------------
+		// Selector = keccak256("transfer(address,uint256)")[..4] = 0xa9059cbb.
+		let amount: u128 = 1_000 * UNIT;
+		let mut data = vec![0xa9, 0x05, 0x9c, 0xbb];
+		data.extend_from_slice(&[0u8; 12]);
+		data.extend_from_slice(other.as_bytes());
+		let amount_word = U256::from(amount).to_big_endian();
+		data.extend_from_slice(&amount_word);
+
+		let res = <Runtime as pallet_evm::Config>::Runner::call(
+			caller,
+			precompile,
+			data,
+			U256::zero(),
+			1_000_000,
+			Some(max_fee_per_gas),
+			None,
+			None,
+			Vec::new(),
+			Vec::new(),
+			true,
+			true,
+			None,
+			None,
+			None,
+			<Runtime as pallet_evm::Config>::config(),
+		)
+		.expect("transfer call must dispatch without runtime error");
+		assert!(
+			res.exit_reason.is_succeed(),
+			"transfer must succeed: {:?}",
+			res.exit_reason
+		);
+		// Solidity returns `bool true` as a 32-byte word with low byte = 1.
+		assert_eq!(U256::from_big_endian(&res.value), U256::one());
+
+		// Recipient mirror account credited; sender mirror account decremented
+		// (note: gas fee is also charged to caller_acc, so use `<=`).
+		assert_eq!(Balances::free_balance(&other_acc), amount);
+		assert!(Balances::free_balance(&caller_acc) <= initial - amount);
+	});
+}
+
+#[test]
 fn evm_chain_id_constant_matches_genesis_value() {
 	// The runtime parameter feeds `pallet-evm-chain-id` via the genesis preset;
 	// verify the source-of-truth constant is the value we configured.


### PR DESCRIPTION
## Summary

- add a new balances-erc20 precompile that exposes the native UNIT token through an ERC20 interface at `0x0000000000000000000000000000000000000802`
- implement ERC20 metadata, balance queries, transfers, approvals, transferFrom, WETH-style deposit handling, withdraw to arbitrary `AccountId32`, and EIP-2612 permit flows
- register the precompile in the runtime, add the new workspace crate, refresh related dependencies, and cover the integration with unit and runtime tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native token ERC20 precompile support at address 0x0802 with standard token operations (transfer, approve, balanceOf, etc.)
  * Implemented EIP-2612 permit functionality enabling gasless token approvals via cryptographic signatures
  * Added cross-domain transfer helpers for moving native funds between EVM and Substrate

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/motoZ-crypto/crypto-node/pull/86)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->