### PR TITLE
Fix mining subscription firing on a timer instead of on task change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9848,6 +9848,7 @@ dependencies = [
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -11411,7 +11412,6 @@ dependencies = [
  "frame-metadata-hash-extension",
  "frame-system",
  "futures",
- "futures-timer",
  "jsonrpsee",
  "log",
  "pallet-ethereum",

--- a/consensus/sc-consensus-pow/Cargo.toml
+++ b/consensus/sc-consensus-pow/Cargo.toml
@@ -36,3 +36,4 @@ sp-inherents.workspace = true
 sp-runtime.default-features = true
 sp-runtime.workspace = true
 thiserror.workspace = true
+tokio = { features = ["sync"], workspace = true }

--- a/consensus/sc-consensus-pow/src/worker.rs
+++ b/consensus/sc-consensus-pow/src/worker.rs
@@ -22,6 +22,7 @@ use std::{
 	},
 	time::Duration,
 };
+use tokio::sync::watch;
 
 use crate::{PowAlgorithm, Seal, LOG_TARGET, POW_ENGINE_ID};
 
@@ -63,11 +64,9 @@ pub struct MiningHandle<
 	L: sc_consensus::JustificationSyncLink<Block>,
 > {
 	version: Arc<AtomicUsize>,
+	task_changed: watch::Sender<u64>,
 	algorithm: Arc<Algorithm>,
 	justification_sync_link: Arc<L>,
-	/// Builds for the current head, oldest first. A fresh task stacks on each
-	/// tick so a miner may solve any one still tied to the head; the head moving
-	/// on clears the lot. Bounded by `MAX_LIVE_TASKS`.
 	build: Arc<Mutex<VecDeque<MiningBuild<Block, Algorithm>>>>,
 	block_import: Arc<Mutex<BoxBlockImport<Block>>>,
 }
@@ -80,7 +79,8 @@ where
 	L: sc_consensus::JustificationSyncLink<Block>,
 {
 	fn increment_version(&self) {
-		self.version.fetch_add(1, Ordering::SeqCst);
+		let version = self.version.fetch_add(1, Ordering::SeqCst) + 1;
+		let _ = self.task_changed.send(version as u64);
 	}
 
 	pub(crate) fn new(
@@ -90,6 +90,7 @@ where
 	) -> Self {
 		Self {
 			version: Arc::new(AtomicUsize::new(0)),
+			task_changed: watch::channel(0).0,
 			algorithm: Arc::new(algorithm),
 			justification_sync_link: Arc::new(justification_sync_link),
 			build: Arc::new(Mutex::new(VecDeque::new())),
@@ -127,6 +128,12 @@ where
 	/// it can be certain that `best_hash` and `metadata` were not changed.
 	pub fn version(&self) -> Version {
 		Version(self.version.load(Ordering::SeqCst))
+	}
+
+	/// Subscribe to task changes so a caller can await the next task instead of
+	/// polling.
+	pub fn subscribe(&self) -> watch::Receiver<u64> {
+		self.task_changed.subscribe()
 	}
 
 	/// Get the current best hash. `None` if the worker has just started or the client is doing
@@ -239,6 +246,7 @@ where
 	fn clone(&self) -> Self {
 		Self {
 			version: self.version.clone(),
+			task_changed: self.task_changed.clone(),
 			algorithm: self.algorithm.clone(),
 			justification_sync_link: self.justification_sync_link.clone(),
 			build: self.build.clone(),

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,7 +24,6 @@ frame-metadata-hash-extension.workspace = true
 frame-system.default-features = true
 frame-system.workspace = true
 futures = { features = ["thread-pool"], workspace = true }
-futures-timer.workspace = true
 jsonrpsee = { features = ["server", "macros"], workspace = true }
 tokio = { features = ["rt"], workspace = true }
 log.workspace = true

--- a/node/src/mining_rpc.rs
+++ b/node/src/mining_rpc.rs
@@ -7,9 +7,8 @@
 //! pre-runtime digest the node builds, so an external miner cannot redirect the
 //! reward.
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
-use futures_timer::Delay;
 use jsonrpsee::{
 	core::{
 		async_trait,
@@ -21,10 +20,7 @@ use jsonrpsee::{
 };
 use serde::{Deserialize, Serialize};
 use sp_core::{Bytes, H256, U256};
-
-/// Push a fresh task to subscribers on this cadence, matching the new-task
-/// generation interval.
-const TASK_INTERVAL: Duration = Duration::from_secs(1);
+use tokio::sync::watch;
 
 /// No mining task exists yet (worker just started or syncing).
 const NO_TASK: i32 = 9001;
@@ -47,6 +43,10 @@ pub trait ExternalMiner: Send + Sync {
 	/// new or old; a `pre_hash` the head has moved past is gone, so it returns
 	/// `false`.
 	fn submit_seal(&self, pre_hash: H256, seal: Vec<u8>) -> bool;
+
+	/// A receiver that wakes on every task change, letting the subscription await
+	/// the next task instead of polling.
+	fn task_changes(&self) -> watch::Receiver<u64>;
 }
 
 /// Everything an external miner needs to compute the work for one task.
@@ -117,16 +117,15 @@ impl MiningApiServer for Mining {
 
 	async fn subscribe_task(&self, pending: PendingSubscriptionSink) -> SubscriptionResult {
 		let sink = pending.accept().await?;
-		let mut first = true;
+		// Subscribe before the first read so a task built in the gap still wakes us.
+		let mut changes = self.handle.task_changes();
 		loop {
-			if !first {
-				Delay::new(TASK_INTERVAL).await;
-			}
-			first = false;
-
 			if let Some(task) = task_of(&*self.handle, &self.miner, &self.protocol)
 				&& sink.send(SubscriptionMessage::from_json(&task)?).await.is_err()
 			{
+				break;
+			}
+			if changes.changed().await.is_err() {
 				break;
 			}
 		}
@@ -159,11 +158,17 @@ mod tests {
 		latest: Option<(H256, U256)>,
 		live: Vec<H256>,
 		submitted: Mutex<Vec<(H256, Vec<u8>)>>,
+		changes: watch::Sender<u64>,
 	}
 
 	impl MockMiner {
 		fn new(latest: Option<(H256, U256)>, live: Vec<H256>) -> Arc<Self> {
-			Arc::new(Self { latest, live, submitted: Mutex::new(Vec::new()) })
+			Arc::new(Self {
+				latest,
+				live,
+				submitted: Mutex::new(Vec::new()),
+				changes: watch::channel(0).0,
+			})
 		}
 	}
 
@@ -175,6 +180,10 @@ mod tests {
 		fn submit_seal(&self, pre_hash: H256, seal: Vec<u8>) -> bool {
 			self.submitted.lock().unwrap().push((pre_hash, seal));
 			self.live.contains(&pre_hash)
+		}
+
+		fn task_changes(&self) -> watch::Receiver<u64> {
+			self.changes.subscribe()
 		}
 	}
 

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -175,6 +175,10 @@ where
 	fn submit_seal(&self, pre_hash: H256, seal: Vec<u8>) -> bool {
 		futures::executor::block_on(self.submit(pre_hash, seal))
 	}
+
+	fn task_changes(&self) -> tokio::sync::watch::Receiver<u64> {
+		self.subscribe()
+	}
 }
 
 struct BestSolution {
@@ -385,6 +389,8 @@ pub fn new_full<
 			);
 
 			log::info!(target: "pow", "👛 Miner: {}", miner);
+			log::info!(target: "pow", "🧵 Mining thread(s): {}", node_miner);
+
 			let pre_runtime = codec::Encode::encode(&miner);
 
 			let (mining_handle, mining_worker) = sc_consensus_pow::start_mining_worker(


### PR DESCRIPTION
The subscription resent the current task on its own one second timer, decoupled from when the worker rebuilds tasks. After a new block the miner kept hashing the stale head until the next tick, and duplicate pushes went out in between.

Wire it to the worker instead. A watch channel fires on every build, head move, or sync reset, so each new task goes out once, the moment it exists. Drop the now unused futures-timer from the node.