### PR TITLE
Freeze the PoScan work value across architectures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           cargo test -p obj-asteroid --test determinism --locked
           cargo test -p obj-asteroid --test spectral --locked golden
+          cargo test -p poscan --test golden --locked
         timeout-minutes: 15
       - name: Add wasm target
         run: rustup target add wasm32-wasip1

--- a/consensus/obj-asteroid/tests/determinism.rs
+++ b/consensus/obj-asteroid/tests/determinism.rs
@@ -36,12 +36,17 @@ fn mesh_fingerprint(mesh: &Mesh) -> u64 {
     fnv1a(&buf)
 }
 
-/// (seed, subdivisions, mesh fingerprint).
-const MESH_GOLDEN: [(u64, u32, u64); 4] = [
+/// (seed, subdivisions, mesh fingerprint). Subdivision 4 is the on-chain mining
+/// resolution, frozen here beside the lighter level the seam tests exercise.
+const MESH_GOLDEN: [(u64, u32, u64); 8] = [
     (0x0, 3, 0xb192d0954cf2ad83),
     (0x1, 3, 0xf5c3672f25b02031),
     (0x2a, 3, 0xa4f06fe37253ce42),
     (0xdead_beef, 3, 0xa0b0d08c5deafe5c),
+    (0x0, 4, 0x8291dee3ea07baa0),
+    (0x1, 4, 0x56c2a257a4f6cb55),
+    (0x2a, 4, 0x0c78e63b5245717d),
+    (0xdead_beef, 4, 0x2547477c49d8ea72),
 ];
 
 #[test]

--- a/consensus/obj-asteroid/tests/spectral.rs
+++ b/consensus/obj-asteroid/tests/spectral.rs
@@ -99,6 +99,20 @@ const SCAN_GOLDEN: [(u64, u64); 4] = [
     (0xdead_beef, 0x37e165355dfcda75),
 ];
 
+/// On-chain mining resolution. The protocol scans a subdivision 4 body at this many
+/// samples, so the cross-environment leg must freeze that exact path, not only the
+/// lighter default the seam tests share.
+const MINING_SUBDIVISIONS: u32 = 4;
+const MINING_SAMPLES: usize = 4096;
+
+/// (seed, scan feature fingerprint) at the on-chain mining resolution.
+const SCAN_GOLDEN_MINING: [(u64, u64); 4] = [
+    (0x0, 0x6da1b2a0b181616c),
+    (0x1, 0xd3e887809042186c),
+    (0x2a, 0x88be365da70385d6),
+    (0xdead_beef, 0xbbb64605ce4c62cc),
+];
+
 /// (seed, registered identity hash). The coarse on-chain tag.
 const IDENTITY_GOLDEN: [(u64, &str); 4] = [
     (0x0, "1f8e42839dbd9894eca3c17c1140d85c6513eee5b14c4e7e3e766b29b9310f63"),
@@ -115,6 +129,16 @@ fn scan_golden_vectors() {
             .unwrap_or_else(|e| panic!("seed {seed:#x}: scan failed: {e}"));
         let got = scan_fingerprint(&f);
         assert_eq!(got, want, "seed={seed:#x}: scan features drifted, got 0x{got:016x}");
+    }
+}
+
+#[test]
+fn scan_golden_vectors_mining() {
+    for (seed, want) in SCAN_GOLDEN_MINING {
+        let f = scan(asteroid(seed, MINING_SUBDIVISIONS), MINING_SAMPLES)
+            .unwrap_or_else(|e| panic!("seed {seed:#x}: scan failed: {e}"));
+        let got = scan_fingerprint(&f);
+        assert_eq!(got, want, "seed={seed:#x}: mining-resolution scan drifted, got 0x{got:016x}");
     }
 }
 
@@ -139,6 +163,10 @@ fn regenerate_golden() {
     for (seed, _) in SCAN_GOLDEN {
         let f = scan(asteroid(seed, SUBDIVISIONS), p.target_samples).unwrap();
         println!("scan  ({seed:#x}, 0x{:016x}),", scan_fingerprint(&f));
+    }
+    for (seed, _) in SCAN_GOLDEN_MINING {
+        let f = scan(asteroid(seed, MINING_SUBDIVISIONS), MINING_SAMPLES).unwrap();
+        println!("mine  ({seed:#x}, 0x{:016x}),", scan_fingerprint(&f));
     }
     for (seed, _) in IDENTITY_GOLDEN {
         let (id, _) = register(asteroid(seed, SUBDIVISIONS), &p).unwrap();

--- a/consensus/poscan/tests/golden.rs
+++ b/consensus/poscan/tests/golden.rs
@@ -1,0 +1,57 @@
+//! Golden vectors for the consensus work value `s`. `Compute::work` grows the
+//! asteroid, scans it at the on-chain resolution, fine quantizes the features and
+//! hashes the buckets. One input must reproduce one `s` on every node or the chain
+//! forks. These freeze `s` bit-for-bit.
+//!
+//! The vectors run native on x86_64 and aarch64, so a CPU that reorders the float
+//! path turns them red. The wasm side of `s` rides transitively. `obj-asteroid`'s
+//! `spectral` golden freezes the scan features at this same resolution under
+//! wasmtime, and the steps left on top, a libm round and SHA256, carry no
+//! cross-target float variance. poscan cannot ride wasm32-wasip1 itself because
+//! sp-core drags a native secp256k1 C build that will not cross-compile, so the
+//! feature golden stands in for that leg.
+//!
+//! A red vector is a consensus break to investigate, never a stale value to
+//! refresh. `regenerate` is the only sanctioned way to move them.
+
+use poscan::Compute;
+use sp_core::{H256, U256};
+
+/// (pre_hash low u64, nonce, lowercase hex of `s`). The value that goes on chain.
+const WORK_GOLDEN: [(u64, u64, &str); 4] = [
+	(0x0, 0x0, "5cea70c24b6ff7d7761e8817f63e1068baeeabb132fb08c918159127243bac8d"),
+	(0x1, 0x1, "864d75aa5b4599aa6cf29a8c76681c800d8177efd0a209c492324b4a84eb6961"),
+	(0x2a, 0x2a, "0f155bccfa1c57143c04e47f9affec27a84a828e75da5fd4ff8422919c6649b6"),
+	(0xdead_beef, 0xdead_beef, "55657c14aefeb8dffd90838e78dbc059f152cdff13ba3d280acccaaf44fcba2c"),
+];
+
+fn work_of(pre: u64, nonce: u64) -> H256 {
+	Compute { pre_hash: H256::from_low_u64_be(pre), nonce: U256::from(nonce) }
+		.work()
+		.unwrap_or_else(|| panic!("pre={pre:#x} nonce={nonce:#x}: mesh was unscannable"))
+}
+
+#[test]
+fn work_golden_vectors() {
+	for (pre, nonce, want) in WORK_GOLDEN {
+		let got = format!("{:x}", work_of(pre, nonce));
+		assert_eq!(got, want, "pre={pre:#x} nonce={nonce:#x}: work value drifted, got {got}");
+	}
+}
+
+#[test]
+fn work_is_reproducible() {
+	assert_eq!(work_of(7, 7), work_of(7, 7));
+}
+
+/// Print current values. Run ONLY after a deliberate decision to move the canonical
+/// `s`, then paste the values above. Running it to silence a red vector hands the
+/// chain a silent fork.
+///   cargo test -p poscan --test golden -- --ignored --nocapture regenerate
+#[test]
+#[ignore]
+fn regenerate() {
+	for (pre, nonce, _) in WORK_GOLDEN {
+		println!("({pre:#x}, {nonce:#x}, \"{:x}\"),", work_of(pre, nonce));
+	}
+}


### PR DESCRIPTION
- golden `s` from Compute::work as hex, run native on x86_64 and aarch64
- extend the obj-asteroid mesh and scan golden to the on-chain resolution so the wasm leg covers it
- add the poscan golden to the determinism CI job

Closes #104 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded golden test coverage for consensus determinism and scanning, including additional seed/resolution cases.
  * Added a new golden test suite for work value calculations, with determinism checks and regeneration support.

* **Chores**
  * Updated CI to run the new consensus golden test as part of the native determinism checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->