### PR TITLE
Retire sudo and point governance brakes at prime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7449,21 +7449,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-sudo"
-version = "46.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9e54ba9c63b81b630ded4bc798f3b9c406060545"
-dependencies = [
- "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-io",
- "sp-runtime",
-]
-
-[[package]]
 name = "pallet-timestamp"
 version = "45.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2603#9e54ba9c63b81b630ded4bc798f3b9c406060545"
@@ -11551,7 +11536,6 @@ dependencies = [
  "pallet-reward",
  "pallet-scheduler",
  "pallet-session",
- "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,6 @@ pallet-proxy = { git = "https://github.com/paritytech/polkadot-sdk", branch = "s
 pallet-referenda = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 pallet-scheduler = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 pallet-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false, features = ["historical"] }
-pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }
 pallet-treasury = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2603", default-features = false }

--- a/pallets/prime/src/lib.rs
+++ b/pallets/prime/src/lib.rs
@@ -1,7 +1,7 @@
 //! # Prime
 //!
-//! A downgraded sudo privilege that only allows runtime upgrades and
-//! killing proposals on the spender track.
+//! A downgraded sudo privilege that only allows runtime upgrades,
+//! cancelling or killing referenda and rejecting treasury spends.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -16,6 +16,10 @@ mod tests;
 
 pub mod weights;
 pub use weights::*;
+
+use core::marker::PhantomData;
+use frame_support::traits::EnsureOrigin;
+use frame_system::RawOrigin;
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -33,7 +37,7 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 	}
 
-	/// Account allowed to upgrade the runtime and rotate this key.
+	/// Account holding the prime privileges.
 	#[pallet::storage]
 	pub type Key<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
 
@@ -97,5 +101,25 @@ pub mod pallet {
 			ensure!(Key::<T>::get().as_ref() == Some(&who), Error::<T>::RequirePrime);
 			Ok(who)
 		}
