### PR TITLE
Add testnet and mainnet chain specs

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,7 +1,7 @@
 use sc_service::ChainType;
 use serde_json::json;
 use solochain_template_runtime::{
-	configs::SS58Prefix, genesis_config_presets::INTEGRATION_RUNTIME_PRESET, WASM_BINARY,
+	configs::SS58Prefix, genesis_config_presets::{INTEGRATION_RUNTIME_PRESET, TESTNET_RUNTIME_PRESET, MAINNET_RUNTIME_PRESET}, WASM_BINARY,
 };
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
@@ -30,6 +30,20 @@ pub fn development_chain_spec() -> Result<ChainSpec, String> {
 	.build())
 }
 
+pub fn integration_chain_spec() -> Result<ChainSpec, String> {
+	Ok(ChainSpec::builder(
+		WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
+		None,
+	)
+	.with_name("Numen Integration Testnet")
+	.with_id("integration")
+	.with_protocol_id("numen")
+	.with_chain_type(ChainType::Local)
+	.with_genesis_config_preset_name(INTEGRATION_RUNTIME_PRESET)
+	.with_properties(chain_properties())
+	.build())
+}
+
 pub fn local_chain_spec() -> Result<ChainSpec, String> {
 	Ok(ChainSpec::builder(
 		WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
@@ -44,16 +58,30 @@ pub fn local_chain_spec() -> Result<ChainSpec, String> {
 	.build())
 }
 
-pub fn integration_chain_spec() -> Result<ChainSpec, String> {
+pub fn testnet_chain_spec() -> Result<ChainSpec, String> {
 	Ok(ChainSpec::builder(
 		WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
 		None,
 	)
-	.with_name("Numen Integration Testnet")
-	.with_id("integration")
+	.with_name("Numen Testnet")
+	.with_id("testnet")
 	.with_protocol_id("numen")
-	.with_chain_type(ChainType::Local)
-	.with_genesis_config_preset_name(INTEGRATION_RUNTIME_PRESET)
+	.with_chain_type(ChainType::Live)
+	.with_genesis_config_preset_name(TESTNET_RUNTIME_PRESET)
+	.with_properties(chain_properties())
+	.build())
+}
+
+pub fn mainnet_chain_spec() -> Result<ChainSpec, String> {
+	Ok(ChainSpec::builder(
+		WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
+		None,
+	)
+	.with_name("Numen Mainnet")
+	.with_id("mainnet")
+	.with_protocol_id("numen")
+	.with_chain_type(ChainType::Live)
+	.with_genesis_config_preset_name(MAINNET_RUNTIME_PRESET)
 	.with_properties(chain_properties())
 	.build())
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -7,11 +7,11 @@ use solochain_template_runtime::{
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::GenericChainSpec;
 
-fn chain_properties() -> sc_service::Properties {
+fn chain_properties(token_symbol: &str) -> sc_service::Properties {
 	serde_json::from_value(json!({
 		"ss58Format": SS58Prefix::get(),
 		"tokenDecimals": 18,
-		"tokenSymbol": "NUMN"
+		"tokenSymbol": token_symbol
 	}))
 	.expect("valid properties")
 }
@@ -26,7 +26,7 @@ pub fn development_chain_spec() -> Result<ChainSpec, String> {
 	.with_protocol_id("numen")
 	.with_chain_type(ChainType::Development)
 	.with_genesis_config_preset_name(sp_genesis_builder::DEV_RUNTIME_PRESET)
-	.with_properties(chain_properties())
+	.with_properties(chain_properties("tNUMN"))
 	.build())
 }
 
@@ -40,7 +40,7 @@ pub fn integration_chain_spec() -> Result<ChainSpec, String> {
 	.with_protocol_id("numen")
 	.with_chain_type(ChainType::Local)
 	.with_genesis_config_preset_name(INTEGRATION_RUNTIME_PRESET)
-	.with_properties(chain_properties())
+	.with_properties(chain_properties("tNUMN"))
 	.build())
 }
 
@@ -54,7 +54,7 @@ pub fn local_chain_spec() -> Result<ChainSpec, String> {
 	.with_protocol_id("numen")
 	.with_chain_type(ChainType::Local)
 	.with_genesis_config_preset_name(sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET)
-	.with_properties(chain_properties())
+	.with_properties(chain_properties("tNUMN"))
 	.build())
 }
 
@@ -68,7 +68,7 @@ pub fn testnet_chain_spec() -> Result<ChainSpec, String> {
 	.with_protocol_id("numen")
 	.with_chain_type(ChainType::Live)
 	.with_genesis_config_preset_name(TESTNET_RUNTIME_PRESET)
-	.with_properties(chain_properties())
+	.with_properties(chain_properties("tNUMN"))
 	.build())
 }
 
@@ -82,6 +82,6 @@ pub fn mainnet_chain_spec() -> Result<ChainSpec, String> {
 	.with_protocol_id("numen")
 	.with_chain_type(ChainType::Live)
 	.with_genesis_config_preset_name(MAINNET_RUNTIME_PRESET)
-	.with_properties(chain_properties())
+	.with_properties(chain_properties("NUMN"))
 	.build())
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -37,13 +37,20 @@ impl SubstrateCli for Cli {
 	}
 
 	fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
-		Ok(match id {
-			"dev" => Box::new(chain_spec::development_chain_spec()?),
-			"" | "local" => Box::new(chain_spec::local_chain_spec()?),
-			"integration" => Box::new(chain_spec::integration_chain_spec()?),
-			path =>
-				Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?),
-		})
+		match id {
+			"dev" => Ok(Box::new(chain_spec::development_chain_spec()?)),
+			"integration" => Ok(Box::new(chain_spec::integration_chain_spec()?)),
+			"local" => Ok(Box::new(chain_spec::local_chain_spec()?)),
+			"testnet" => Ok(Box::new(chain_spec::testnet_chain_spec()?)),
+			"mainnet" => Ok(Box::new(chain_spec::mainnet_chain_spec()?)),
+			"" => Err(
+				"Chain specification not provided. Please specify it with the argument `--chain <SPEC>`."
+					.to_owned(),
+			),
+			path => Ok(Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(
+				path,
+			))?)),
+		}
 	}
 }
 

--- a/pallets/reward/src/lib.rs
+++ b/pallets/reward/src/lib.rs
@@ -77,10 +77,6 @@ pub mod pallet {
             reward
         }
 
