### PR TITLE
Add prime pallet for runtime upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7314,6 +7314,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-prime"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-externalities",
+ "sp-io",
+ "sp-runtime",
+ "sp-version",
+]
+
+[[package]]
 name = "pallet-proxy"
 version = "46.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9e54ba9c63b81b630ded4bc798f3b9c406060545"
@@ -11530,6 +11545,7 @@ dependencies = [
  "pallet-im-online",
  "pallet-multisig",
  "pallet-preimage",
+ "pallet-prime",
  "pallet-proxy",
  "pallet-referenda",
  "pallet-reward",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "consensus/sc-consensus-pow",
     "node",
     "pallets/difficulty",
+    "pallets/prime",
     "pallets/reward",
     "pallets/validator",
     "precompiles/balances-erc20",
@@ -26,6 +27,7 @@ poscan = { path = "./consensus/poscan", default-features = false }
 poscan-pow = { path = "./consensus/poscan-pow", default-features = false }
 obj-asteroid = { path = "./consensus/obj-asteroid", default-features = false }
 pallet-difficulty = { path = "./pallets/difficulty", default-features = false }
+pallet-prime = { path = "./pallets/prime", default-features = false }
 pallet-reward = { path = "./pallets/reward", default-features = false }
 pallet-validator = { path = "./pallets/validator", default-features = false }
 clap = { version = "4.6.1" }
@@ -85,6 +87,7 @@ sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "
 sp-consensus = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
+sp-externalities = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 sp-genesis-builder = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 sp-inherents = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }

--- a/pallets/prime/Cargo.toml
+++ b/pallets/prime/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "pallet-prime"
+description = "runtime upgrade admin pallet"
+version = "0.1.0"
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+codec = { features = ["derive"], workspace = true }
+frame-support.workspace = true
+frame-system.workspace = true
+scale-info = { features = ["derive"], workspace = true }
+
+[dev-dependencies]
+sp-core.default-features = true
+sp-core.workspace = true
+sp-externalities.default-features = true
+sp-externalities.workspace = true
+sp-io.default-features = true
+sp-io.workspace = true
+sp-runtime.default-features = true
+sp-runtime.workspace = true
+sp-version.default-features = true
+sp-version.workspace = true
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"scale-info/std",
+]
+runtime-benchmarks = [
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+]
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+]

--- a/pallets/prime/src/lib.rs
+++ b/pallets/prime/src/lib.rs
@@ -1,0 +1,101 @@
+//! # Prime
+//!
+//! A downgraded sudo privilege that only allows runtime upgrades and
+//! killing proposals on the spender track.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+pub use pallet::*;
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+pub mod weights;
+pub use weights::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use alloc::vec::Vec;
+	use frame_support::{dispatch::DispatchClass, pallet_prelude::*};
+	use frame_system::{pallet_prelude::*, WeightInfo as _};
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config<RuntimeEvent: From<Event<Self>>> {
+		/// Weight information for extrinsics in this pallet.
+		type WeightInfo: WeightInfo;
+	}
+
+	/// Account allowed to upgrade the runtime and rotate this key.
+	#[pallet::storage]
+	pub type Key<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
+
+	#[pallet::genesis_config]
+	#[derive(frame_support::DefaultNoBound)]
+	pub struct GenesisConfig<T: Config> {
+		pub key: Option<T::AccountId>,
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
+		fn build(&self) {
+			if let Some(key) = &self.key {
+				Key::<T>::put(key);
+			}
+		}
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// The prime key moved to a new account.
+		KeyChanged { old: T::AccountId, new: T::AccountId },
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// The caller is not the prime key.
+		RequirePrime,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Replace the runtime code, forwarding to `System::set_code` as root.
+		#[pallet::call_index(0)]
+		#[pallet::weight((
+			T::WeightInfo::upgrade()
+				.saturating_add(<T as frame_system::Config>::SystemWeightInfo::set_code()),
+			DispatchClass::Operational,
+		))]
+		pub fn upgrade(origin: OriginFor<T>, code: Vec<u8>) -> DispatchResultWithPostInfo {
+			Self::ensure_prime(origin)?;
+			frame_system::Pallet::<T>::set_code(frame_system::RawOrigin::Root.into(), code)
+		}
+
+		/// Hand the prime key to a new account.
+		#[pallet::call_index(1)]
+		#[pallet::weight(T::WeightInfo::set_key())]
+		pub fn set_key(origin: OriginFor<T>, new: T::AccountId) -> DispatchResult {
+			let old = Self::ensure_prime(origin)?;
+			Key::<T>::put(&new);
+			Self::deposit_event(Event::KeyChanged { old, new });
+			Ok(())
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		/// Require a signed origin matching the stored prime key.
+		fn ensure_prime(origin: OriginFor<T>) -> Result<T::AccountId, DispatchError> {
+			let who = ensure_signed(origin)?;
+			ensure!(Key::<T>::get().as_ref() == Some(&who), Error::<T>::RequirePrime);
+			Ok(who)
+		}
+	}
+}

