### PR TITLE
Brand the chain as Numen

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -10,7 +10,7 @@ pub type ChainSpec = sc_service::GenericChainSpec;
 fn chain_properties() -> sc_service::Properties {
 	serde_json::from_value(json!({
 		"tokenDecimals": 18,
-		"tokenSymbol": "UNIT"
+		"tokenSymbol": "NUMN"
 	}))
 	.expect("valid properties")
 }
@@ -20,8 +20,9 @@ pub fn development_chain_spec() -> Result<ChainSpec, String> {
 		WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
 		None,
 	)
-	.with_name("Development")
+	.with_name("Numen Development")
 	.with_id("dev")
+	.with_protocol_id("numen")
 	.with_chain_type(ChainType::Development)
 	.with_genesis_config_preset_name(sp_genesis_builder::DEV_RUNTIME_PRESET)
 	.with_properties(chain_properties())
@@ -33,8 +34,9 @@ pub fn local_chain_spec() -> Result<ChainSpec, String> {
 		WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
 		None,
 	)
-	.with_name("Local Testnet")
+	.with_name("Numen Local Testnet")
 	.with_id("local_testnet")
+	.with_protocol_id("numen")
 	.with_chain_type(ChainType::Local)
 	.with_genesis_config_preset_name(sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET)
 	.with_properties(chain_properties())
@@ -46,8 +48,9 @@ pub fn integration_chain_spec() -> Result<ChainSpec, String> {
 		WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
 		None,
 	)
-	.with_name("Integration Testnet")
+	.with_name("Numen Integration Testnet")
 	.with_id("integration")
+	.with_protocol_id("numen")
 	.with_chain_type(ChainType::Local)
 	.with_genesis_config_preset_name(INTEGRATION_RUNTIME_PRESET)
 	.with_properties(chain_properties())

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -13,7 +13,7 @@ use sp_keyring::Sr25519Keyring;
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
-		"Substrate Node".into()
+		"Numen Node".into()
 	}
 
 	fn impl_version() -> String {

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,4 +1,4 @@
-//! Substrate Node Template CLI library.
+//! Numen node CLI library.
 #![warn(missing_docs)]
 #![allow(clippy::result_large_err)]
 

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -1,7 +1,7 @@
 #[cfg(all(feature = "std", feature = "metadata-hash"))]
 fn main() {
 	substrate_wasm_builder::WasmBuilder::init_with_defaults()
-		.enable_metadata_hash("UNIT", 18)
+		.enable_metadata_hash("NUMN", 18)
 		.build();
 }
 

--- a/runtime/src/configs/evm.rs
+++ b/runtime/src/configs/evm.rs
@@ -84,12 +84,12 @@ impl FindAuthor<H160> for EvmFindAuthorZero {
 	}
 }
 