-        /// Extract the block author from the PoW pre-runtime digest.
-        ///
-        /// The miner encodes their `AccountId` as the payload of a
-        /// `PreRuntime(POW_ENGINE_ID, _)` digest item.
         fn find_author() -> Option<T::AccountId> {
             let digest = frame_system::Pallet::<T>::digest();
             T::FindAuthor::find_author(digest.logs.iter().filter_map(|log| log.as_pre_runtime()))

--- a/pallets/reward/src/lib.rs
+++ b/pallets/reward/src/lib.rs
@@ -77,6 +77,10 @@ pub mod pallet {
             reward
         }
 
+        /// Extract the block author from the PoW pre-runtime digest.
+        ///
+        /// The miner encodes their `AccountId` as the payload of a
+        /// `PreRuntime(POW_ENGINE_ID, _)` digest item.
         fn find_author() -> Option<T::AccountId> {
             let digest = frame_system::Pallet::<T>::digest();
             T::FindAuthor::find_author(digest.logs.iter().filter_map(|log| log.as_pre_runtime()))

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -130,11 +130,13 @@ impl pallet_balances::Config for Runtime {
 }
 
 parameter_types! {
-	/// Initial block reward: 16 UNIT per block, halving every `HalvingInterval`.
+	/// Reward for the first halving period, in smallest units.
 	pub const InitialReward: Balance = 16 * super::UNIT;
-	/// Blocks between reward halvings (~4 years at a 10s block time). The
-	/// geometric series caps total mined issuance at `2 * InitialReward *
-	/// HalvingInterval` = 400,000,000 UNIT.
+	/// Blocks between reward halvings. The 400,000,000 UNIT cap on total mined
+	/// issuance is the geometric sum `2 * InitialReward * HalvingInterval`, so
+	/// this interval follows from the cap rather than from a wall-clock target.
+	/// It lands near four years at a 10s block time, and retuning
+	/// `TargetBlockTime` moves that duration without touching the cap.
 	pub const HalvingInterval: BlockNumber = 12_500_000;
 }
 

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -130,13 +130,11 @@ impl pallet_balances::Config for Runtime {
 }
 
 parameter_types! {
-	/// Reward for the first halving period, in smallest units.
+	/// Initial block reward: 16 UNIT per block, halving every `HalvingInterval`.
 	pub const InitialReward: Balance = 16 * super::UNIT;
-	/// Blocks between reward halvings. The 400,000,000 UNIT cap on total mined
-	/// issuance is the geometric sum `2 * InitialReward * HalvingInterval`, so
-	/// this interval follows from the cap rather than from a wall-clock target.
-	/// It lands near four years at a 10s block time, and retuning
-	/// `TargetBlockTime` moves that duration without touching the cap.
+	/// Blocks between reward halvings (~4 years at a 10s block time). The
+	/// geometric series caps total mined issuance at `2 * InitialReward *
+	/// HalvingInterval` = 400,000,000 UNIT.
 	pub const HalvingInterval: BlockNumber = 12_500_000;
 }
 

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -334,9 +334,9 @@ impl pallet_grandpa::Config for Runtime {
 /// Block-author finder shared by `pallet-authorship` and `pallet-reward`.
 ///
 /// The internal and external miners write the block author as the payload of a
-/// `PreRuntime(POW_ENGINE_ID, _)` digest. Decoding it here lets fee routing
-/// ([`DealWithFees`]) credit the miner and lets the GRANDPA equivocation report
-/// pipeline attribute a reporter.
+/// `PreRuntime(POW_ENGINE_ID, _)` digest. Decoding it in one place lets fee
+/// routing ([`DealWithFees`]) credit the miner, pays out the block reward, and
+/// lets the GRANDPA equivocation report pipeline attribute a reporter.
 pub struct PowFindAuthor;
 
 impl frame_support::traits::FindAuthor<AccountId> for PowFindAuthor {

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -334,9 +334,9 @@ impl pallet_grandpa::Config for Runtime {
 /// Block-author finder shared by `pallet-authorship` and `pallet-reward`.
 ///
 /// The internal and external miners write the block author as the payload of a
-/// `PreRuntime(POW_ENGINE_ID, _)` digest. Decoding it in one place lets fee
-/// routing ([`DealWithFees`]) credit the miner, pays out the block reward, and
-/// lets the GRANDPA equivocation report pipeline attribute a reporter.
+/// `PreRuntime(POW_ENGINE_ID, _)` digest. Decoding it here lets fee routing
+/// ([`DealWithFees`]) credit the miner and lets the GRANDPA equivocation report
+/// pipeline attribute a reporter.
 pub struct PowFindAuthor;
 
 impl frame_support::traits::FindAuthor<AccountId> for PowFindAuthor {

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -132,11 +132,9 @@ impl pallet_balances::Config for Runtime {
 parameter_types! {
 	/// Reward for the first halving period, in smallest units.
 	pub const InitialReward: Balance = 16 * super::UNIT;
-	/// Blocks between reward halvings. The 400,000,000 UNIT cap on total mined
-	/// issuance is the geometric sum `2 * InitialReward * HalvingInterval`, so
-	/// this interval follows from the cap rather than from a wall-clock target.
-	/// It lands near four years at a 10s block time, and retuning
-	/// `TargetBlockTime` moves that duration without touching the cap.
+	/// Blocks between reward halvings (~4 years at a 10s block time). The
+	/// geometric series caps total mined issuance at `2 * InitialReward *
+	/// HalvingInterval` = 400,000,000 UNIT.
 	pub const HalvingInterval: BlockNumber = 12_500_000;
 }
 
@@ -336,9 +334,9 @@ impl pallet_grandpa::Config for Runtime {
 /// Block-author finder shared by `pallet-authorship` and `pallet-reward`.
 ///
 /// The internal and external miners write the block author as the payload of a
-/// `PreRuntime(POW_ENGINE_ID, _)` digest. Decoding it in one place lets fee
-/// routing ([`DealWithFees`]) credit the miner, pays out the block reward, and
-/// lets the GRANDPA equivocation report pipeline attribute a reporter.
+/// `PreRuntime(POW_ENGINE_ID, _)` digest. Decoding it here lets fee routing
+/// ([`DealWithFees`]) credit the miner, enables block reward payouts, and lets
+/// the GRANDPA equivocation report pipeline attribute a reporter.
 pub struct PowFindAuthor;
 
 impl frame_support::traits::FindAuthor<AccountId> for PowFindAuthor {

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -241,7 +241,77 @@ pub fn integration_config_genesis() -> Value {
 	)
 }
 
+pub fn testnet_config_genesis() -> Value {
+	testnet_genesis_with_extra_keys(
+		vec![
+			Sr25519Keyring::Alice.to_account_id(),
+			Sr25519Keyring::Bob.to_account_id(),
+			Sr25519Keyring::Charlie.to_account_id(),
+			Sr25519Keyring::Dave.to_account_id(),
+			Sr25519Keyring::Eve.to_account_id(),
+			Sr25519Keyring::Ferdie.to_account_id(),
+			Sr25519Keyring::AliceStash.to_account_id(),
+			Sr25519Keyring::BobStash.to_account_id(),
+		],
+		Sr25519Keyring::Alice.to_account_id(),
+		vec![
+			(
+				Sr25519Keyring::Alice.to_account_id(),
+				Ed25519Keyring::Alice.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Alice),
+			),
+			(
+				Sr25519Keyring::Bob.to_account_id(),
+				Ed25519Keyring::Bob.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Bob),
+			),
+			(
+				Sr25519Keyring::Charlie.to_account_id(),
+				Ed25519Keyring::Charlie.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Charlie),
+			),
+		],
+		vec![],
+	)
+}
+
+pub fn mainnet_config_genesis() -> Value {
+	testnet_genesis_with_extra_keys(
+		vec![
+			Sr25519Keyring::Alice.to_account_id(),
+			Sr25519Keyring::Bob.to_account_id(),
+			Sr25519Keyring::Charlie.to_account_id(),
+			Sr25519Keyring::Dave.to_account_id(),
+			Sr25519Keyring::Eve.to_account_id(),
+			Sr25519Keyring::Ferdie.to_account_id(),
+			Sr25519Keyring::AliceStash.to_account_id(),
+			Sr25519Keyring::BobStash.to_account_id(),
+		],
+		Sr25519Keyring::Alice.to_account_id(),
+		vec![
+			(
+				Sr25519Keyring::Alice.to_account_id(),
+				Ed25519Keyring::Alice.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Alice),
+			),
+			(
+				Sr25519Keyring::Bob.to_account_id(),
+				Ed25519Keyring::Bob.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Bob),
+			),
+			(
+				Sr25519Keyring::Charlie.to_account_id(),
+				Ed25519Keyring::Charlie.public().into(),
+				im_online_from_keyring(Sr25519Keyring::Charlie),
+			),
+		],
+		vec![],
+	)
+}
+
 pub const INTEGRATION_RUNTIME_PRESET: &str = "integration";
+pub const TESTNET_RUNTIME_PRESET: &str = "testnet";
+pub const MAINNET_RUNTIME_PRESET: &str = "mainnet";
 
 /// Provides the JSON representation of predefined genesis config for given `id`.
 pub fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
@@ -249,6 +319,8 @@ pub fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
 		sp_genesis_builder::DEV_RUNTIME_PRESET => development_config_genesis(),
 		sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET => local_config_genesis(),
 		INTEGRATION_RUNTIME_PRESET => integration_config_genesis(),
+		TESTNET_RUNTIME_PRESET => testnet_config_genesis(),
+		MAINNET_RUNTIME_PRESET => mainnet_config_genesis(),
 		_ => return None,
 	};
 	Some(
@@ -264,5 +336,7 @@ pub fn preset_names() -> Vec<PresetId> {
 		PresetId::from(sp_genesis_builder::DEV_RUNTIME_PRESET),
 		PresetId::from(sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET),
 		PresetId::from(INTEGRATION_RUNTIME_PRESET),
+		PresetId::from(TESTNET_RUNTIME_PRESET),
+		PresetId::from(MAINNET_RUNTIME_PRESET),
 	]
 }

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -12,6 +12,11 @@ use sp_core::{H160, U256};
 use sp_genesis_builder::{self, PresetId};
 use sp_keyring::{Ed25519Keyring, Sr25519Keyring};
 
+/// Genesis issuance seeded into the substrate-side balances, split evenly
+/// across the endowed accounts. The remaining 400 million UNIT of the 1 billion
+/// UNIT supply cap is emitted over time as mining rewards.
+const GENESIS_ISSUANCE: u128 = 600_000_000 * UNIT;
+
 /// Per-account starting balance for the well-known Frontier dev EVM accounts,
 /// pre-funded only by the development-facing presets (dev / local /
 /// integration). One million UNIT is far more than any tooling test needs.
@@ -83,7 +88,13 @@ fn testnet_genesis(
 	root: AccountId,
 	initial_validators: Vec<(AccountId, GrandpaId, ImOnlineId)>,
 ) -> Value {
-	testnet_genesis_with_extra_keys(endowed_accounts, root, initial_validators, Vec::new())
+	testnet_genesis_with_extra_keys(
+		endowed_accounts,
+		root,
+		initial_validators,
+		Vec::new(),
+		dev_evm_accounts(),
+	)
 }
 
 fn testnet_genesis_with_extra_keys(
@@ -91,9 +102,9 @@ fn testnet_genesis_with_extra_keys(
 	root: AccountId,
 	initial_validators: Vec<(AccountId, GrandpaId, ImOnlineId)>,
 	extra_session_keys: Vec<(AccountId, GrandpaId, ImOnlineId)>,
+	evm_accounts: BTreeMap<H160, GenesisAccount>,
 ) -> Value {
-	let total_supply: u128 = 1_000_000_000 * UNIT;
-	let balance_per_account = total_supply / endowed_accounts.len() as u128;
+	let balance_per_account = GENESIS_ISSUANCE / endowed_accounts.len() as u128;
 	let initial_difficulty = U256::from(1_000u64);
 	let validator_accounts: Vec<AccountId> =
 		initial_validators.iter().map(|(a, _, _)| a.clone()).collect();
@@ -134,7 +145,7 @@ fn testnet_genesis_with_extra_keys(
 			..Default::default()
 		},
 		evm: EVMConfig {
-			accounts: dev_evm_accounts(),
+			accounts: evm_accounts,
 			..Default::default()
 		},
 	})
@@ -237,6 +248,7 @@ pub fn integration_config_genesis() -> Value {
 			),
 		],
 		vec![],
+		dev_evm_accounts(),
 	)
 }
 
