### PR TITLE
Drop sp-core from poscan so its work golden rides wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,5 @@ jobs:
         run: |
           cargo test -p obj-asteroid --test determinism --target wasm32-wasip1 --locked
           cargo test -p obj-asteroid --test spectral --target wasm32-wasip1 --locked golden
+          cargo test -p poscan --test golden --target wasm32-wasip1 --locked
         timeout-minutes: 15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8026,8 +8026,8 @@ dependencies = [
  "libm",
  "obj-asteroid",
  "parity-scale-codec",
+ "primitive-types",
  "sha2 0.11.0",
- "sp-core",
  "spectral3d",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ futures = { version = "0.3.32" }
 futures-timer = { version = "3.0.3" }
 jsonrpsee = { version = "0.24.10" }
 sha2 = { version = "0.11.0", default-features = false }
+primitive-types = { version = "0.13.1", default-features = false, features = ["codec"] }
 async-trait = { version = "0.1.89" }
 log = { version = "0.4.29" }
 parking_lot = { version = "0.12.5" }

--- a/consensus/poscan/Cargo.toml
+++ b/consensus/poscan/Cargo.toml
@@ -13,13 +13,13 @@ publish = false
 codec = { features = ["derive"], workspace = true }
 libm.workspace = true
 obj-asteroid.workspace = true
+primitive-types.workspace = true
 sha2.workspace = true
-sp-core.workspace = true
 spectral3d.workspace = true
 
 [features]
 default = ["std"]
 std = [
 	"codec/std",
-	"sp-core/std",
+	"primitive-types/std",
 ]

--- a/consensus/poscan/src/lib.rs
+++ b/consensus/poscan/src/lib.rs
@@ -17,7 +17,7 @@ use alloc::vec::Vec;
 
 use codec::{Decode, DecodeAll, Encode};
 use sha2::{Digest, Sha256};
-use sp_core::{H256, U256};
+use primitive_types::{H256, U256};
 use spectral3d::{N_FEATURES, QUANT_STEP};
 
 // ── Protocol parameters ─────────────────────────────────────────────

--- a/consensus/poscan/tests/golden.rs
+++ b/consensus/poscan/tests/golden.rs
@@ -3,19 +3,16 @@
 //! hashes the buckets. One input must reproduce one `s` on every node or the chain
 //! forks. These freeze `s` bit-for-bit.
 //!
-//! The vectors run native on x86_64 and aarch64, so a CPU that reorders the float
-//! path turns them red. The wasm side of `s` rides transitively. `obj-asteroid`'s
-//! `spectral` golden freezes the scan features at this same resolution under
-//! wasmtime, and the steps left on top, a libm round and SHA256, carry no
-//! cross-target float variance. poscan cannot ride wasm32-wasip1 itself because
-//! sp-core drags a native secp256k1 C build that will not cross-compile, so the
-//! feature golden stands in for that leg.
+//! The vectors run native on x86_64 and aarch64 and under wasm32-wasip1 via
+//! wasmtime, so any target that reorders the float path turns them red. Running
+//! `s` itself under wasm freezes the consensus value on the wasm float path the
+//! runtime verifies on, with no transitive proxy.
 //!
 //! A red vector is a consensus break to investigate, never a stale value to
 //! refresh. `regenerate` is the only sanctioned way to move them.
 
 use poscan::Compute;
-use sp_core::{H256, U256};
+use primitive_types::{H256, U256};
 
 /// (pre_hash low u64, nonce, lowercase hex of `s`). The value that goes on chain.
 const WORK_GOLDEN: [(u64, u64, &str); 4] = [


### PR DESCRIPTION
poscan only borrowed H256 and U256 from sp-core, and sp-core drags a native secp256k1 C build that will not cross compile to wasm32-wasip1. Swapping to primitive-types, which sp-core merely re-exports, removes that block, so the work golden now runs directly under wasmtime next to native. The on chain s value stays bit identical because the types are the same.

This makes the wasm determinism gate a direct check on the work value s itself instead of a proxy on the scan features, run on both x86_64 and aarch64 in CI.

#104 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded cross-target validation by running an additional golden test under `wasm32-wasip1`.
  * Clarified consistency expectations for golden test data to help prevent accidental consensus-breaking changes.

* **Chores**
  * Updated an internal numeric type dependency used by the workspace and related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->