+	}
+}
+
+/// Ensure the origin is a signed account matching the stored prime key.
+pub struct EnsurePrime<T>(PhantomData<T>);
+
+impl<T: Config> EnsureOrigin<T::RuntimeOrigin> for EnsurePrime<T> {
+	type Success = ();
+
+	fn try_origin(o: T::RuntimeOrigin) -> Result<Self::Success, T::RuntimeOrigin> {
+		o.into().and_then(|raw| match raw {
+			RawOrigin::Signed(ref who) if Key::<T>::get().as_ref() == Some(who) => Ok(()),
+			raw => Err(T::RuntimeOrigin::from(raw)),
+		})
+	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn try_successful_origin() -> Result<T::RuntimeOrigin, ()> {
+		let key = Key::<T>::get().ok_or(())?;
+		Ok(RawOrigin::Signed(key).into())
 	}
 }

--- a/pallets/prime/src/tests.rs
+++ b/pallets/prime/src/tests.rs
@@ -1,5 +1,5 @@
-use crate::{mock::*, Error, Event, Key};
-use frame_support::{assert_noop, assert_ok};
+use crate::{mock::*, EnsurePrime, Error, Event, Key};
+use frame_support::{assert_noop, assert_ok, traits::EnsureOrigin};
 use sp_runtime::{BuildStorage, DispatchError};
 use sp_version::RuntimeVersion;
 
@@ -95,5 +95,31 @@ fn set_key_rejects_non_prime() {
 			Prime::set_key(RuntimeOrigin::signed(OTHER), OTHER),
 			Error::<Test>::RequirePrime,
 		);
+	});
+}
+
+#[test]
+fn ensure_prime_origin_accepts_prime_key() {
+	new_test_ext().execute_with(|| {
+		assert!(EnsurePrime::<Test>::try_origin(RuntimeOrigin::signed(PRIME)).is_ok());
+	});
+}
+
+#[test]
+fn ensure_prime_origin_rejects_others() {
+	new_test_ext().execute_with(|| {
+		assert!(EnsurePrime::<Test>::try_origin(RuntimeOrigin::signed(OTHER)).is_err());
+		assert!(EnsurePrime::<Test>::try_origin(RuntimeOrigin::root()).is_err());
+		assert!(EnsurePrime::<Test>::try_origin(RuntimeOrigin::none()).is_err());
+	});
+}
+
+#[test]
+fn ensure_prime_origin_rejects_everyone_without_key() {
+	let t = frame_system::GenesisConfig::<Test>::default()
+		.build_storage()
+		.unwrap();
+	sp_io::TestExternalities::from(t).execute_with(|| {
+		assert!(EnsurePrime::<Test>::try_origin(RuntimeOrigin::signed(PRIME)).is_err());
 	});
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -39,7 +39,6 @@ pallet-referenda.workspace = true
 pallet-scheduler.workspace = true
 pallet-reward.workspace = true
 pallet-session.workspace = true
-pallet-sudo.workspace = true
 pallet-timestamp.workspace = true
 pallet-transaction-payment-rpc-runtime-api.workspace = true
 pallet-transaction-payment.workspace = true
@@ -123,7 +122,6 @@ std = [
 	"pallet-scheduler/std",
 	"pallet-reward/std",
 	"pallet-session/std",
-	"pallet-sudo/std",
 	"pallet-timestamp/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	"pallet-transaction-payment/std",
@@ -188,7 +186,6 @@ runtime-benchmarks = [
 	"pallet-scheduler/runtime-benchmarks",
 	"pallet-reward/runtime-benchmarks",
 	"pallet-session/runtime-benchmarks",
-	"pallet-sudo/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"pallet-transaction-payment/runtime-benchmarks",
 	"pallet-treasury/runtime-benchmarks",
@@ -220,7 +217,6 @@ try-runtime = [
 	"pallet-scheduler/try-runtime",
 	"pallet-reward/try-runtime",
 	"pallet-session/try-runtime",
-	"pallet-sudo/try-runtime",
 	"pallet-timestamp/try-runtime",
 	"pallet-transaction-payment/try-runtime",
 	"pallet-treasury/try-runtime",

--- a/runtime/src/benchmarks.rs
+++ b/runtime/src/benchmarks.rs
@@ -4,7 +4,6 @@ frame_benchmarking::define_benchmarks!(
 	[frame_system_extensions, SystemExtensionsBench::<Runtime>]
 	[pallet_balances, Balances]
 	[pallet_timestamp, Timestamp]
-	[pallet_sudo, Sudo]
 	[pallet_treasury, Treasury]
 	[pallet_bounties, Bounties]
 	[pallet_child_bounties, ChildBounties]

--- a/runtime/src/configs/governance.rs
+++ b/runtime/src/configs/governance.rs
@@ -11,7 +11,7 @@ use frame_support::{
 	parameter_types,
 	traits::{ConstU32, EitherOf},
 };
-use frame_system::{EnsureRoot, EnsureRootWithSuccess, EnsureSigned};
+use frame_system::{EnsureRootWithSuccess, EnsureSigned};
 use pallet_referenda::{Curve, Track, TrackInfo};
 use sp_runtime::{str_array as s, FixedI64};
 
@@ -207,8 +207,8 @@ impl pallet_referenda::Config for Runtime {
 	type Scheduler = Scheduler;
 	type Currency = Balances;
 	type SubmitOrigin = EnsureSigned<AccountId>;
-	type CancelOrigin = EnsureRoot<AccountId>;
-	type KillOrigin = EnsureRoot<AccountId>;
+	type CancelOrigin = pallet_prime::EnsurePrime<Runtime>;
+	type KillOrigin = pallet_prime::EnsurePrime<Runtime>;
 	type Slash = Treasury;
 	type Votes = pallet_conviction_voting::VotesOf<Runtime>;
 	type Tally = pallet_conviction_voting::TallyOf<Runtime>;

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -186,12 +186,6 @@ impl pallet_transaction_payment::Config for Runtime {
 	type WeightInfo = pallet_transaction_payment::weights::SubstrateWeight<Runtime>;
 }
 
-impl pallet_sudo::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeCall = RuntimeCall;
-	type WeightInfo = pallet_sudo::weights::SubstrateWeight<Runtime>;
-}
-
 impl pallet_prime::Config for Runtime {
 	type WeightInfo = pallet_prime::weights::SubstrateWeight<Runtime>;
 }
@@ -621,7 +615,7 @@ parameter_types! {
 impl pallet_treasury::Config for Runtime {
 	type PalletId = TreasuryPalletId;
 	type Currency = Balances;
-	type RejectOrigin = EnsureRoot<AccountId>;
+	type RejectOrigin = pallet_prime::EnsurePrime<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 	type SpendPeriod = SpendPeriod;
 	type Burn = Burn;

--- a/runtime/src/genesis_config_presets.rs
+++ b/runtime/src/genesis_config_presets.rs
@@ -1,6 +1,6 @@
 use crate::{
 	AccountId, BalancesConfig, DifficultyConfig, EVMChainIdConfig, EVMConfig, PrimeConfig,
-	RuntimeGenesisConfig, SessionConfig, SessionKeys, SudoConfig, ValidatorConfig, UNIT,
+	RuntimeGenesisConfig, SessionConfig, SessionKeys, ValidatorConfig, UNIT,
 };
 use alloc::{collections::BTreeMap, vec, vec::Vec};
 use fp_evm::GenesisAccount;
@@ -115,7 +115,6 @@ const PRIME_MULTISIG: [u8; 32] = hex!("db45d74546b00d6efd137e9a2ea63a3b1595bad6a
 
 fn genesis_patch(
 	balances: Vec<(AccountId, u128)>,
-	sudo_key: Option<AccountId>,
 	prime_key: Option<AccountId>,
 	validators: Vec<(AccountId, GrandpaId, ImOnlineId)>,
 	chain_id: u64,
@@ -133,7 +132,6 @@ fn genesis_patch(
 
 	build_struct_json_patch!(RuntimeGenesisConfig {
 		balances: BalancesConfig { balances },
-		sudo: SudoConfig { key: sudo_key },
 		prime: PrimeConfig { key: prime_key },
 		difficulty: DifficultyConfig { initial_difficulty },
 		session: SessionConfig { keys: session_keys },
@@ -151,7 +149,6 @@ pub fn development_config_genesis() -> Value {
 	genesis_patch(
 		dev_balances(),
 		Some(Sr25519Keyring::Alice.to_account_id()),
-		Some(Sr25519Keyring::Alice.to_account_id()),
 		dev_validators(),
 		DEV_EVM_CHAIN_ID,
 		dev_evm_accounts(),
@@ -162,7 +159,6 @@ pub fn development_config_genesis() -> Value {
 pub fn local_config_genesis() -> Value {
 	genesis_patch(
 		dev_balances(),
-		Some(Sr25519Keyring::Alice.to_account_id()),
 		Some(Sr25519Keyring::Alice.to_account_id()),
 		dev_validators(),
 		DEV_EVM_CHAIN_ID,
@@ -175,7 +171,6 @@ pub fn integration_config_genesis() -> Value {
 	genesis_patch(
 		dev_balances(),
 		Some(Sr25519Keyring::Alice.to_account_id()),
-		Some(Sr25519Keyring::Alice.to_account_id()),
 		dev_validators(),
 		DEV_EVM_CHAIN_ID,
 		dev_evm_accounts(),
@@ -186,7 +181,6 @@ pub fn integration_config_genesis() -> Value {
 pub fn testnet_config_genesis() -> Value {
 	genesis_patch(
 		live_balances(),
-		None,
 		Some(PRIME_MULTISIG.into()),
 		live_validators(),
 		TEST_EVM_CHAIN_ID,
@@ -198,7 +192,6 @@ pub fn testnet_config_genesis() -> Value {
 pub fn mainnet_config_genesis() -> Value {
 	genesis_patch(
 		live_balances(),
-		None,
 		Some(PRIME_MULTISIG.into()),
 		live_validators(),
 		MAIN_EVM_CHAIN_ID,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -210,9 +210,6 @@ mod runtime {
 	#[runtime::pallet_index(3)]
 	pub type TransactionPayment = pallet_transaction_payment;
 
-	#[runtime::pallet_index(255)]
-	pub type Sudo = pallet_sudo;
-
 	#[runtime::pallet_index(4)]
 	pub type BlockReward = pallet_reward;
 


### PR DESCRIPTION
## What

- Add an EnsurePrime origin to pallet prime that admits only the stored prime key
- Point referenda CancelOrigin and KillOrigin plus treasury RejectOrigin at prime, bounties inherit the latter
- Drop pallet sudo from the runtime, genesis presets, benchmarks list and both Cargo.toml files

## Why

The referendum brake and the treasury veto paths were gated on Root, which no extrinsic can reach once sudo is gone. Wiring them to prime keeps cancel, kill, spend rejection and curator removal usable on live networks while sudo retires for good. ScheduleOrigin and ManagerOrigin stay on EnsureRoot and go dead on purpose.

Closes #120