@@ -271,6 +283,7 @@ pub fn testnet_config_genesis() -> Value {
 			),
 		],
 		vec![],
+		BTreeMap::new(),
 	)
 }
 
@@ -305,6 +318,7 @@ pub fn mainnet_config_genesis() -> Value {
 			),
 		],
 		vec![],
+		BTreeMap::new(),
 	)
 }
 

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -12,10 +12,9 @@ use sp_core::{H160, U256};
 use sp_genesis_builder::{self, PresetId};
 use sp_keyring::{Ed25519Keyring, Sr25519Keyring};
 
-/// Per-account starting balance for the well-known Frontier dev EVM accounts
-/// pre-funded by every preset (including `integration`). One million UNIT is
-/// far more than any tooling test needs, while still leaving headroom against
-/// the 1 billion UNIT total supply seeded into the substrate-side balances.
+/// Per-account starting balance for the well-known Frontier dev EVM accounts,
+/// pre-funded only by the development-facing presets (dev / local /
+/// integration). One million UNIT is far more than any tooling test needs.
 const DEV_EVM_ACCOUNT_BALANCE: u128 = 1_000_000 * UNIT;
 
 /// Genesis treasury endowment. 600M NUMN seeded once into the on-chain treasury

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -12,20 +12,22 @@ use sp_core::{H160, U256};
 use sp_genesis_builder::{self, PresetId};
 use sp_keyring::{Ed25519Keyring, Sr25519Keyring};
 