--- a/pallets/prime/src/mock.rs
+++ b/pallets/prime/src/mock.rs
@@ -1,0 +1,88 @@
+use crate as pallet_prime;
+use codec::Encode;
+use frame_support::{derive_impl, parameter_types};
+use sp_runtime::BuildStorage;
+use sp_version::RuntimeVersion;
+
+pub type AccountId = u64;
+
+#[frame_support::runtime]
+mod runtime {
+	#[runtime::runtime]
+	#[runtime::derive(
+		RuntimeCall,
+		RuntimeEvent,
+		RuntimeError,
+		RuntimeOrigin,
+		RuntimeFreezeReason,
+		RuntimeHoldReason,
+		RuntimeSlashReason,
+		RuntimeLockId,
+		RuntimeTask,
+		RuntimeViewFunction
+	)]
+	pub struct Test;
+
+	#[runtime::pallet_index(0)]
+	pub type System = frame_system::Pallet<Test>;
+
+	#[runtime::pallet_index(1)]
+	pub type Prime = pallet_prime::Pallet<Test>;
+}
+
+parameter_types! {
+	pub Version: RuntimeVersion = RuntimeVersion {
+		spec_name: alloc::borrow::Cow::Borrowed("test"),
+		spec_version: 1,
+		..Default::default()
+	};
+}
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+	type Block = frame_system::mocking::MockBlock<Test>;
+	type AccountId = AccountId;
+	type Lookup = sp_runtime::traits::IdentityLookup<AccountId>;
+	type Version = Version;
+}
+
+impl pallet_prime::Config for Test {
+	type WeightInfo = ();
+}
+
+pub const PRIME: AccountId = 1;
+pub const OTHER: AccountId = 2;
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let mut t = frame_system::GenesisConfig::<Test>::default()
+		.build_storage()
+		.unwrap();
+	pallet_prime::GenesisConfig::<Test> { key: Some(PRIME) }
+		.assimilate_storage(&mut t)
+		.unwrap();
+	let mut ext: sp_io::TestExternalities = t.into();
+	ext.execute_with(|| System::set_block_number(1));
+	ext
+}
+
+/// Version probe stub fed to the externalities in place of a wasm executor.
+struct ReadRuntimeVersion(Vec<u8>);
+
+impl sp_core::traits::ReadRuntimeVersion for ReadRuntimeVersion {
+	fn read_runtime_version(
+		&self,
+		_wasm_code: &[u8],
+		_ext: &mut dyn sp_externalities::Externalities,
+	) -> Result<Vec<u8>, String> {
+		Ok(self.0.clone())
+	}
+}
+
+/// Externalities whose version probe reports `version` for any code blob.
+pub fn new_test_ext_with_version(version: RuntimeVersion) -> sp_io::TestExternalities {
+	let mut ext = new_test_ext();
+	ext.register_extension(sp_core::traits::ReadRuntimeVersionExt::new(ReadRuntimeVersion(
+		version.encode(),
+	)));
+	ext
+}

