### PR TITLE
Add criterion benches for the block verification path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,10 +1848,11 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
@@ -1851,6 +1861,7 @@ dependencies = [
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
@@ -1862,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.6.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools 0.13.0",
@@ -6888,6 +6899,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "pallet-asset-conversion"
 version = "28.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#c112e83f4f6b6f8818affb900edcfb34d6fd2af0"
@@ -11342,6 +11363,8 @@ dependencies = [
 name = "solochain-template-runtime"
 version = "0.1.0"
 dependencies = [
+ "criterion",
+ "cumulus-primitives-proof-size-hostfunction",
  "ethereum",
  "fp-evm",
  "fp-rpc",
@@ -11378,6 +11401,7 @@ dependencies = [
  "parity-scale-codec",
  "poscan",
  "poscan-pow",
+ "sc-executor",
  "scale-info",
  "serde_json",
  "sp-api",
@@ -11385,6 +11409,7 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-consensus-pow",
  "sp-core",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2603)",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,8 +1862,6 @@ dependencies = [
  "num-traits",
  "oorandom",
  "page_size",
- "plotters",
- "rayon",
  "regex",
  "serde",
  "serde_json",
@@ -7710,34 +7708,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
 
 [[package]]
 name = "polkadot-ckb-merkle-mountain-range"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1217,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6c0e7b807d60291f42f33f58480c0bfafe28ed08286446f45e463728cf9c1c"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,6 +1322,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.1.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1796,6 +1835,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -2293,7 +2365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4123,6 +4195,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -6699,6 +6782,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7602,6 +7691,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polkadot-ckb-merkle-mountain-range"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8023,6 +8140,7 @@ checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 name = "poscan"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "libm",
  "obj-asteroid",
  "parity-scale-codec",
@@ -12776,7 +12894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12919,6 +13037,16 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -14798,18 +14926,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ derive_more = { version = "2.1.1", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 hex-literal = "1.1.0"
 similar-asserts = "2.0.0"
-criterion = "0.8.2"
+criterion = { version = "0.8.2", default-features = false, features = ["cargo_bench_support"] }
 evm = { git = "https://github.com/rust-ethereum/evm.git", branch = "v0.x", default-features = false }
 frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 frame-metadata-hash-extension = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ derive_more = { version = "2.1.1", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 hex-literal = "1.1.0"
 similar-asserts = "2.0.0"
-criterion = "0.7"
+criterion = "0.8.2"
 evm = { git = "https://github.com/rust-ethereum/evm.git", branch = "v0.x", default-features = false }
 frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 frame-metadata-hash-extension = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ derive_more = { version = "2.1.1", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 hex-literal = "1.1.0"
 similar-asserts = "2.0.0"
+criterion = "0.7"
 evm = { git = "https://github.com/rust-ethereum/evm.git", branch = "v0.x", default-features = false }
 frame-benchmarking-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 frame-metadata-hash-extension = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }

--- a/consensus/poscan/Cargo.toml
+++ b/consensus/poscan/Cargo.toml
@@ -17,6 +17,13 @@ primitive-types.workspace = true
 sha2.workspace = true
 spectral3d.workspace = true
 
+[dev-dependencies]
+criterion.workspace = true
+
+[[bench]]
+name = "verify"
+harness = false
+
 [features]
 default = ["std"]
 std = [

--- a/consensus/poscan/benches/verify.rs
+++ b/consensus/poscan/benches/verify.rs
@@ -1,0 +1,51 @@
+//! Criterion baseline for the block verification path.
+//!
+//! Measures the full `verify_seal` replay plus its two dominant segments,
+//! asteroid generation and the spectral3d scan. Run `cargo bench -p poscan`
+//! before and after any parameter change to compare baselines. Numbers are
+//! for local comparison only and never gate CI.
+
+use codec::Encode;
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use poscan::{Compute, Seal, TARGET_SAMPLES, hash_meets_difficulty, verify_seal};
+use primitive_types::{H256, U256};
+use std::hint::black_box;
+
+/// Mine a valid seal by scanning successive nonces. Difficulty one accepts
+/// every work value, so the first structurally scannable mesh wins.
+fn mine(pre_hash: H256, difficulty: U256) -> Seal {
+	let mut nonce = U256::zero();
+	loop {
+		let compute = Compute { pre_hash, nonce };
+		if let Some(work) = compute.work()
+			&& hash_meets_difficulty(&work, difficulty)
+		{
+			return Seal { nonce, work };
+		}
+		nonce = nonce.saturating_add(U256::one());
+	}
+}
+
+fn verify_path(c: &mut Criterion) {
+	let pre_hash = H256::from_low_u64_be(42);
+	let difficulty = U256::one();
+	let seal = mine(pre_hash, difficulty);
+	let raw = seal.encode();
+	let compute = Compute { pre_hash, nonce: seal.nonce };
+	let mesh = compute.mesh();
+
+	c.bench_function("mesh_generation", |b| b.iter(|| black_box(compute.mesh())));
+	c.bench_function("scan", |b| {
+		b.iter_batched(
+			|| mesh.clone(),
+			|m| spectral3d::scan(m, TARGET_SAMPLES).unwrap(),
+			BatchSize::SmallInput,
+		)
+	});
+	c.bench_function("verify_seal", |b| {
+		b.iter(|| verify_seal(black_box(pre_hash), black_box(&raw), black_box(difficulty)).unwrap())
+	});
+}
+
+criterion_group!(benches, verify_path);
+criterion_main!(benches);

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -73,6 +73,14 @@ substrate-wasm-builder = { optional = true, workspace = true, default-features =
 
 [dev-dependencies]
 sp-io = { workspace = true, default-features = true }
+criterion.workspace = true
+sc-executor = { workspace = true, default-features = true }
+sp-crypto-hashing = { workspace = true, default-features = true }
+cumulus-primitives-proof-size-hostfunction = { workspace = true, default-features = true }
+
+[[bench]]
+name = "verify_wasm"
+harness = false
 
 [features]
 default = ["std"]

--- a/runtime/benches/verify_wasm.rs
+++ b/runtime/benches/verify_wasm.rs
@@ -1,0 +1,85 @@
+//! Criterion baseline for seal verification inside the wasm runtime.
+//!
+//! Loads the real runtime blob and drives `PowVerifyApi` through
+//! `sc_executor::WasmExecutor`, the same execution path block import takes,
+//! so numbers include the executor call overhead on top of the scan itself.
+//! Run `cargo bench -p solochain-template-runtime` before and after any
+//! parameter change to compare baselines. Numbers never gate CI.
+
+use codec::{Decode, Encode};
+use criterion::{Criterion, criterion_group, criterion_main};
+use poscan::{Compute, Seal, hash_meets_difficulty};
+use sc_executor::WasmExecutor;
+use sp_core::traits::{CallContext, CodeExecutor, RuntimeCode, WrappedRuntimeCode};
+use sp_core::{H256, U256};
+use std::hint::black_box;
+
+/// Host function set mirroring the node executor.
+type HostFunctions = (
+	sp_io::SubstrateHostFunctions,
+	cumulus_primitives_proof_size_hostfunction::storage_proof_size::HostFunctions,
+);
+
+/// Mine a valid seal by scanning successive nonces. Difficulty one accepts
+/// every work value, so the first structurally scannable mesh wins.
+fn mine(pre_hash: H256, difficulty: U256) -> Seal {
+	let mut nonce = U256::zero();
+	loop {
+		let compute = Compute { pre_hash, nonce };
+		if let Some(work) = compute.work()
+			&& hash_meets_difficulty(&work, difficulty)
+		{
+			return Seal { nonce, work };
+		}
+		nonce = nonce.saturating_add(U256::one());
+	}
+}
+
+/// Run one runtime api call on the wasm blob under fresh externalities,
+/// matching how block import verifies each seal.
+fn call(
+	executor: &WasmExecutor<HostFunctions>,
+	code: &RuntimeCode,
+	method: &str,
+	args: &[u8],
+) -> Vec<u8> {
+	let mut ext = sp_io::TestExternalities::default();
+	let mut ext = ext.ext();
+	executor
+		.call(&mut ext, code, method, args, CallContext::Offchain)
+		.0
+		.expect("runtime call succeeds")
+}
+
+fn wasm_verify_path(c: &mut Criterion) {
+	let blob = solochain_template_runtime::WASM_BINARY.expect("runtime wasm built");
+	let executor = WasmExecutor::<HostFunctions>::builder().build();
+	let wrapped = WrappedRuntimeCode(blob.into());
+	let runtime_code = RuntimeCode {
+		code_fetcher: &wrapped,
+		hash: sp_crypto_hashing::blake2_256(blob).to_vec(),
+		heap_pages: None,
+	};
+
+	let pre_hash = H256::from_low_u64_be(42);
+	let difficulty = U256::one();
+	let seal = mine(pre_hash, difficulty);
+	let verify_args = (pre_hash, seal.encode(), difficulty).encode();
+	let mesh_args = (pre_hash, seal.nonce).encode();
+
+	// The first calls compile and cache the wasm module and prove the mined
+	// seal actually verifies before any timing starts.
+	let out = call(&executor, &runtime_code, "PowVerifyApi_verify_seal", &verify_args);
+	assert_eq!(bool::decode(&mut &out[..]), Ok(true));
+	call(&executor, &runtime_code, "PowVerifyApi_generate_mesh", &mesh_args);
+
+	c.bench_function("wasm_verify_seal", |b| {
+		b.iter(|| black_box(call(&executor, &runtime_code, "PowVerifyApi_verify_seal", &verify_args)))
+	});
+	c.bench_function("wasm_generate_mesh", |b| {
+		b.iter(|| black_box(call(&executor, &runtime_code, "PowVerifyApi_generate_mesh", &mesh_args)))
+	});
+}
+
+criterion_group!(benches, wasm_verify_path);
+criterion_main!(benches);


### PR DESCRIPTION
## Native segments

- Bench the poscan verify path with mesh_generation, scan and verify_seal cases to show where the time goes when tuning parameters
- Baseline on this machine reads 0.86ms mesh, 2.14ms scan, 3.14ms full replay

## Wasm runtime

- Drive PowVerifyApi on the real runtime blob through sc-executor with the node host functions, the same path block import takes
- Baseline reads 5.84ms wasm_verify_seal and 1.89ms wasm_generate_mesh, about 1.9x native

## Deps

- Add criterion 0.8.2 as a workspace dev dependency

Benches run locally on demand via cargo bench and never gate CI.