-/// Genesis issuance seeded into the substrate-side balances, split evenly
-/// across the endowed accounts. The remaining 400 million UNIT of the 1 billion
-/// UNIT supply cap is emitted over time as mining rewards.
+/// Genesis issuance minted to the treasury by the testnet and mainnet
+/// presets. The remaining 400 million UNIT of the 1 billion UNIT supply cap
+/// is emitted over time as mining rewards.
 const GENESIS_ISSUANCE: u128 = 600_000_000 * UNIT;
 
-/// Per-account starting balance for the well-known Frontier dev EVM accounts,
-/// pre-funded only by the development-facing presets (dev / local /
-/// integration). One million UNIT is far more than any tooling test needs.
-const DEV_EVM_ACCOUNT_BALANCE: u128 = 1_000_000 * UNIT;
+/// Starting balance for the placeholder testnet operator accounts. Kept small
+/// so the testnet ledger stays dominated by the treasury and mirrors the
+/// mainnet genesis shape.
+const TESTNET_ACCOUNT_BALANCE: u128 = 1_000_000 * UNIT;
 
-/// Genesis treasury endowment. 600M NUMN seeded once into the on-chain treasury
-/// pot, which has no ongoing income. Dev presets keep their own account funding
-/// on top for testing.
-const TREASURY_GENESIS_ENDOWMENT: u128 = 600_000_000 * UNIT;
+/// Per-account starting balance for the well-known Frontier dev EVM accounts
+/// pre-funded by the dev, local and integration presets. The EVM genesis
+/// mints these funds on top of the balances pallet issuance, pushing dev
+/// chains past the nominal supply cap. That is harmless on throwaway
+/// networks, and one million UNIT is far more than any tooling test needs.
+const DEV_EVM_ACCOUNT_BALANCE: u128 = 1_000_000 * UNIT;
 
 /// Well-known Frontier dev ECDSA accounts pre-funded on the EVM side.
 ///
@@ -83,74 +85,6 @@ fn dev_evm_accounts() -> BTreeMap<H160, GenesisAccount> {
 	.collect()
 }
 
-fn testnet_genesis(
-	endowed_accounts: Vec<AccountId>,
-	root: AccountId,
-	initial_validators: Vec<(AccountId, GrandpaId, ImOnlineId)>,
-) -> Value {
-	testnet_genesis_with_extra_keys(
-		endowed_accounts,
-		root,
-		initial_validators,
-		Vec::new(),
-		dev_evm_accounts(),
-	)
-}
-
-fn testnet_genesis_with_extra_keys(
-	endowed_accounts: Vec<AccountId>,
-	root: AccountId,
-	initial_validators: Vec<(AccountId, GrandpaId, ImOnlineId)>,
-	extra_session_keys: Vec<(AccountId, GrandpaId, ImOnlineId)>,
-	evm_accounts: BTreeMap<H160, GenesisAccount>,
-) -> Value {
-	let balance_per_account = GENESIS_ISSUANCE / endowed_accounts.len() as u128;
-	let initial_difficulty = U256::from(1_000u64);
-	let validator_accounts: Vec<AccountId> =
-		initial_validators.iter().map(|(a, _, _)| a.clone()).collect();
-	let mut session_keys: Vec<(AccountId, AccountId, SessionKeys)> = initial_validators
-		.into_iter()
-		.map(|(account, grandpa, im_online)| {
-			(account.clone(), account, SessionKeys { grandpa, im_online })
-		})
-		.collect();
-	for (account, grandpa, im_online) in extra_session_keys.into_iter() {
-		session_keys.push((account.clone(), account, SessionKeys { grandpa, im_online }));
-	}
-	let mut initial_balances: Vec<(AccountId, u128)> = endowed_accounts
-		.iter()
-		.cloned()
-		.map(|k| (k, balance_per_account))
-		.collect();
-	initial_balances.push((crate::configs::TreasuryAccount::get(), TREASURY_GENESIS_ENDOWMENT));
-
-	build_struct_json_patch!(RuntimeGenesisConfig {
-		balances: BalancesConfig {
-			balances: initial_balances,
-		},
-		sudo: SudoConfig { key: Some(root) },
-		difficulty: DifficultyConfig {
-			initial_difficulty,
-			// anchor_target: U256::zero(),
-			// anchor_timestamp: 0,
-			// anchor_height: 0,
-		},
-		session: SessionConfig { keys: session_keys },
-		validator: ValidatorConfig {
-			initial_validators: validator_accounts,
-			..Default::default()
-		},
-		evm_chain_id: EVMChainIdConfig {
-			chain_id: 32026,
-			..Default::default()
-		},
-		evm: EVMConfig {
-			accounts: evm_accounts,
-			..Default::default()
-		},
-	})
-}
-
 /// Derive an `ImOnlineId` from an Sr25519 dev keyring entry.
 ///
 /// Heartbeat keys live under their own key type (`imon`) but the underlying