--- a/pallets/prime/src/tests.rs
+++ b/pallets/prime/src/tests.rs
@@ -1,0 +1,99 @@
+use crate::{mock::*, Error, Event, Key};
+use frame_support::{assert_noop, assert_ok};
+use sp_runtime::{BuildStorage, DispatchError};
+use sp_version::RuntimeVersion;
+
+fn upgrade_version(spec_version: u32) -> RuntimeVersion {
+	RuntimeVersion {
+		spec_name: "test".into(),
+		spec_version,
+		..Default::default()
+	}
+}
+
+#[test]
+fn genesis_key_lands_in_storage() {
+	new_test_ext().execute_with(|| {
+		assert_eq!(Key::<Test>::get(), Some(PRIME));
+	});
+}
+
+#[test]
+fn empty_key_rejects_everyone() {
+	let t = frame_system::GenesisConfig::<Test>::default()
+		.build_storage()
+		.unwrap();
+	sp_io::TestExternalities::from(t).execute_with(|| {
+		assert_noop!(
+			Prime::set_key(RuntimeOrigin::signed(PRIME), OTHER),
+			Error::<Test>::RequirePrime,
+		);
+	});
+}
+
+#[test]
+fn upgrade_replaces_runtime_code() {
+	new_test_ext_with_version(upgrade_version(2)).execute_with(|| {
+		assert_ok!(Prime::upgrade(RuntimeOrigin::signed(PRIME), vec![1, 2, 3]));
+		System::assert_has_event(frame_system::Event::CodeUpdated.into());
+	});
+}
+
+#[test]
+fn upgrade_keeps_system_version_checks() {
+	new_test_ext_with_version(upgrade_version(1)).execute_with(|| {
+		assert_noop!(
+			Prime::upgrade(RuntimeOrigin::signed(PRIME), vec![1, 2, 3]),
+			frame_system::Error::<Test>::SpecVersionNeedsToIncrease,
+		);
+	});
+}
+
+#[test]
+fn upgrade_rejects_non_prime() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Prime::upgrade(RuntimeOrigin::signed(OTHER), vec![1, 2, 3]),
+			Error::<Test>::RequirePrime,
+		);
+	});
+}
+
+#[test]
+fn upgrade_rejects_unsigned_origins() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Prime::upgrade(RuntimeOrigin::root(), vec![1, 2, 3]),
+			DispatchError::BadOrigin,
+		);
+		assert_noop!(
+			Prime::upgrade(RuntimeOrigin::none(), vec![1, 2, 3]),
+			DispatchError::BadOrigin,
+		);
+	});
+}
+
+#[test]
+fn set_key_rotates_key() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Prime::set_key(RuntimeOrigin::signed(PRIME), OTHER));
+		assert_eq!(Key::<Test>::get(), Some(OTHER));
+		System::assert_last_event(Event::<Test>::KeyChanged { old: PRIME, new: OTHER }.into());
+
+		assert_noop!(
+			Prime::set_key(RuntimeOrigin::signed(PRIME), PRIME),
+			Error::<Test>::RequirePrime,
+		);
+		assert_ok!(Prime::set_key(RuntimeOrigin::signed(OTHER), PRIME));
+	});
+}
+
+#[test]
+fn set_key_rejects_non_prime() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Prime::set_key(RuntimeOrigin::signed(OTHER), OTHER),
+			Error::<Test>::RequirePrime,
+		);
+	});
+}

