### PR TITLE
Add validator stake exemption list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11510,6 +11510,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
+ "hex-literal 1.1.0",
  "pallet-authorship",
  "pallet-balances",
  "pallet-base-fee",

--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -17,7 +17,7 @@ extern crate alloc;
 
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::{
-    traits::{Currency, Get, LockableCurrency},
+    traits::{Contains, Currency, Get, LockableCurrency},
     BoundedVec,
 };
 use scale_info::TypeInfo;
@@ -98,6 +98,9 @@ pub mod pallet {
         #[pallet::constant]
         type LockAmount: Get<BalanceOf<Self>>;
 
+        /// Accounts that validate without locking stake.
+        type StakeExempt: Contains<Self::AccountId>;
+
         /// Lock duration applied at registration and on each renewal.
         #[pallet::constant]
         type LockDuration: Get<BlockNumberFor<Self>>;
@@ -160,9 +163,9 @@ pub mod pallet {
     /// Genesis configuration for `pallet-validator`.
     ///
     /// `initial_validators` lists the accounts that must be present in the
-    /// active validator set at block 0. Each account is locked using
-    /// `Config::LockAmount` and `Config::LockDuration` so that subsequent
-    /// auto-renewal, exit, and kick logic operates on real lock records.
+    /// active validator set at block 0. They are appointed by the chain spec
+    /// and stake nothing. Each account still gets a lock record with a zero
+    /// amount so auto-renewal, exit, and kick logic operates on real records.
     /// The accounts are pushed directly into `DesiredValidators` (not
     /// `PendingValidators`) so that the very first session already has a
     /// non-empty authority set for `pallet-session` and downstream consumers
@@ -178,26 +181,19 @@ pub mod pallet {
     #[pallet::genesis_build]
     impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
         fn build(&self) {
-            let amount = T::LockAmount::get();
             let duration = T::LockDuration::get();
             let now = BlockNumberFor::<T>::zero();
             let expiry_block = now.saturating_add(duration);
-            let lock_id = T::LockId::get();
 
             let mut active: BoundedVec<T::AccountId, T::MaxValidators> = BoundedVec::default();
             for who in &self.initial_validators {
                 if ValidatorLocks::<T>::contains_key(who) {
                     continue;
                 }
-                assert!(
-                    T::Currency::free_balance(who) >= amount,
-                    "Genesis validator must be endowed with at least LockAmount",
-                );
-                T::Currency::set_lock(lock_id, who, amount, WithdrawReasons::all());
                 ValidatorLocks::<T>::insert(
                     who,
                     LockInfo {
-                        amount,
+                        amount: BalanceOf::<T>::zero(),
                         lock_block: now,
                         expiry_block,
                         status: ValidatorStatus::Active,
@@ -368,7 +364,7 @@ pub mod pallet {
                 RejoinCooldown::<T>::remove(&who);
             }
 
-            let amount = T::LockAmount::get();
+            let amount = Self::required_lock(&who);
             let duration = T::LockDuration::get();
 
             ensure!(
@@ -448,6 +444,17 @@ pub mod pallet {
 const LOG_TARGET: &str = "runtime::validator";
 
 impl<T: Config> Pallet<T> {
+    /// Stake required from `who` when joining the validator set. A zero
+    /// amount never places a currency lock because `set_lock` treats zero
+    /// as removal.
+    fn required_lock(who: &T::AccountId) -> BalanceOf<T> {
+        if T::StakeExempt::contains(who) {
+            Zero::zero()
+        } else {
+            T::LockAmount::get()
+        }
+    }
+
     /// Record `who` as offline for the current session.
     ///
     /// Intended to be invoked by the runtime adapter that bridges

--- a/pallets/validator/src/mock.rs
+++ b/pallets/validator/src/mock.rs
@@ -2,7 +2,7 @@ use crate as pallet_validator;
 use crate::SessionInterface;
 use frame_support::{
 	derive_impl, parameter_types,
-	traits::{ConstU128, ConstU32, ConstU64, LockIdentifier, VariantCountOf, Hooks},
+	traits::{ConstU128, ConstU32, ConstU64, Contains, LockIdentifier, VariantCountOf, Hooks},
 };
 use sp_runtime::BuildStorage;
 
@@ -76,10 +76,18 @@ impl SessionInterface<AccountId> for MockSession {
 	}
 }
 
+pub struct MockStakeExempt;
+impl Contains<AccountId> for MockStakeExempt {
+	fn contains(who: &AccountId) -> bool {
+		*who == EXEMPT
+	}
+}
+
 impl pallet_validator::Config for Test {
 	type Currency = Balances;
 	type SessionInterface = MockSession;
 	type LockAmount = ConstU128<1_000>;
+	type StakeExempt = MockStakeExempt;
 	type LockDuration = ConstU64<10>;
 	type SessionPeriod = ConstU64<5>;
 	type SessionOffset = ConstU64<0>;
@@ -93,6 +101,7 @@ impl pallet_validator::Config for Test {
 pub const ALICE: AccountId = 1;
 pub const BOB: AccountId = 2;
 pub const CHARLIE: AccountId = 3;
+pub const EXEMPT: AccountId = 4;
 
 pub fn new_test_ext(balances: Vec<(AccountId, Balance)>) -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::<Test>::default()

--- a/pallets/validator/src/tests.rs
+++ b/pallets/validator/src/tests.rs
@@ -3,7 +3,7 @@ use crate::{
     OfflineThisSession, EquivocationThisSession, RejoinCooldown, ValidatorLocks, ValidatorStatus,
 };
 use frame_support::{assert_noop, assert_ok, traits::Get};
-use sp_runtime::{traits::Dispatchable, DispatchError, TokenError};
+use sp_runtime::{traits::Dispatchable, BuildStorage, DispatchError, TokenError};
 
 // region: lock
 
@@ -1015,6 +1015,93 @@ fn rejoin_after_equivocation_cooldown_expired_succeeds() {
         assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
         assert_eq!(ValidatorLocks::<Test>::get(ALICE).unwrap().status, ValidatorStatus::Active);
         assert!(RejoinCooldown::<Test>::get(ALICE).is_none());
+    });
+}
+
+// endregion
+
+// region: stake exemption
+
+#[test]
+fn exempt_account_locks_with_zero_balance() {
+    let lock_duration: u64 = <Test as crate::Config>::LockDuration::get();
+
+    new_test_ext(vec![]).execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(EXEMPT)));
+
+        let lock = ValidatorLocks::<Test>::get(EXEMPT).expect("lock recorded");
+        assert_eq!(
+            lock,
+            LockInfo {
+                amount: 0,
+                lock_block: 1,
+                expiry_block: 1 + lock_duration,
+                status: ValidatorStatus::Active,
+            }
+        );
+        // A zero amount places no currency lock.
+        assert!(pallet_balances::Locks::<Test>::get(EXEMPT).is_empty());
+        assert_eq!(PendingValidators::<Test>::get().to_vec(), vec![EXEMPT]);
+        System::assert_last_event(
+            Event::ValidatorLocked { who: EXEMPT, amount: 0, expiry_block: 1 + lock_duration }
+                .into(),
+        );
+    });
+}
+
+#[test]
+fn exempt_account_rejoin_checks_cooldown_but_not_stake() {
+    let rejoin_cooldown: u64 = <Test as crate::Config>::RejoinCooldownPeriod::get();
+
+    new_test_ext(vec![]).execute_with(|| {
+        RejoinCooldown::<Test>::insert(EXEMPT, rejoin_cooldown);
+
+        // Exemption skips the stake but not the cooldown.
+        System::set_block_number(rejoin_cooldown);
+        assert_noop!(
+            Validator::lock(RuntimeOrigin::signed(EXEMPT)),
+            Error::<Test>::InCooldown
+        );
+
+        // Past the deadline the rejoin succeeds without any balance.
+        System::set_block_number(rejoin_cooldown + 1);
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(EXEMPT)));
+        assert_eq!(ValidatorLocks::<Test>::get(EXEMPT).unwrap().amount, 0);
+        assert!(RejoinCooldown::<Test>::get(EXEMPT).is_none());
+    });
+}
+
+// endregion
+
+// region: genesis
+
+#[test]
+fn genesis_validator_needs_no_endowment() {
+    let lock_duration: u64 = <Test as crate::Config>::LockDuration::get();
+
+    let mut t = frame_system::GenesisConfig::<Test>::default()
+        .build_storage()
+        .unwrap();
+    crate::GenesisConfig::<Test> {
+        initial_validators: vec![ALICE],
+        ..Default::default()
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+    let mut ext: sp_io::TestExternalities = t.into();
+    ext.execute_with(|| {
+        assert_eq!(DesiredValidators::<Test>::get().to_vec(), vec![ALICE]);
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("lock recorded");
+        assert_eq!(
+            lock,
+            LockInfo {
+                amount: 0,
+                lock_block: 0,
+                expiry_block: lock_duration,
+                status: ValidatorStatus::Active,
+            }
+        );
+        assert!(pallet_balances::Locks::<Test>::get(ALICE).is_empty());
     });
 }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -22,6 +22,7 @@ frame-system-benchmarking = { optional = true, workspace = true }
 frame-system-rpc-runtime-api.workspace = true
 frame-system.workspace = true
 frame-try-runtime = { optional = true, workspace = true }
+hex-literal.workspace = true
 pallet-authorship.workspace = true
 pallet-balances.workspace = true
 pallet-bounties.workspace = true

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -5,7 +5,7 @@ use frame_support::{
 	traits::{
 		fungible::{Balanced, Credit, HoldConsideration},
 		tokens::{PayFromAccount, UnityAssetBalanceConversion},
-		ConstU128, ConstU32, ConstU64, ConstU8, EqualPrivilegeOnly, InstanceFilter,
+		ConstU128, ConstU32, ConstU64, ConstU8, Contains, EqualPrivilegeOnly, InstanceFilter,
 		LinearStoragePrice, OnUnbalanced, VariantCountOf,
 	},
 	weights::{
@@ -18,6 +18,7 @@ use frame_system::{
 	limits::{BlockLength, BlockWeights},
 	EnsureRoot,
 };
+use hex_literal::hex;
 use pallet_session::PeriodicSessions;
 use pallet_transaction_payment::{FungibleAdapter, Multiplier, TargetedFeeAdjustment};
 use scale_info::TypeInfo;
@@ -392,6 +393,42 @@ parameter_types! {
 	pub const ValidatorLockId: frame_support::traits::LockIdentifier = *b"validatr";
 }
 
+/// Validator accounts allowed to join without locking stake.
+pub struct StakeExemptAccounts;
+
+impl Contains<AccountId> for StakeExemptAccounts {
+	fn contains(who: &AccountId) -> bool {
+		STAKE_EXEMPT_ACCOUNTS.iter().any(|k| who == &AccountId::from(*k))
+	}
+}
+
+const STAKE_EXEMPT_ACCOUNTS: [[u8; 32]; 12] = [
+	// nu5WR2b5yFx6zUPudqfJtfnmDpg45PFafTFp5iwxH2bdKiqnW
+	hex!("7ebc23de675cd320952153f65eed8636ede3ee914d38d86a03b8690c5ef87745"),
+	// nu8FjWHe9eBn1oR9N7xADxKKTSpDMkYwocg9sPNBzXFxN1NoZ
+	hex!("f83e5c47238ae444ef3165741b0c2a26a15bfb910655376680dc86d47032ee71"),
+	// nu6Gk7pfM9Sxp19o64d5tP1pvGfkWELvk4t9C6d7AWaLjc1gN
+	hex!("a08b338e366fdd4d7a4e66cd6ff1c8fe3f8d8b58f72ea980938612df2a12cb2f"),
+	// nu6davM837qycpvwZ5WxDFn3U9NWxHYLLWwkT3DzsyGMv6nyk
+	hex!("b0706466389590c5e85c2536368db64510bea6def16ac1ac096e754342476f63"),
+	// nu6DhnACdsRfJXMBMG1VDZzTWYPCGvZhy6T6oo8LK1iZsjj9p
+	hex!("9e399761be3d62aff2f2496882f35e719a7d26e6e34964a8691507b7be44e436"),
+	// nu5jPGTWz3LigxmaYgxhnWDc4QEHCC3HMT661gB8ofHvAEPWs
+	hex!("88a0671aa30b1b6199ff5ac847d7ec059ec7bf7baf57b7c47aced431704a5333"),
+	// nu6GtAuvYCiCUy7PmqsLycXdRBdP63aeehug8EFkY9aE2Kj7y
+	hex!("a0a64fa9165f3f5115cd4c2e056f06531d9d9411aaaacf452625bd0623cc0d79"),
+	// nu2noBaVTbqQ4qxh3Smb8z77LsYaTRfQhgK9tsQqfv7tHm2VF
+	hex!("0685f2537b8dd8efa5eef6c2d7d95484b7e804559e0c2308708bfbd4c1ae0723"),
+	// nu8KAW3iGL6ATT4Zc4pWtXXpAhr1FoRUQ3mP1d6QfN9NZfaDD
+	hex!("fadc3d802a278f17424a98cf2ed40c359d41a80a6cdfe16f20530adf3cc98006"),
+	// nu2v7qUMJ8CdTVGHWprxDcoVsrxpFE813aB1LZk5uZnCYdbRH
+	hex!("0c1b7509c3728c1c3ca068448d742c71ac656401f308aef5883311e153eddb4c"),
+	// nu4zngCeKZmRT9kxEVh8Uv6vTHw2WxrRcvkAsRs5TBnWQPMSa
+	hex!("6823a740cbaa7316bc810058581f9d0b0223226b4291ab894cdd5bd0ea3b4976"),
+	// nu3R1jsSHf5ZSJ8G6yYaFtVakPEEutA3qZgKkB8JCFaY3e1ep
+	hex!("22250d0c61bc635742f2c9f14b3630e41574d2ea8e3e4e3a5b8526ff2148566a"),
+];
+
 #[cfg(not(feature = "zombienet-runtime"))]
 parameter_types! {
 	pub const SessionPeriod: BlockNumber = 10 * MINUTES;
@@ -405,6 +442,7 @@ impl pallet_validator::Config for Runtime {
 	type SessionPeriod = SessionPeriod;
 	type SessionOffset = SessionOffset;
 	type LockAmount = ConstU128<{ 1_000 * UNIT }>;
+	type StakeExempt = StakeExemptAccounts;
 	#[allow(clippy::identity_op)]
 	type LockDuration = ConstU32<{ 1 * DAYS }>;
 	type LockId = ValidatorLockId;
@@ -429,6 +467,7 @@ impl pallet_validator::Config for Runtime {
 	type SessionPeriod = SessionPeriod;
 	type SessionOffset = SessionOffset;
 	type LockAmount = ConstU128<{ 1 * UNIT }>;
+	type StakeExempt = StakeExemptAccounts;
 	type LockDuration = ConstU32<{ SessionPeriod::get() + 2 * MINUTES }>;
 	type LockId = ValidatorLockId;
 	type MaxValidators = ConstU32<4>;


### PR DESCRIPTION
- Add stake-exempt accounts that can join the validator set without staking.
- Include all genesis accounts in the validator set at genesis without staking.