-/// ERC20 metadata for the native UNIT token, injected into the
+/// ERC20 metadata for the native token, injected into the
 /// `balances-erc20` precompile.
 pub struct NativeErc20Metadata;
 impl Erc20Metadata for NativeErc20Metadata {
-	const NAME: &'static str = "UNIT";
-	const SYMBOL: &'static str = "UNIT";
+	const NAME: &'static str = "Numen";
+	const SYMBOL: &'static str = "NUMN";
 	const DECIMALS: u8 = 18;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -62,8 +62,8 @@ impl_opaque_keys! {
 // https://docs.substrate.io/main-docs/build/upgrade#runtime-versioning
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-	spec_name: alloc::borrow::Cow::Borrowed("solochain-template-runtime"),
-	impl_name: alloc::borrow::Cow::Borrowed("solochain-template-runtime"),
+	spec_name: alloc::borrow::Cow::Borrowed("numen"),
+	impl_name: alloc::borrow::Cow::Borrowed("numen"),
 	authoring_version: 1,
 	// The version of the runtime specification. A full node will not attempt to use its native
 	//   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,

--- a/zombienet/evm-tooling/README.md
+++ b/zombienet/evm-tooling/README.md
@@ -1,7 +1,6 @@
 # EVM developer-tooling compatibility
 
-This directory verifies that the crypto-node Frontier EVM stack works with
-the mainstream Ethereum toolchain.
+This directory verifies that the crypto-node Frontier EVM stack works with the mainstream Ethereum toolchain.
 
 ## Layout
 
@@ -11,9 +10,7 @@ the mainstream Ethereum toolchain.
 | `foundry/`    | Foundry (`forge`/`cast`) | `forge build`, `forge create`, `forge script`, `cast call/send` |
 | `scripts/`    | ethers v6 + web3 v4      | native coin transfer + read-only RPC smoke checks               |
 
-The corresponding zombienet end-to-end scenario lives at
-[`../integration/scenarios/08-evm-tooling.zndsl`](../integration/scenarios/08-evm-tooling.zndsl)
-and is exercised by [`../integration/scripts/run-all.sh`](../integration/scripts/run-all.sh).
+The corresponding zombienet end-to-end scenario lives at [`../integration/scenarios/08-evm-tooling.zndsl`](../integration/scenarios/08-evm-tooling.zndsl) and is exercised by [`../integration/scripts/run-all.sh`](../integration/scripts/run-all.sh).
 
 ## Chain parameters
 
@@ -22,12 +19,11 @@ and is exercised by [`../integration/scripts/run-all.sh`](../integration/scripts
 | RPC URL (default)  | `http://127.0.0.1:9944` |
 | WebSocket URL      | `ws://127.0.0.1:9944`   |
 | Chain ID           | `32026`                 |
-| Currency symbol    | `UNIT`                  |
+| Currency symbol    | `NUMN`                  |
 | Decimals           | `18`                    |
 | Block explorer URL | _(none yet)_            |
 
-Start a single-node dev chain that exposes both the substrate and Ethereum
-RPC namespaces on the same port:
+Start a single-node dev chain that exposes both the substrate and Ethereum RPC namespaces on the same port:
 
 ```bash
 ./target/release/solochain-template-node --dev --rpc-cors all --rpc-port 9944
@@ -35,10 +31,7 @@ RPC namespaces on the same port:
 
 ## Pre-funded development accounts
 
-Every preset (`development`, `local_testnet`, `integration`) pre-funds the
-six well-known **Frontier dev ECDSA accounts** with `1,000,000 UNIT` each.
-Their private keys are publicly documented and ship with every Frontier
-template; **they MUST NOT be used in any non-development network.**
+Every preset (`development`, `local_testnet`, `integration`) pre-funds the six well-known **Frontier dev ECDSA accounts** with `1,000,000 NUMN` each. Their private keys are publicly documented and ship with every Frontier template; **they MUST NOT be used in any non-development network.**
 
 | Name      | Address                                      | Private key                                                          |
 | --------- | -------------------------------------------- | -------------------------------------------------------------------- |
@@ -49,8 +42,7 @@ template; **they MUST NOT be used in any non-development network.**
 | Ethan     | `0xFf64d3F6efE2317EE2807d223a0Bdc4c0c49dfDB` | `0x7dce9bc8babb68fec1409be38c8e1a52650206a7ed90ff956ae8a6d15eeaaef4` |
 | Faith     | `0xC0F0f4ab324C46e55D02D0033343B4Be8A55532d` | `0xb9d2ea9a615f3165812e8d44de0d24da9bbd164b65c4f0573e1ce2c8dbd9c8df` |
 
-The `runtime/tests/evm.rs` suite asserts that every preset emits exactly
-these six entries with the documented starting balance.
+The `runtime/tests/evm.rs` suite asserts that every preset emits exactly these six entries with the documented starting balance.
 
 ## MetaMask walkthrough
 
@@ -60,30 +52,23 @@ MetaMask is exercised manually; the steps below are the canonical recipe.
 
 Open MetaMask → **Networks → Add a custom network**:
 
-- Network name: `Crypto-Node Dev`
+- Network name: `Numen Dev`
 - New RPC URL: `http://127.0.0.1:9944`
 - Chain ID: `32026`
-- Currency symbol: `UNIT`
+- Currency symbol: `NUMN`
 - Block explorer URL: _(leave blank)_
 
-Save. MetaMask will validate that the RPC responds to `eth_chainId` and
-returns `0x7d1a` (== 32026).
+Save. MetaMask will validate that the RPC responds to `eth_chainId` and returns `0x7d1a` (== 32026).
 
 ### 2. Import a pre-funded account
 
-**Account menu → Add account or hardware wallet → Import account → Private
-key**, paste any of the keys from the table above (Alith is the canonical
-choice). The balance should immediately render as `1,000,000 UNIT`.
+**Account menu → Add account or hardware wallet → Import account → Private key**, paste any of the keys from the table above (Alith is the canonical choice). The balance should immediately render as `1,000,000 NUMN`.
 
 ### 3. Native coin transfer
 
-From the imported account, send any amount to a second imported account
-(e.g. Baltathar). Once the dev node mines the inclusion block (~20 s
-default `TargetBlockTime`), MetaMask reports the tx as **Confirmed** and
-both balances update accordingly.
+From the imported account, send any amount to a second imported account (e.g. Baltathar). Once the dev node mines the inclusion block (~20 s default `TargetBlockTime`), MetaMask reports the tx as **Confirmed** and both balances update accordingly.
 
-The same flow is automated by
-[`scripts/transfer-ethers.js`](scripts/transfer-ethers.js).
+The same flow is automated by [`scripts/transfer-ethers.js`](scripts/transfer-ethers.js).
 
 ### 4. Contract interaction
 
@@ -96,58 +81,28 @@ The same flow is automated by
    # prints: Token: 0x...
    ```
 
-2. In MetaMask: **Tokens → Import tokens → Custom token**, paste the
-   printed address. Symbol auto-fills as `CNT`, decimals as `18`.
+2. In MetaMask: **Tokens → Import tokens → Custom token**, paste the printed address. Symbol auto-fills as `CNT`, decimals as `18`.
 
-3. Use **Send** to transfer `CNT` between imported accounts. MetaMask
-   constructs the `transfer(address,uint256)` calldata, signs with the
-   imported key, and submits to the Frontier RPC. The receipt and updated
-   balances appear once the next block is mined.
+3. Use **Send** to transfer `CNT` between imported accounts. MetaMask constructs the `transfer(address,uint256)` calldata, signs with the imported key, and submits to the Frontier RPC. The receipt and updated balances appear once the next block is mined.
 
-If any step fails, capture the MetaMask "Activity → Speed up / Cancel"
-detail panel and the dev-node log; both are required for a useful bug
-report.
+If any step fails, capture the MetaMask "Activity → Speed up / Cancel" detail panel and the dev-node log; both are required for a useful bug report.
 
-## Native UNIT as ERC20 (precompile `0x0802`)
+## Native NUMN as ERC20 (precompile `0x0802`)
 
-The runtime exposes the native balance pallet through an ERC20-shaped
-precompile at `0x0000000000000000000000000000000000000802`
-(`pallet-evm-precompile-balances-erc20`). It serves two purposes:
+The runtime exposes the native balance pallet through an ERC20-shaped precompile at `0x0000000000000000000000000000000000000802` (`pallet-evm-precompile-balances-erc20`). It serves two purposes:
 
-1. **EVM-native UNIT as ERC20** — `name` / `symbol` / `decimals` /
-   `totalSupply` / `balanceOf` / `transfer` / `transferFrom` / `approve` /
-   `allowance` are routed straight to `pallet-balances`. Wallets and
-   contracts can therefore handle native UNIT through the same ERC20
-   tooling they already use.
-2. **EVM → Substrate bridge** — the non-standard
-   `withdraw(bytes32 dest, uint256 amount)` selector moves `amount` from
-   the caller's mirror substrate account to the substrate `AccountId32`
-   given by `dest`, emitting `Withdrawal(address,bytes32,uint256)`. This
-   is the supported way to move funds **back from the EVM side to a pure
-   substrate account** (e.g. Alice / Bob / sudo) — a vanilla EVM `value`
-   transfer cannot reach an `AccountId32` that has no `H160` preimage.
+1. **EVM-native NUMN as ERC20** — `name` / `symbol` / `decimals` / `totalSupply` / `balanceOf` / `transfer` / `transferFrom` / `approve` / `allowance` are routed straight to `pallet-balances`. Wallets and contracts can therefore handle native NUMN through the same ERC20 tooling they already use.
+2. **EVM → Substrate bridge** — the non-standard `withdraw(bytes32 dest, uint256 amount)` selector moves `amount` from the caller's mirror substrate account to the substrate `AccountId32` given by `dest`, emitting `Withdrawal(address,bytes32,uint256)`. This is the supported way to move funds **back from the EVM side to a pure substrate account** (e.g. Alice / Bob / sudo) — a vanilla EVM `value` transfer cannot reach an `AccountId32` that has no `H160` preimage.
 
-The Rust end-to-end coverage lives in
-[`runtime/tests/evm.rs`](../../runtime/tests/evm.rs)
-(`balances_erc20_precompile_balance_of_and_transfer_via_runner`). The
-JavaScript counterparts that drive the precompile through the live
-JSON-RPC are:
+The Rust end-to-end coverage lives in [`runtime/tests/evm.rs`](../../runtime/tests/evm.rs) (`balances_erc20_precompile_balance_of_and_transfer_via_runner`). The JavaScript counterparts that drive the precompile through the live JSON-RPC are:
 
-| Path                                                                                       | What it covers                                               |
-| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
-| [`scripts/transfer-precompile.js`](scripts/transfer-precompile.js)                         | ERC20 `transfer` of native UNIT (Alith → Baltathar via 0x0802) |
-| [`scripts/withdraw-to-substrate.js`](scripts/withdraw-to-substrate.js)                     | `withdraw(bytes32,uint256)` — Alith (EVM) → Alice (substrate) |
-| [`hardhat/test/NativeErc20.test.js`](hardhat/test/NativeErc20.test.js)                     | Hardhat assertion suite for `balanceOf` / `transfer` at 0x0802 |
-| [`../integration/js-scripts/evm-precompile-roundtrip.js`](../integration/js-scripts/evm-precompile-roundtrip.js) | Zombienet round-trip: substrate → EVM → substrate          |
+| Path                                                                                                             | What it covers                                                 |
+| ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [`scripts/transfer-precompile.js`](scripts/transfer-precompile.js)                                               | ERC20 `transfer` of native NUMN (Alith → Baltathar via 0x0802) |
+| [`scripts/withdraw-to-substrate.js`](scripts/withdraw-to-substrate.js)                                           | `withdraw(bytes32,uint256)` — Alith (EVM) → Alice (substrate)  |
+| [`hardhat/test/NativeErc20.test.js`](hardhat/test/NativeErc20.test.js)                                           | Hardhat assertion suite for `balanceOf` / `transfer` at 0x0802 |
+| [`../integration/js-scripts/evm-precompile-roundtrip.js`](../integration/js-scripts/evm-precompile-roundtrip.js) | Zombienet round-trip: substrate → EVM → substrate              |
 
-### MetaMask: import native UNIT as a token
+### MetaMask: import native NUMN as a token
 
-In MetaMask: **Tokens → Import tokens → Custom token**, paste
-`0x0000000000000000000000000000000000000802`. Symbol auto-fills as
-`UNIT`, decimals as `18`. The reported balance now mirrors the same
-account's `eth_getBalance`, and `Send` constructs an ERC20
-`transfer(address,uint256)` against the precompile instead of a value
-transaction. Withdrawing to a substrate account requires constructing
-the `withdraw` calldata manually (e.g. through Etherscan-style
-"interact with contract" dialogs); the canonical example is in
-`scripts/withdraw-to-substrate.js`.
+In MetaMask: **Tokens → Import tokens → Custom token**, paste `0x0000000000000000000000000000000000000802`. Symbol auto-fills as `NUMN`, decimals as `18`. The reported balance now mirrors the same account's `eth_getBalance`, and `Send` constructs an ERC20 `transfer(address,uint256)` against the precompile instead of a value transaction. Withdrawing to a substrate account requires constructing the `withdraw` calldata manually (e.g. through Etherscan-style "interact with contract" dialogs); the canonical example is in `scripts/withdraw-to-substrate.js`.

--- a/zombienet/evm-tooling/hardhat/test/NativeErc20.test.js
+++ b/zombienet/evm-tooling/hardhat/test/NativeErc20.test.js
@@ -1,4 +1,4 @@
-// Native UNIT as ERC20 (precompile at 0x0000…0802) round-trip.
+// Native NUMN as ERC20 (precompile at 0x0000…0802) round-trip.
 //
 //   npx hardhat --network cryptoNode test mocha
 //
@@ -22,13 +22,13 @@ const ERC20_ABI = [
   "function transfer(address,uint256) returns (bool)",
 ];
 
-describe("Native UNIT ERC20 precompile (0x0802)", function () {
+describe("Native NUMN ERC20 precompile (0x0802)", function () {
   this.timeout(120_000);
 
-  it("exposes UNIT metadata", async function () {
+  it("exposes NUMN metadata", async function () {
     const erc20 = new ethers.Contract(PRECOMPILE, ERC20_ABI, ethers.provider);
-    expect(await erc20.name()).to.equal("UNIT");
-    expect(await erc20.symbol()).to.equal("UNIT");
+    expect(await erc20.name()).to.equal("Numen");
+    expect(await erc20.symbol()).to.equal("NUMN");
     expect(Number(await erc20.decimals())).to.equal(18);
   });
 
@@ -41,7 +41,7 @@ describe("Native UNIT ERC20 precompile (0x0802)", function () {
     expect(erc20Bal).to.equal(nativeBal);
   });
 
-  it("transfer moves native UNIT between mirror accounts", async function () {
+  it("transfer moves native NUMN between mirror accounts", async function () {
     const [alith, baltathar] = await ethers.getSigners();
     const erc20 = new ethers.Contract(PRECOMPILE, ERC20_ABI, alith);
 

--- a/zombienet/evm-tooling/scripts/README.md
+++ b/zombienet/evm-tooling/scripts/README.md
@@ -19,7 +19,7 @@ node transfer-ethers.js
 # 4. read-only RPC smoke check
 node query-web3.js
 
-# 5. native UNIT as ERC20 via the 0x0802 precompile (Alith → Baltathar)
+# 5. native NUMN as ERC20 via the 0x0802 precompile (Alith → Baltathar)
 node transfer-precompile.js
 
 # 6. EVM → substrate withdrawal via 0x0802 (Alith → Alice)

--- a/zombienet/evm-tooling/scripts/query-web3.js
+++ b/zombienet/evm-tooling/scripts/query-web3.js
@@ -26,7 +26,7 @@ async function main() {
   ];
   for (const [name, addr] of accounts) {
     const bal = await web3.eth.getBalance(addr);
-    console.log(`${name} ${addr}: ${web3.utils.fromWei(bal, "ether")} UNIT`);
+    console.log(`${name} ${addr}: ${web3.utils.fromWei(bal, "ether")} NUMN`);
   }
 
   if (Number(chainId) !== 32026) {

--- a/zombienet/evm-tooling/scripts/transfer-ethers.js
+++ b/zombienet/evm-tooling/scripts/transfer-ethers.js
@@ -2,7 +2,7 @@
 //
 //   node transfer-ethers.js
 //
-// Defaults: Alith → Baltathar, 1.5 UNIT, RPC at 127.0.0.1:9944.
+// Defaults: Alith → Baltathar, 1.5 NUMN, RPC at 127.0.0.1:9944.
 
 const { JsonRpcProvider, Wallet, formatEther, parseEther } = require("ethers");
 
@@ -26,7 +26,7 @@ async function main() {
   const wallet = new Wallet(ALITH_PK, provider);
   console.log(`from:    ${wallet.address}`);
   console.log(`to:      ${BALTATHAR}`);
-  console.log(`amount:  ${formatEther(AMOUNT)} UNIT`);
+  console.log(`amount:  ${formatEther(AMOUNT)} NUMN`);
 
   const beforeFrom = await provider.getBalance(wallet.address);
   const beforeTo = await provider.getBalance(BALTATHAR);

--- a/zombienet/evm-tooling/scripts/transfer-precompile.js
+++ b/zombienet/evm-tooling/scripts/transfer-precompile.js
@@ -1,14 +1,14 @@
-// Native UNIT transfer through the ERC20 precompile at 0x0802.
+// Native NUMN transfer through the ERC20 precompile at 0x0802.
 //
 //   node transfer-precompile.js
 //
-// Defaults: Alith -> Baltathar, 1.5 UNIT, RPC at 127.0.0.1:9944.
+// Defaults: Alith -> Baltathar, 1.5 NUMN, RPC at 127.0.0.1:9944.
 //
 // Unlike `transfer-ethers.js` (which submits a vanilla EVM value tx), this
 // script invokes `transfer(address,uint256)` on the
 // `pallet-evm-precompile-balances-erc20` precompile. The on-chain effect is
 // identical (native balance moves between mirror substrate accounts), but
-// the call path proves that wallets / contracts treating UNIT as ERC20 work
+// the call path proves that wallets / contracts treating NUMN as ERC20 work
 // against the chain.
 
 const { JsonRpcProvider, Wallet, Contract, formatEther, parseEther } = require("ethers");
@@ -49,7 +49,7 @@ async function main() {
     erc20.decimals(),
   ]);
   console.log(`token:   ${name} (${symbol}, ${decimals} decimals) @ ${PRECOMPILE}`);
-  if (symbol !== "UNIT" || Number(decimals) !== 18) {
+  if (symbol !== "NUMN" || Number(decimals) !== 18) {
     console.error(`unexpected metadata: symbol=${symbol} decimals=${decimals}`);
     process.exit(1);
   }

--- a/zombienet/evm-tooling/scripts/withdraw-to-substrate.js
+++ b/zombienet/evm-tooling/scripts/withdraw-to-substrate.js
@@ -2,7 +2,7 @@
 //
 //   node withdraw-to-substrate.js
 //
-// Sends `amount` UNIT from Alith's mirror substrate account to a target
+// Sends `amount` NUMN from Alith's mirror substrate account to a target
 // substrate AccountId32 by invoking
 // `withdraw(bytes32 dest, uint256 amount)` on the precompile.
 //
@@ -59,10 +59,10 @@ async function main() {
 
   console.log(`from(EVM):       ${wallet.address}`);
   console.log(`to(substrate):   ${ALICE_PUBKEY}`);
-  console.log(`amount:          ${formatEther(AMOUNT)} UNIT`);
+  console.log(`amount:          ${formatEther(AMOUNT)} NUMN`);
 
   const before = await erc20.balanceOf(wallet.address);
-  console.log(`before alith:    ${formatEther(before)} UNIT`);
+  console.log(`before alith:    ${formatEther(before)} NUMN`);
 
   const tx = await erc20.withdraw(ALICE_PUBKEY, AMOUNT);
   console.log(`tx hash:         ${tx.hash}`);
@@ -83,7 +83,7 @@ async function main() {
   const srcTopic = getAddress("0x" + log.topics[1].slice(26));
   const destTopic = log.topics[2];
   const wad = BigInt(log.data);
-  console.log(`event Withdrawal src=${srcTopic} dest=${destTopic} wad=${formatEther(wad)} UNIT`);
+  console.log(`event Withdrawal src=${srcTopic} dest=${destTopic} wad=${formatEther(wad)} NUMN`);
 
   if (srcTopic !== getAddress(wallet.address)) {
     console.error(`event src mismatch: got ${srcTopic}, want ${wallet.address}`);
@@ -99,10 +99,10 @@ async function main() {
   }
 
   const after = await erc20.balanceOf(wallet.address);
-  console.log(`after alith:     ${formatEther(after)} UNIT`);
+  console.log(`after alith:     ${formatEther(after)} NUMN`);
   // After the call: balance must drop by at least `AMOUNT` (the rest is gas).
   if (before - after < AMOUNT) {
-    console.error(`alith delta ${formatEther(before - after)} UNIT < requested ${formatEther(AMOUNT)} UNIT`);
+    console.error(`alith delta ${formatEther(before - after)} NUMN < requested ${formatEther(AMOUNT)} NUMN`);
     process.exit(1);
   }
 }

--- a/zombienet/integration/README.md
+++ b/zombienet/integration/README.md
@@ -11,7 +11,7 @@ With `TargetBlockTime = 20s` (so `MINUTES = 3` blocks) the derived constants are
 | Constant                         | zombienet-runtime |
 | -------------------------------- | -----------: |
 | `SessionPeriod`                  |       3 mins |
-| `LockAmount`                     |       1 UNIT |
+| `LockAmount`                     |       1 NUMN |
 | `LockDuration`                   |       5 mins |
 | `RenewInterval`                  |       3 mins |
 | `RejoinCooldownPeriod`           |       1 mins |


### PR DESCRIPTION
## What

Names the chain Numen with token symbol NUMN across every user visible surface.

- Chain specs carry Numen display names, a numen libp2p protocol id and the NUMN token symbol
- Runtime spec_name and impl_name become numen
- The metadata hash and the balances erc20 precompile expose the token as Numen (NUMN, 18 decimals)
- Node impl name becomes Numen Node
- Zombienet scripts, hardhat assertions and READMEs track the new symbol

## What stays put

Chain spec ids (dev, local_testnet, integration), crate and binary names, the EVM chain id and the internal UNIT denomination constants are unchanged, so zombienet wiring and bench commands keep working.

## Verification

cargo check passes and the impact scan shows no affected execution flows.