--- a/pallets/prime/src/weights.rs
+++ b/pallets/prime/src/weights.rs
@@ -1,0 +1,31 @@
+//! Handwritten weights covering only this pallet's own work. The `upgrade`
+//! call adds the system `set_code` weight on top at the call site.
+
+use core::marker::PhantomData;
+use frame_support::{traits::Get, weights::Weight};
+
+pub trait WeightInfo {
+	fn upgrade() -> Weight;
+	fn set_key() -> Weight;
+}
+
+pub struct SubstrateWeight<T>(PhantomData<T>);
+impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+	fn upgrade() -> Weight {
+		Weight::from_parts(9_000_000, 0)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+	}
+	fn set_key() -> Weight {
+		Weight::from_parts(9_000_000, 0)
+			.saturating_add(T::DbWeight::get().reads_writes(1_u64, 1_u64))
+	}
+}
+
+impl WeightInfo for () {
+	fn upgrade() -> Weight {
+		Weight::zero()
+	}
+	fn set_key() -> Weight {
+		Weight::zero()
+	}
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -33,6 +33,7 @@ pallet-grandpa.workspace = true
 pallet-im-online.workspace = true
 pallet-multisig.workspace = true
 pallet-preimage.workspace = true
+pallet-prime.workspace = true
 pallet-proxy.workspace = true
 pallet-referenda.workspace = true
 pallet-scheduler.workspace = true
@@ -116,6 +117,7 @@ std = [
 	"pallet-im-online/std",
 	"pallet-multisig/std",
 	"pallet-preimage/std",
+	"pallet-prime/std",
 	"pallet-proxy/std",
 	"pallet-referenda/std",
 	"pallet-scheduler/std",
@@ -180,6 +182,7 @@ runtime-benchmarks = [
 	"pallet-im-online/runtime-benchmarks",
 	"pallet-multisig/runtime-benchmarks",
 	"pallet-preimage/runtime-benchmarks",
+	"pallet-prime/runtime-benchmarks",
 	"pallet-proxy/runtime-benchmarks",
 	"pallet-referenda/runtime-benchmarks",
 	"pallet-scheduler/runtime-benchmarks",
@@ -211,6 +214,7 @@ try-runtime = [
 	"pallet-im-online/try-runtime",
 	"pallet-multisig/try-runtime",
 	"pallet-preimage/try-runtime",
+	"pallet-prime/try-runtime",
 	"pallet-proxy/try-runtime",
 	"pallet-referenda/try-runtime",
 	"pallet-scheduler/try-runtime",

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -192,6 +192,10 @@ impl pallet_sudo::Config for Runtime {
 	type WeightInfo = pallet_sudo::weights::SubstrateWeight<Runtime>;
 }
 
+impl pallet_prime::Config for Runtime {
+	type WeightInfo = pallet_prime::weights::SubstrateWeight<Runtime>;
+}
+
 parameter_types! {
 	/// Deposits track the storage footprint of a pending multisig. Each
 	/// signatory adds 32 bytes, priced at the same 0.01 NUMN per byte as

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -1,5 +1,5 @@
 use crate::{
-	AccountId, BalancesConfig, DifficultyConfig, EVMChainIdConfig, EVMConfig,
+	AccountId, BalancesConfig, DifficultyConfig, EVMChainIdConfig, EVMConfig, PrimeConfig,
 	RuntimeGenesisConfig, SessionConfig, SessionKeys, SudoConfig, ValidatorConfig, UNIT,
 };
 use alloc::{collections::BTreeMap, vec, vec::Vec};
@@ -109,10 +109,14 @@ fn live_balances() -> Vec<(AccountId, u128)> {
 	]
 }
 
+// nu7bkLdXi7aBVP8phwhrm3Js8PgNjseDbaj5XPuzfkQhgDzYT
+const PRIME_MULTISIG: [u8; 32] = hex!("db45d74546b00d6efd137e9a2ea63a3b1595bad6aa3407370eedf43d59fb0b5a");
+
 
 fn genesis_patch(
 	balances: Vec<(AccountId, u128)>,
 	sudo_key: Option<AccountId>,
+	prime_key: Option<AccountId>,
 	validators: Vec<(AccountId, GrandpaId, ImOnlineId)>,
 	chain_id: u64,
 	evm_accounts: BTreeMap<H160, GenesisAccount>,
@@ -130,6 +134,7 @@ fn genesis_patch(
 	build_struct_json_patch!(RuntimeGenesisConfig {
 		balances: BalancesConfig { balances },
 		sudo: SudoConfig { key: sudo_key },
+		prime: PrimeConfig { key: prime_key },
 		difficulty: DifficultyConfig { initial_difficulty },
 		session: SessionConfig { keys: session_keys },
 		validator: ValidatorConfig {
@@ -146,6 +151,7 @@ pub fn development_config_genesis() -> Value {
 	genesis_patch(
 		dev_balances(),
 		Some(Sr25519Keyring::Alice.to_account_id()),
+		Some(Sr25519Keyring::Alice.to_account_id()),
 		dev_validators(),
 		DEV_EVM_CHAIN_ID,
 		dev_evm_accounts(),
@@ -156,6 +162,7 @@ pub fn development_config_genesis() -> Value {
 pub fn local_config_genesis() -> Value {
 	genesis_patch(
 		dev_balances(),
+		Some(Sr25519Keyring::Alice.to_account_id()),
 		Some(Sr25519Keyring::Alice.to_account_id()),
 		dev_validators(),
 		DEV_EVM_CHAIN_ID,
@@ -168,6 +175,7 @@ pub fn integration_config_genesis() -> Value {
 	genesis_patch(
 		dev_balances(),
 		Some(Sr25519Keyring::Alice.to_account_id()),
+		Some(Sr25519Keyring::Alice.to_account_id()),
 		dev_validators(),
 		DEV_EVM_CHAIN_ID,
 		dev_evm_accounts(),
@@ -179,6 +187,7 @@ pub fn testnet_config_genesis() -> Value {
 	genesis_patch(
 		live_balances(),
 		None,
+		Some(PRIME_MULTISIG.into()),
 		live_validators(),
 		TEST_EVM_CHAIN_ID,
 		BTreeMap::new(),
@@ -190,6 +199,7 @@ pub fn mainnet_config_genesis() -> Value {
 	genesis_patch(
 		live_balances(),
 		None,
+		Some(PRIME_MULTISIG.into()),
 		live_validators(),
 		MAIN_EVM_CHAIN_ID,
 		BTreeMap::new(),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -287,6 +287,9 @@ mod runtime {
 
 	#[runtime::pallet_index(26)]
 	pub type Proxy = pallet_proxy;
+
+	#[runtime::pallet_index(27)]
+	pub type Prime = pallet_prime;
 }
 
 // pallet-im-online submits unsigned heartbeat extrinsics from offchain


### PR DESCRIPTION
Adds the prime pallet from the #120 addendum. A single prime key, seeded at genesis and rotatable by its holder, forwards runtime upgrades through set_code as root, so the spec name and version checks of a regular upgrade still apply. Dev presets hand the key to Alice while testnet and mainnet seed the prime multisig. Origin rewiring for the referendum brake lands separately.