### PR TITLE
Increase timeout limit for clippy and test jobs in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: ./.github/actions/ubuntu-dependencies
       - name: Run clippy
         run: SKIP_WASM_BUILD=1 cargo clippy --all-targets --locked --workspace --quiet
-        timeout-minutes: 15
+        timeout-minutes: 30
 
   test:
     runs-on: ubuntu-latest
@@ -30,4 +30,4 @@ jobs:
       - uses: ./.github/actions/ubuntu-dependencies
       - name: Run tests
         run: SKIP_WASM_BUILD=1 cargo test --workspace --locked
-        timeout-minutes: 15
+        timeout-minutes: 30


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI pipeline reliability by adjusting build step timeouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/motoZ-crypto/crypto-node/pull/88)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->