@@ -160,166 +94,243 @@ fn im_online_from_keyring(keyring: Sr25519Keyring) -> ImOnlineId {
 	keyring.public().into()
 }
 
+/// Build the `(validator, validator, SessionKeys)` triples the session pallet
+/// expects. The account repeats because the validator is also the owner of its
+/// registered session keys.
+fn session_keys(
+	validators: &[(AccountId, GrandpaId, ImOnlineId)],
+) -> Vec<(AccountId, AccountId, SessionKeys)> {
+	validators
+		.iter()
+		.cloned()
+		.map(|(account, grandpa, im_online)| {
+			(account.clone(), account, SessionKeys { grandpa, im_online })
+		})
+		.collect()
+}
+
 pub fn development_config_genesis() -> Value {
-	testnet_genesis(
-		vec![
-			Sr25519Keyring::Alice.to_account_id(),
-			Sr25519Keyring::Bob.to_account_id(),
-			Sr25519Keyring::Charlie.to_account_id(),
-			Sr25519Keyring::AliceStash.to_account_id(),
-			Sr25519Keyring::BobStash.to_account_id(),
-		],
+	let endowed_accounts = vec![
 		Sr25519Keyring::Alice.to_account_id(),
-		vec![
-			(
-				Sr25519Keyring::Alice.to_account_id(),
-				Ed25519Keyring::Alice.public().into(),
-				im_online_from_keyring(Sr25519Keyring::Alice),
-			),
-			(
-				Sr25519Keyring::Bob.to_account_id(),
-				Ed25519Keyring::Bob.public().into(),
-				im_online_from_keyring(Sr25519Keyring::Bob),
-			),
-			(
-				Sr25519Keyring::Charlie.to_account_id(),
-				Ed25519Keyring::Charlie.public().into(),
-				im_online_from_keyring(Sr25519Keyring::Charlie),
-			),
-		],
-	)
+		Sr25519Keyring::Bob.to_account_id(),
+		Sr25519Keyring::Charlie.to_account_id(),
+		Sr25519Keyring::AliceStash.to_account_id(),
+		Sr25519Keyring::BobStash.to_account_id(),
+	];
+	let validators: Vec<(AccountId, GrandpaId, ImOnlineId)> = vec![
+		(
+			Sr25519Keyring::Alice.to_account_id(),
+			Ed25519Keyring::Alice.public().into(),
+			im_online_from_keyring(Sr25519Keyring::Alice),
+		),
+		(
+			Sr25519Keyring::Bob.to_account_id(),
+			Ed25519Keyring::Bob.public().into(),
+			im_online_from_keyring(Sr25519Keyring::Bob),
+		),
+		(
+			Sr25519Keyring::Charlie.to_account_id(),
+			Ed25519Keyring::Charlie.public().into(),
+			im_online_from_keyring(Sr25519Keyring::Charlie),
+		),
+	];
+	let total_supply: u128 = 1_000_000_000 * UNIT;
+	let balance_per_account = total_supply / endowed_accounts.len() as u128;
+	build_struct_json_patch!(RuntimeGenesisConfig {
+		balances: BalancesConfig {
+			balances: endowed_accounts
+				.iter()
+				.cloned()
+				.map(|k| (k, balance_per_account))
+				.collect::<Vec<_>>(),
+		},
+		sudo: SudoConfig { key: Some(Sr25519Keyring::Alice.to_account_id()) },
+		difficulty: DifficultyConfig { initial_difficulty: U256::from(1_000u64) },
+		session: SessionConfig { keys: session_keys(&validators) },
+		validator: ValidatorConfig {
+			initial_validators: validators.iter().map(|(a, _, _)| a.clone()).collect::<Vec<_>>(),
+			..Default::default()
+		},
+		// The dev, local and integration presets share one chain id, kept
+		// distinct from testnet and mainnet so EIP-155 signatures never
+		// replay across networks.
+		evm_chain_id: EVMChainIdConfig { chain_id: 320262, ..Default::default() },
+		evm: EVMConfig { accounts: dev_evm_accounts(), ..Default::default() },
+	})
 }
 
 pub fn local_config_genesis() -> Value {
-	testnet_genesis(
-		Sr25519Keyring::iter()
-			.filter(|v| v != &Sr25519Keyring::One && v != &Sr25519Keyring::Two)
-			.map(|v| v.to_account_id())
-			.collect::<Vec<_>>(),
-		Sr25519Keyring::Alice.to_account_id(),
-		vec![
-			(
-				Sr25519Keyring::Alice.to_account_id(),
-				Ed25519Keyring::Alice.public().into(),
-				im_online_from_keyring(Sr25519Keyring::Alice),
-			),
-			(
-				Sr25519Keyring::Bob.to_account_id(),
-				Ed25519Keyring::Bob.public().into(),
-				im_online_from_keyring(Sr25519Keyring::Bob),
-			),
-			(
-				Sr25519Keyring::Charlie.to_account_id(),
-				Ed25519Keyring::Charlie.public().into(),
-				im_online_from_keyring(Sr25519Keyring::Charlie),
-			),
-		],
-	)
+	let endowed_accounts = Sr25519Keyring::iter()
+		.filter(|v| v != &Sr25519Keyring::One && v != &Sr25519Keyring::Two)
+		.map(|v| v.to_account_id())
+		.collect::<Vec<_>>();
+	let validators: Vec<(AccountId, GrandpaId, ImOnlineId)> = vec![
+		(
+			Sr25519Keyring::Alice.to_account_id(),
+			Ed25519Keyring::Alice.public().into(),
+			im_online_from_keyring(Sr25519Keyring::Alice),
+		),
+		(
+			Sr25519Keyring::Bob.to_account_id(),
+			Ed25519Keyring::Bob.public().into(),
+			im_online_from_keyring(Sr25519Keyring::Bob),
+		),
+		(
+			Sr25519Keyring::Charlie.to_account_id(),
+			Ed25519Keyring::Charlie.public().into(),
+			im_online_from_keyring(Sr25519Keyring::Charlie),
+		),
+	];
+	let total_supply: u128 = 1_000_000_000 * UNIT;
+	let balance_per_account = total_supply / endowed_accounts.len() as u128;
+	build_struct_json_patch!(RuntimeGenesisConfig {
+		balances: BalancesConfig {
+			balances: endowed_accounts
+				.iter()
+				.cloned()
+				.map(|k| (k, balance_per_account))
+				.collect::<Vec<_>>(),
+		},
+		sudo: SudoConfig { key: Some(Sr25519Keyring::Alice.to_account_id()) },
+		difficulty: DifficultyConfig { initial_difficulty: U256::from(1_000u64) },
+		session: SessionConfig { keys: session_keys(&validators) },
+		validator: ValidatorConfig {
+			initial_validators: validators.iter().map(|(a, _, _)| a.clone()).collect::<Vec<_>>(),
+			..Default::default()
+		},
+		evm_chain_id: EVMChainIdConfig { chain_id: 320262, ..Default::default() },
+		evm: EVMConfig { accounts: dev_evm_accounts(), ..Default::default() },
+	})
 }
 
 pub fn integration_config_genesis() -> Value {
-	testnet_genesis_with_extra_keys(
-		vec![
-			Sr25519Keyring::Alice.to_account_id(),
-			Sr25519Keyring::Bob.to_account_id(),
-			Sr25519Keyring::Charlie.to_account_id(),
-			Sr25519Keyring::Dave.to_account_id(),
-			Sr25519Keyring::Eve.to_account_id(),
-			Sr25519Keyring::Ferdie.to_account_id(),
-			Sr25519Keyring::AliceStash.to_account_id(),
-			Sr25519Keyring::BobStash.to_account_id(),
-		],
+	let endowed_accounts = vec![
 		Sr25519Keyring::Alice.to_account_id(),
-		vec![
-			(
-				Sr25519Keyring::Alice.to_account_id(),
-				Ed25519Keyring::Alice.public().into(),
-				im_online_from_keyring(Sr25519Keyring::Alice),
-			),
-			(
-				Sr25519Keyring::Bob.to_account_id(),
-				Ed25519Keyring::Bob.public().into(),
-				im_online_from_keyring(Sr25519Keyring::Bob),
-			),
-			(
-				Sr25519Keyring::Charlie.to_account_id(),
-				Ed25519Keyring::Charlie.public().into(),
-				im_online_from_keyring(Sr25519Keyring::Charlie),
-			),
-		],
-		vec![],
-		dev_evm_accounts(),
-	)
+		Sr25519Keyring::Bob.to_account_id(),
+		Sr25519Keyring::Charlie.to_account_id(),
+		Sr25519Keyring::Dave.to_account_id(),
+		Sr25519Keyring::Eve.to_account_id(),
+		Sr25519Keyring::Ferdie.to_account_id(),
+		Sr25519Keyring::AliceStash.to_account_id(),
+		Sr25519Keyring::BobStash.to_account_id(),
+	];
+	let validators: Vec<(AccountId, GrandpaId, ImOnlineId)> = vec![
+		(
+			Sr25519Keyring::Alice.to_account_id(),
+			Ed25519Keyring::Alice.public().into(),
+			im_online_from_keyring(Sr25519Keyring::Alice),
+		),
+		(
+			Sr25519Keyring::Bob.to_account_id(),
+			Ed25519Keyring::Bob.public().into(),
+			im_online_from_keyring(Sr25519Keyring::Bob),
+		),
+		(
+			Sr25519Keyring::Charlie.to_account_id(),
+			Ed25519Keyring::Charlie.public().into(),
+			im_online_from_keyring(Sr25519Keyring::Charlie),
+		),
+	];
+	let total_supply: u128 = 1_000_000_000 * UNIT;
+	let balance_per_account = total_supply / endowed_accounts.len() as u128;
+	build_struct_json_patch!(RuntimeGenesisConfig {
+		balances: BalancesConfig {
+			balances: endowed_accounts
+				.iter()
+				.cloned()
+				.map(|k| (k, balance_per_account))
+				.collect::<Vec<_>>(),
+		},
+		sudo: SudoConfig { key: Some(Sr25519Keyring::Alice.to_account_id()) },
+		difficulty: DifficultyConfig { initial_difficulty: U256::from(1_000u64) },
+		session: SessionConfig { keys: session_keys(&validators) },
+		validator: ValidatorConfig {
+			initial_validators: validators.iter().map(|(a, _, _)| a.clone()).collect::<Vec<_>>(),
+			..Default::default()
+		},
+		evm_chain_id: EVMChainIdConfig { chain_id: 320262, ..Default::default() },
+		evm: EVMConfig { accounts: dev_evm_accounts(), ..Default::default() },
+	})
 }
 
 pub fn testnet_config_genesis() -> Value {
-	testnet_genesis_with_extra_keys(
-		vec![
-			Sr25519Keyring::Alice.to_account_id(),
-			Sr25519Keyring::Bob.to_account_id(),
-			Sr25519Keyring::Charlie.to_account_id(),
-			Sr25519Keyring::Dave.to_account_id(),
-			Sr25519Keyring::Eve.to_account_id(),
-			Sr25519Keyring::Ferdie.to_account_id(),
-			Sr25519Keyring::AliceStash.to_account_id(),
-			Sr25519Keyring::BobStash.to_account_id(),
-		],
+	let endowed_accounts = vec![
 		Sr25519Keyring::Alice.to_account_id(),
-		vec![
-			(
-				Sr25519Keyring::Alice.to_account_id(),
-				Ed25519Keyring::Alice.public().into(),
-				im_online_from_keyring(Sr25519Keyring::Alice),
-			),
-			(
-				Sr25519Keyring::Bob.to_account_id(),
-				Ed25519Keyring::Bob.public().into(),
-				im_online_from_keyring(Sr25519Keyring::Bob),
-			),
-			(
-				Sr25519Keyring::Charlie.to_account_id(),
-				Ed25519Keyring::Charlie.public().into(),
-				im_online_from_keyring(Sr25519Keyring::Charlie),
-			),
-		],
-		vec![],
-		BTreeMap::new(),
-	)
+		Sr25519Keyring::Bob.to_account_id(),
+		Sr25519Keyring::Charlie.to_account_id(),
+		Sr25519Keyring::Dave.to_account_id(),
+		Sr25519Keyring::Eve.to_account_id(),
+		Sr25519Keyring::Ferdie.to_account_id(),
+		Sr25519Keyring::AliceStash.to_account_id(),
+		Sr25519Keyring::BobStash.to_account_id(),
+	];
+	let validators: Vec<(AccountId, GrandpaId, ImOnlineId)> = vec![
+		(
+			Sr25519Keyring::Alice.to_account_id(),
+			Ed25519Keyring::Alice.public().into(),
+			im_online_from_keyring(Sr25519Keyring::Alice),
+		),
+		(
+			Sr25519Keyring::Bob.to_account_id(),
+			Ed25519Keyring::Bob.public().into(),
+			im_online_from_keyring(Sr25519Keyring::Bob),
+		),
+		(
+			Sr25519Keyring::Charlie.to_account_id(),
+			Ed25519Keyring::Charlie.public().into(),
+			im_online_from_keyring(Sr25519Keyring::Charlie),
+		),
+	];
+	let mut balances: Vec<(AccountId, u128)> = endowed_accounts
+		.iter()
+		.cloned()
+		.map(|k| (k, TESTNET_ACCOUNT_BALANCE))
+		.collect();
+	balances.push((crate::configs::TreasuryAccount::get(), GENESIS_ISSUANCE));
+	build_struct_json_patch!(RuntimeGenesisConfig {
+		balances: BalancesConfig { balances },
+		difficulty: DifficultyConfig { initial_difficulty: U256::from(1_000u64) },
+		session: SessionConfig { keys: session_keys(&validators) },
+		validator: ValidatorConfig {
+			initial_validators: validators.iter().map(|(a, _, _)| a.clone()).collect::<Vec<_>>(),
+			..Default::default()
+		},
+		evm_chain_id: EVMChainIdConfig { chain_id: 320261, ..Default::default() },
+		evm: EVMConfig { accounts: BTreeMap::new(), ..Default::default() },
+	})
 }
 
 pub fn mainnet_config_genesis() -> Value {
-	testnet_genesis_with_extra_keys(
-		vec![
+	let validators: Vec<(AccountId, GrandpaId, ImOnlineId)> = vec![
+		(
 			Sr25519Keyring::Alice.to_account_id(),
+			Ed25519Keyring::Alice.public().into(),
+			im_online_from_keyring(Sr25519Keyring::Alice),
+		),
+		(
 			Sr25519Keyring::Bob.to_account_id(),
+			Ed25519Keyring::Bob.public().into(),
+			im_online_from_keyring(Sr25519Keyring::Bob),
+		),
+		(
 			Sr25519Keyring::Charlie.to_account_id(),
-			Sr25519Keyring::Dave.to_account_id(),
-			Sr25519Keyring::Eve.to_account_id(),
-			Sr25519Keyring::Ferdie.to_account_id(),
-			Sr25519Keyring::AliceStash.to_account_id(),
-			Sr25519Keyring::BobStash.to_account_id(),
-		],
-		Sr25519Keyring::Alice.to_account_id(),
-		vec![
-			(
-				Sr25519Keyring::Alice.to_account_id(),
-				Ed25519Keyring::Alice.public().into(),
-				im_online_from_keyring(Sr25519Keyring::Alice),
-			),
-			(
-				Sr25519Keyring::Bob.to_account_id(),
-				Ed25519Keyring::Bob.public().into(),
-				im_online_from_keyring(Sr25519Keyring::Bob),
-			),
-			(
-				Sr25519Keyring::Charlie.to_account_id(),
-				Ed25519Keyring::Charlie.public().into(),
-				im_online_from_keyring(Sr25519Keyring::Charlie),
-			),
-		],
-		vec![],
-		BTreeMap::new(),
-	)
+			Ed25519Keyring::Charlie.public().into(),
+			im_online_from_keyring(Sr25519Keyring::Charlie),
+		),
+	];
+	build_struct_json_patch!(RuntimeGenesisConfig {
+		balances: BalancesConfig {
+			balances: vec![(crate::configs::TreasuryAccount::get(), GENESIS_ISSUANCE)],
+		},
+		difficulty: DifficultyConfig { initial_difficulty: U256::from(1_000u64) },
+		session: SessionConfig { keys: session_keys(&validators) },
+		validator: ValidatorConfig {
+			initial_validators: validators.iter().map(|(a, _, _)| a.clone()).collect::<Vec<_>>(),
+			..Default::default()
+		},
+		evm_chain_id: EVMChainIdConfig { chain_id: 32026, ..Default::default() },
+		evm: EVMConfig { accounts: BTreeMap::new(), ..Default::default() },
+	})
 }
 
 pub const INTEGRATION_RUNTIME_PRESET: &str = "integration";

