### PR TITLE
Align equivocation tracking and kicking logic with offline implementation

### DIFF
--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -305,8 +305,6 @@ pub mod pallet {
             for (who, amount) in to_release {
                 T::Currency::remove_lock(T::LockId::get(), &who);
                 ValidatorLocks::<T>::remove(&who);
-                OfflineSessionCount::<T>::remove(&who);
-                OfflineThisSession::<T>::remove(&who);
                 Self::deposit_event(Event::LockReleased { who, amount });
             }
 

--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -149,10 +149,13 @@ pub mod pallet {
     #[pallet::storage]
 	pub type OfflineSessionCount<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, u32, ValueQuery>;
 
-    /// Accounts reported as offline during the current session. Cleared when
-    /// the next session boundary is processed.
+    /// Accounts reported as offline during the current session. Cleared when the next session boundary is processed.
     #[pallet::storage]
 	pub type OfflineThisSession<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, (), OptionQuery>;
+
+    /// Accounts reported for GRANDPA equivocation during the current session. Cleared when the next session boundary is processed.
+    #[pallet::storage]
+	pub type EquivocationThisSession<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, (), OptionQuery>;
 
     /// Genesis configuration for `pallet-validator`.
     ///
@@ -463,56 +466,94 @@ impl<T: Config> Pallet<T> {
         );
     }
 
-    /// Mark `who` as kicked due to GRANDPA equivocation.
+    /// Record `who` for a GRANDPA equivocation kick at the next session
+    /// boundary.
     ///
-    /// Idempotent: a non-validator or an already kicked account is silently
-    /// ignored. The currency lock is left in place so that funds unlock at the
-    /// original `expiry_block`; auto-renewal stops because the status leaves
-    /// [`ValidatorStatus::Active`]. The account is removed from the active set
-    /// at the next session boundary by `new_session`.
+    /// Mirrors the offline path: rather than mutating validator state in the
+    /// middle of a session — which would flip the status to `Kicked` while the
+    /// account is still a member of the active set until the boundary — this
+    /// only flags the account. The actual kick (status transition, rejoin
+    /// cooldown, removal from the pending queue and active set) is applied
+    /// atomically in `new_session` via `process_equivocations`.
+    ///
+    /// Idempotent: non-validators, accounts not in [`ValidatorStatus::Active`],
+    /// and repeated reports within the same session are silently ignored. An
+    /// `EquivocationReported` event is emitted immediately for observability.
     pub fn note_equivocation(who: &T::AccountId) {
-        let mut transitioned = false;
-        ValidatorLocks::<T>::mutate(who, |maybe_info| {
-            if let Some(info) = maybe_info {
-                if info.status == ValidatorStatus::Kicked {
-                    return;
-                }
-                info.status = ValidatorStatus::Kicked;
-                transitioned = true;
-            }
-        });
-        if !transitioned {
+        let is_active = ValidatorLocks::<T>::get(who)
+            .map(|info| info.status == ValidatorStatus::Active)
+            .unwrap_or(false);
+        if !is_active {
             log::debug!(
                 target: LOG_TARGET,
                 "equivocation report ignored: account is not an active validator",
             );
             return;
         }
+        if EquivocationThisSession::<T>::contains_key(who) {
+            // Already flagged this session; keep repeated reports idempotent.
+            return;
+        }
+        EquivocationThisSession::<T>::insert(who, ());
+        Self::deposit_event(Event::EquivocationReported { who: who.clone() });
+        log::info!(
+            target: LOG_TARGET,
+            "equivocation reported; kick deferred to next session boundary",
+        );
+    }
 
+    /// Apply a kick to `who`: flip the lock status from `Active` to `Kicked`,
+    /// start the rejoin cooldown, and clear any transient offline tracking
+    /// state. The currency lock is left in place so funds unlock at the
+    /// original `expiry_block`; auto-renewal stops because the status left
+    /// `Active`. Emits `ValidatorKicked` with `reason`. Returns whether a kick
+    /// actually happened (an account not in `Active` is left untouched).
+    fn kick_validator(who: &T::AccountId, reason: KickReason) -> bool {
+        let mut kicked = false;
+        ValidatorLocks::<T>::mutate(who, |maybe_info| {
+            if let Some(info) = maybe_info {
+                if info.status == ValidatorStatus::Active {
+                    info.status = ValidatorStatus::Kicked;
+                    kicked = true;
+                }
+            }
+        });
+        if !kicked {
+            return false;
+        }
         let now = frame_system::Pallet::<T>::block_number();
         let cooldown = T::RejoinCooldownPeriod::get();
         RejoinCooldown::<T>::insert(who, now.saturating_add(cooldown));
-
         OfflineSessionCount::<T>::remove(who);
         OfflineThisSession::<T>::remove(who);
-
-        // Drop from the pending queue so the account is not promoted at the
-        // next session boundary if it had not yet been activated.
-        PendingValidators::<T>::mutate(|queue| {
-            if let Some(pos) = queue.iter().position(|a| a == who) {
-                queue.remove(pos);
-            }
-        });
-
-        Self::deposit_event(Event::EquivocationReported { who: who.clone() });
         Self::deposit_event(Event::ValidatorKicked {
             who: who.clone(),
-            reason: KickReason::Equivocation,
+            reason,
         });
-        log::info!(
-            target: LOG_TARGET,
-            "validator kicked due to GRANDPA equivocation",
-        );
+        true
+    }
+
+    /// Apply deferred GRANDPA equivocation kicks at a session boundary.
+    ///
+    /// For each account flagged via `note_equivocation` during the session,
+    /// flip the status to `Kicked`, record a rejoin cooldown, and emit
+    /// `ValidatorKicked`. Performing this here keeps the status transition
+    /// atomic with removal from the active set (done by `new_session`), so an
+    /// equivocator is never simultaneously `Kicked` and still a member of
+    /// `DesiredValidators`. Runs before `process_offline_counters` so an
+    /// equivocation kick takes precedence over a concurrent offline kick for
+    /// the same account.
+    fn process_equivocations() {
+        let flagged: alloc::vec::Vec<T::AccountId> =
+            EquivocationThisSession::<T>::drain().map(|(who, _)| who).collect();
+        for who in flagged {
+            if Self::kick_validator(&who, KickReason::Equivocation) {
+                log::info!(
+                    target: LOG_TARGET,
+                    "validator kicked due to GRANDPA equivocation",
+                );
+            }
+        }
     }
 
     /// Update offline counters for the current active set and kick any
@@ -521,12 +562,10 @@ impl<T: Config> Pallet<T> {
     /// recomputed.
     fn process_offline_counters() {
         let threshold = T::OfflineThreshold::get();
-        let cooldown = T::RejoinCooldownPeriod::get();
-        let now = frame_system::Pallet::<T>::block_number();
         let active = DesiredValidators::<T>::get();
 
         for who in active.iter() {
-            
+
             // Only Active validators participate in the offline accounting.
             // Anything else (ExitRequested / Kicked / Cooldown / removed) is
             // already on its way out and must not be overwritten by an offline
@@ -539,9 +578,7 @@ impl<T: Config> Pallet<T> {
                 continue;
             }
 
-            let was_offline = OfflineThisSession::<T>::take(who).is_some();
-
-            if !was_offline {
+            if OfflineThisSession::<T>::take(who).is_none() {
                 if OfflineSessionCount::<T>::contains_key(who) {
                     OfflineSessionCount::<T>::remove(who);
                 }
@@ -560,23 +597,13 @@ impl<T: Config> Pallet<T> {
                 continue;
             }
 
-            // Threshold reached: kick.
-            OfflineSessionCount::<T>::remove(who);
-            ValidatorLocks::<T>::mutate(who, |maybe_info| {
-                if let Some(info) = maybe_info {
-                    info.status = ValidatorStatus::Kicked;
-                }
-            });
-            RejoinCooldown::<T>::insert(who, now.saturating_add(cooldown));
-            Self::deposit_event(Event::ValidatorKicked {
-                who: who.clone(),
-                reason: KickReason::Offline,
-            });
-            log::info!(
-                target: LOG_TARGET,
-                "validator kicked after {} consecutive offline sessions",
-                threshold,
-            );
+            if Self::kick_validator(who, KickReason::Offline) {
+                log::info!(
+                    target: LOG_TARGET,
+                    "validator kicked after {} consecutive offline sessions",
+                    threshold,
+                );
+            }
         }
 
         // Drop any leftover entries (offenders that are not in the active set).
@@ -595,6 +622,7 @@ impl<T: Config> Pallet<T> {
 /// active set, matching the `pallet-session` convention.
 impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
     fn new_session(_new_index: u32) -> Option<alloc::vec::Vec<T::AccountId>> {
+        Self::process_equivocations();
         Self::process_offline_counters();
 
         let previous = DesiredValidators::<T>::get();

--- a/pallets/validator/src/tests.rs
+++ b/pallets/validator/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-    mock::*, DesiredValidators, Error, Event, KickReason, LockInfo, OfflineSessionCount,
-    OfflineThisSession, PendingValidators, RejoinCooldown, ValidatorLocks, ValidatorStatus,
+    mock::*, DesiredValidators, PendingValidators, Error, Event, KickReason, LockInfo, OfflineSessionCount, 
+    OfflineThisSession, EquivocationThisSession, RejoinCooldown, ValidatorLocks, ValidatorStatus,
 };
 use frame_support::{assert_noop, assert_ok, traits::Get};
 use sp_runtime::{traits::Dispatchable, DispatchError, TokenError};
@@ -645,11 +645,14 @@ fn empty_set_fallback_keeps_previous_authorities_after_mass_kick() {
         let set = new_session(1).expect("initial promotion");
         assert_eq!(set, vec![ALICE, BOB]);
 
-        // Kick both validators (e.g. equivocation). Their status switches to
-        // `Kicked` so they are excluded from the next active set, leaving it
-        // empty.
+        // Kick both validators (e.g. equivocation). 
         Validator::note_equivocation(&ALICE);
         Validator::note_equivocation(&BOB);
+
+        // Empty-set fallback: returning `None` keeps `pallet-session`'s
+        // authority set intact, while our own `DesiredValidators` storage is
+        // updated to the empty truth.
+        assert!(new_session(2).is_none());
         assert_eq!(
             ValidatorLocks::<Test>::get(ALICE).unwrap().status,
             ValidatorStatus::Kicked
@@ -658,11 +661,6 @@ fn empty_set_fallback_keeps_previous_authorities_after_mass_kick() {
             ValidatorLocks::<Test>::get(BOB).unwrap().status,
             ValidatorStatus::Kicked
         );
-
-        // Empty-set fallback: returning `None` keeps `pallet-session`'s
-        // authority set intact, while our own `DesiredValidators` storage is
-        // updated to the empty truth.
-        assert!(new_session(2).is_none());
         assert!(DesiredValidators::<Test>::get().is_empty());
     });
 }
@@ -799,65 +797,73 @@ fn note_equivocation_ignores_non_validator() {
 fn note_equivocation_kicks_active_validator() {
     let lock_amount: Balance = <Test as crate::Config>::LockAmount::get();
     let lock_duration: u64 = <Test as crate::Config>::LockDuration::get();
-    let rejoin_cooldown: u64 = <Test as crate::Config>::RejoinCooldownPeriod::get();
 
     new_test_ext(vec![(ALICE, lock_amount), (BOB, lock_amount)]).execute_with(|| {
         assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
         assert_ok!(Validator::lock(RuntimeOrigin::signed(BOB)));
+        new_session(1);
+        assert_eq!(DesiredValidators::<Test>::get().to_vec(), vec![ALICE, BOB]);
 
         Validator::note_equivocation(&ALICE);
+        new_session(2);
 
-        let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock retained");
-        assert_eq!(lock.status, ValidatorStatus::Kicked);
-        // Lock amount and expiry are unchanged so funds unlock at the original block.
-        assert_eq!(lock.amount, lock_amount);
-        assert_eq!(lock.expiry_block, System::block_number() + lock_duration);
-
-        let cooldown = RejoinCooldown::<Test>::get(ALICE).expect("cooldown recorded");
-        assert_eq!(cooldown, System::block_number() + rejoin_cooldown);
-
-        // Both events fire in order: detection then kick.
-        let events: Vec<_> = System::events()
-            .into_iter()
-            .filter_map(|e| match e.event {
-                RuntimeEvent::Validator(ev @ Event::EquivocationReported { .. })
-                | RuntimeEvent::Validator(ev @ Event::ValidatorKicked { .. }) => Some(ev),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(
-            events,
-            vec![
-                Event::EquivocationReported { who: ALICE },
-                Event::ValidatorKicked { who: ALICE, reason: KickReason::Equivocation },
-            ],
-        );
-
-        let set = new_session(1).expect("set must shrink");
-        assert_eq!(set, vec![BOB]);
+        let alice_lock = ValidatorLocks::<Test>::get(ALICE).expect("lock retained");
+        assert_eq!(alice_lock.status, ValidatorStatus::Kicked);
+        assert_eq!(alice_lock.amount, lock_amount);
+        assert_eq!(alice_lock.expiry_block, System::block_number() + lock_duration);
+        assert!(RejoinCooldown::<Test>::get(ALICE).is_some());
         assert_eq!(DesiredValidators::<Test>::get().to_vec(), vec![BOB]);
-
+        // The transient set must be empty after processing.
+        assert!(EquivocationThisSession::<Test>::iter().next().is_none());
+        // Event emitted with `Equivocation` reason.
+        let kicked = System::events().into_iter().any(|e| matches!(
+            e.event,
+            RuntimeEvent::Validator(Event::ValidatorKicked { who: ALICE, reason: KickReason::Equivocation })
+        ));
+        assert!(kicked, "ValidatorKicked event with Equivocation reason expected");
     });
 }
 
 #[test]
 fn note_equivocation_is_idempotent() {
     let lock_amount: Balance = <Test as crate::Config>::LockAmount::get();
+    let rejoin_cooldown: u64 = <Test as crate::Config>::RejoinCooldownPeriod::get();
 
     new_test_ext(vec![(ALICE, lock_amount)]).execute_with(|| {
         assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
-        Validator::note_equivocation(&ALICE);
-        let cooldown_first = RejoinCooldown::<Test>::get(ALICE).expect("cooldown recorded");
+        new_session(1);
 
-        // Advance a block and report again: the cooldown deadline must not move.
+        Validator::note_equivocation(&ALICE);
+        // Advance a block and report again within the same session: still a
+        // single flag and no premature state change.
         System::set_block_number(2);
         Validator::note_equivocation(&ALICE);
+        assert!(EquivocationThisSession::<Test>::contains_key(ALICE));
+        assert_eq!(
+            ValidatorLocks::<Test>::get(ALICE).unwrap().status,
+            ValidatorStatus::Active
+        );
 
-        let cooldown_second = RejoinCooldown::<Test>::get(ALICE).expect("cooldown retained");
-        assert_eq!(cooldown_first, cooldown_second);
-
+        // The boundary applies a single kick; the cooldown is anchored to the
+        // boundary block, not to any individual report.
+        new_session(2);
         let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock retained");
         assert_eq!(lock.status, ValidatorStatus::Kicked);
+        assert_eq!(
+            RejoinCooldown::<Test>::get(ALICE).expect("cooldown recorded"),
+            System::block_number() + rejoin_cooldown
+        );
+        let kicks = System::events()
+            .into_iter()
+            .filter(|e| matches!(
+                e.event,
+                RuntimeEvent::Validator(Event::ValidatorKicked {
+                    who: ALICE,
+                    reason: KickReason::Equivocation
+                })
+            ))
+            .count();
+        assert_eq!(kicks, 1);
     });
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated equivocation handling: Validator kicks for equivocation are now deferred and applied at session boundaries instead of immediately, ensuring more consistent state transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/motoZ-crypto/crypto-node/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->