--- a/zombienet/evm-tooling/README.md
+++ b/zombienet/evm-tooling/README.md
@@ -18,7 +18,7 @@ The corresponding zombienet end-to-end scenario lives at [`../integration/scenar
 | ------------------ | ----------------------- |
 | RPC URL (default)  | `http://127.0.0.1:9944` |
 | WebSocket URL      | `ws://127.0.0.1:9944`   |
-| Chain ID           | `32026`                 |
+| Chain ID           | `320262`                 |
 | Currency symbol    | `NUMN`                  |
 | Decimals           | `18`                    |
 | Block explorer URL | _(none yet)_            |
@@ -54,11 +54,11 @@ Open MetaMask → **Networks → Add a custom network**:
 
 - Network name: `Numen Dev`
 - New RPC URL: `http://127.0.0.1:9944`
-- Chain ID: `32026`
+- Chain ID: `320262`
 - Currency symbol: `NUMN`
 - Block explorer URL: _(leave blank)_
 
-Save. MetaMask will validate that the RPC responds to `eth_chainId` and returns `0x7d1a` (== 32026).
+Save. MetaMask will validate that the RPC responds to `eth_chainId` and returns `0x4e306` (== 320262).
 
 ### 2. Import a pre-funded account
 

--- a/zombienet/evm-tooling/hardhat/hardhat.config.js
+++ b/zombienet/evm-tooling/hardhat/hardhat.config.js
@@ -37,7 +37,7 @@ export default defineConfig({
       type: "http",
       chainType: "generic",
       url: process.env.CRYPTO_NODE_RPC ?? "http://127.0.0.1:9944",
-      chainId: 32026,
+      chainId: 320262,
       accounts: [ALITH_PK, BALTATHAR_PK, CHARLETH_PK],
     },
   },

--- a/zombienet/evm-tooling/hardhat/package.json
+++ b/zombienet/evm-tooling/hardhat/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Hardhat 3 compatibility sample for crypto-node (Frontier EVM, ChainId 32026).",
+  "description": "Hardhat 3 compatibility sample for crypto-node (Frontier EVM, ChainId 320262).",
   "scripts": {
     "compile": "hardhat compile",
     "test": "hardhat --network cryptoNode test mocha",

--- a/zombienet/evm-tooling/hardhat/test/Token.test.js
+++ b/zombienet/evm-tooling/hardhat/test/Token.test.js
@@ -12,9 +12,9 @@ describe("Token (cryptoNode)", function () {
   // mocha timeout so block-confirmation latency doesn't fail the suite.
   this.timeout(120_000);
 
-  it("reports the configured EVM chain id (32026)", async function () {
+  it("reports the configured EVM chain id (320262)", async function () {
     const { chainId } = await ethers.provider.getNetwork();
-    expect(Number(chainId)).to.equal(32026);
+    expect(Number(chainId)).to.equal(320262);
   });
 
   it("deploys, transfers, and reflects the new balances", async function () {

--- a/zombienet/evm-tooling/scripts/README.md
+++ b/zombienet/evm-tooling/scripts/README.md
@@ -31,7 +31,7 @@ Override the endpoint with `CRYPTO_NODE_RPC=http://host:port`.
 Each script exits non-zero on assertion failure:
 
 - `transfer-ethers.js` — recipient balance delta must equal the transfer amount.
-- `query-web3.js` — chain id must be `32026`.
+- `query-web3.js` — chain id must be `320262`.
 - `transfer-precompile.js` — `balanceOf` must equal `eth_getBalance` and the
   recipient delta must match the transfer amount.
 - `withdraw-to-substrate.js` — the receipt must contain a

--- a/zombienet/evm-tooling/scripts/query-web3.js
+++ b/zombienet/evm-tooling/scripts/query-web3.js
@@ -29,8 +29,8 @@ async function main() {
     console.log(`${name} ${addr}: ${web3.utils.fromWei(bal, "ether")} NUMN`);
   }
 
-  if (Number(chainId) !== 32026) {
-    console.error(`unexpected chainId ${chainId}, want 32026`);
+  if (Number(chainId) !== 320262) {
+    console.error(`unexpected chainId ${chainId}, want 320262`);
     process.exit(1);
   }
 }

--- a/zombienet/evm-tooling/scripts/transfer-ethers.js
+++ b/zombienet/evm-tooling/scripts/transfer-ethers.js
@@ -12,7 +12,7 @@ const ALITH_PK =
   "0x5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133";
 const BALTATHAR = "0x3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0";
 const AMOUNT = parseEther(process.env.AMOUNT || "1.5");
-const EXPECTED_CHAIN_ID = 32026n;
+const EXPECTED_CHAIN_ID = 320262n;
 
 async function main() {
   const provider = new JsonRpcProvider(RPC_URL);

--- a/zombienet/evm-tooling/scripts/transfer-precompile.js
+++ b/zombienet/evm-tooling/scripts/transfer-precompile.js
@@ -20,7 +20,7 @@ const ALITH_PK =
 const BALTATHAR = "0x3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0";
 const PRECOMPILE = "0x0000000000000000000000000000000000000802";
 const AMOUNT = parseEther(process.env.AMOUNT || "1.5");
-const EXPECTED_CHAIN_ID = 32026n;
+const EXPECTED_CHAIN_ID = 320262n;
 
 const ERC20_ABI = [
   "function name() view returns (string)",

--- a/zombienet/evm-tooling/scripts/withdraw-to-substrate.js
+++ b/zombienet/evm-tooling/scripts/withdraw-to-substrate.js
@@ -35,7 +35,7 @@ const ALICE_PUBKEY =
   process.env.SUBSTRATE_DEST ||
   "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d";
 const AMOUNT = parseEther(process.env.AMOUNT || "2.5");
-const EXPECTED_CHAIN_ID = 32026n;
+const EXPECTED_CHAIN_ID = 320262n;
 
 const ABI = [
   "function balanceOf(address) view returns (uint256)",

--- a/zombienet/integration/scenarios/02-evm-tooling/evm-tooling.js
+++ b/zombienet/integration/scenarios/02-evm-tooling/evm-tooling.js
@@ -2,7 +2,7 @@
 //
 // Verifies, over ethers v6 + Frontier JSON-RPC, the whole EVM tooling surface
 // this runtime owns:
-//   1. config smoke + cross-node consistency: eth_chainId == 32026 and the
+//   1. config smoke + cross-node consistency: eth_chainId == 320262 and the
 //      initial baseFeePerGas == 1 gwei, identical when read from alice/bob/
 //      charlie (validates pallet-evm ChainId and pallet-base-fee defaults).
 //   2. minimal deploy path: deploy init code that returns a single STOP byte,
@@ -32,7 +32,7 @@ const ALITH_PK =
 const PRECOMPILE = "0x0000000000000000000000000000000000000802";
 const ABI = ["function withdraw(bytes32,uint256) returns (bool)"];
 
-const EXPECTED_CHAIN_ID = 32026n;
+const EXPECTED_CHAIN_ID = 320262n;
 const ONE_GWEI = 1_000_000_000n;
 const UNIT = 10n ** 18n; // runtime UNIT == 1e18, EVM uses 18 decimals.
 const TOPUP = 10n * UNIT; // SS58 -> EVM amount.


### PR DESCRIPTION
Adds chain specs and genesis presets for testnet and mainnet. Both mint the 600M genesis issuance to the treasury and leave the sudo key unset. Dev keyring keys stand in as placeholders for the validators and the testnet operator accounts until the real keys land.

Each network now carries its own EVM chain id (mainnet 32026, testnet 320261, dev chains 320262) so EIP-155 signatures cannot replay across networks, with the zombienet EVM tooling updated to match. The well known dev EVM accounts are prefunded only on the dev, local and integration presets, and chain specs outside mainnet display the tNUMN token symbol. The node now requires an explicit chain argument instead of defaulting to local.

Also polishes a few comments around the reward halving and fee routing.