### PR TITLE
Add tests for untested runtime and node wiring

### DIFF
--- a/consensus/sc-consensus-pow/src/worker.rs
+++ b/consensus/sc-consensus-pow/src/worker.rs
@@ -303,3 +303,165 @@ impl<Block: BlockT> Stream for UntilImportedOrTimeout<Block> {
 		}
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{Error, PowAlgorithm};
+	use futures::executor::block_on;
+	use sc_consensus::{BlockCheckParams, BlockImport, ImportResult};
+	use sp_core::{H256, U256};
+	use sp_runtime::{
+		testing::{Block as RawBlock, Header as TestHeader},
+		OpaqueExtrinsic,
+	};
+
+	type Block = RawBlock<OpaqueExtrinsic>;
+
+	/// Reports zero difficulty and accepts every seal, so `submit` outcomes
+	/// depend only on the task queue and block import.
+	struct AcceptAll;
+
+	impl PowAlgorithm<Block> for AcceptAll {
+		type Difficulty = U256;
+
+		fn difficulty(&self, _parent: H256) -> Result<U256, Error<Block>> {
+			Ok(U256::zero())
+		}
+
+		fn verify(
+			&self,
+			_parent: &BlockId<Block>,
+			_pre_hash: &H256,
+			_pre_digest: Option<&[u8]>,
+			_seal: &Seal,
+			_difficulty: U256,
+		) -> Result<bool, Error<Block>> {
+			Ok(true)
+		}
+	}
+
+	/// Records every imported block and always succeeds.
+	struct RecordingImport(Arc<Mutex<Vec<H256>>>);
+
+	#[async_trait::async_trait]
+	impl BlockImport<Block> for RecordingImport {
+		type Error = sp_consensus::Error;
+
+		async fn check_block(
+			&self,
+			_block: BlockCheckParams<Block>,
+		) -> Result<ImportResult, Self::Error> {
+			Ok(ImportResult::Imported(Default::default()))
+		}
+
+		async fn import_block(
+			&self,
+			block: BlockImportParams<Block>,
+		) -> Result<ImportResult, Self::Error> {
+			self.0.lock().push(block.header.hash());
+			Ok(ImportResult::Imported(Default::default()))
+		}
+	}
+
+	fn handle() -> (MiningHandle<Block, AcceptAll, ()>, Arc<Mutex<Vec<H256>>>) {
+		let imported = Arc::new(Mutex::new(Vec::new()));
+		let import = RecordingImport(imported.clone());
+		(MiningHandle::new(AcceptAll, Box::new(import), ()), imported)
+	}
+
+	fn build(head: u8, task: u64) -> MiningBuild<Block, AcceptAll> {
+		MiningBuild {
+			metadata: MiningMetadata {
+				best_hash: H256::repeat_byte(head),
+				pre_hash: H256::from_low_u64_be(task),
+				pre_runtime: None,
+				difficulty: U256::zero(),
+			},
+			proposal: Proposal {
+				block: <Block as BlockT>::new(TestHeader::new_from_number(1), Vec::new()),
+				storage_changes: Default::default(),
+			},
+		}
+	}
+
+	fn holds_task(handle: &MiningHandle<Block, AcceptAll, ()>, task: u64) -> bool {
+		handle.build.lock().iter().any(|b| b.metadata.pre_hash == H256::from_low_u64_be(task))
+	}
+
+	#[test]
+	fn on_build_evicts_the_oldest_past_the_cap() {
+		let (handle, _) = handle();
+		for task in 0..MAX_LIVE_TASKS as u64 {
+			handle.on_build(build(0xAA, task));
+		}
+		assert_eq!(handle.build.lock().len(), MAX_LIVE_TASKS, "the cap itself still fits");
+		assert!(holds_task(&handle, 0));
+
+		handle.on_build(build(0xAA, MAX_LIVE_TASKS as u64));
+
+		assert_eq!(
+			handle.build.lock().len(),
+			MAX_LIVE_TASKS,
+			"one past the cap evicts instead of growing",
+		);
+		assert!(!holds_task(&handle, 0), "the oldest build is the one evicted");
+		assert!(holds_task(&handle, 1));
+		assert!(holds_task(&handle, MAX_LIVE_TASKS as u64));
+	}
+
+	#[test]
+	fn on_build_drops_all_tasks_of_a_stale_head() {
+		let (handle, _) = handle();
+		for task in 0..3 {
+			handle.on_build(build(0xAA, task));
+		}
+
+		handle.on_build(build(0xBB, 7));
+
+		assert_eq!(handle.build.lock().len(), 1, "a new head starts an empty queue");
+		assert!(holds_task(&handle, 7));
+		assert_eq!(handle.best_hash(), Some(H256::repeat_byte(0xBB)));
+	}
+
+	#[test]
+	fn on_major_syncing_clears_the_queue() {
+		let (handle, _) = handle();
+		for task in 0..3 {
+			handle.on_build(build(0xAA, task));
+		}
+
+		handle.on_major_syncing();
+
+		assert!(handle.build.lock().is_empty());
+		assert_eq!(handle.best_hash(), None);
+		assert!(handle.metadata().is_none());
+	}
+
+	#[test]
+	fn submit_rejects_an_evicted_task() {
+		let (handle, imported) = handle();
+		for task in 0..=MAX_LIVE_TASKS as u64 {
+			handle.on_build(build(0xAA, task));
+		}
+
+		assert!(!block_on(handle.submit(H256::from_low_u64_be(0), vec![1])));
+
+		assert!(imported.lock().is_empty(), "an evicted task must not reach block import");
+	}
+
+	#[test]
+	fn submit_imports_a_retained_older_task_and_clears_the_queue() {
+		let (handle, imported) = handle();
+		handle.on_build(build(0xAA, 1));
+		handle.on_build(build(0xAA, 2));
+
+		assert!(block_on(handle.submit(H256::from_low_u64_be(1), vec![1])));
+
+		assert_eq!(imported.lock().len(), 1);
+		assert!(
+			handle.build.lock().is_empty(),
+			"a landed block invalidates every remaining build",
+		);
+	}
+}

--- a/node/src/object_rpc.rs
+++ b/node/src/object_rpc.rs
@@ -112,13 +112,168 @@ fn rpc_err(code: i32, msg: String) -> ErrorObjectOwned {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use codec::Encode;
+	use sp_api::{ApiError, ApiRef, ProvideRuntimeApi};
+	use sp_blockchain::{BlockStatus, Info};
+	use sp_core::U256;
+	use sp_runtime::{
+		testing::{Block as RawBlock, Header},
+		traits::NumberFor,
+		OpaqueExtrinsic,
+	};
+	use std::{collections::HashMap, sync::Mutex};
+
+	type Block = RawBlock<OpaqueExtrinsic>;
+
+	/// Arguments of every `generate_mesh` replay, in call order.
+	type Replays = Arc<Mutex<Vec<(H256, H256, U256)>>>;
+
+	struct MockApi {
+		mesh: Vec<u8>,
+		replays: Replays,
+	}
+
+	sp_api::mock_impl_runtime_apis! {
+		impl PowVerifyApi<Block> for MockApi {
+			fn verify_seal(&self, _pre_hash: H256, _seal: Vec<u8>, _difficulty: U256) -> bool {
+				true
+			}
+
+			#[advanced]
+			fn generate_mesh(
+				&self,
+				at: H256,
+				pre_hash: H256,
+				nonce: U256,
+			) -> Result<Vec<u8>, ApiError> {
+				self.replays.lock().unwrap().push((at, pre_hash, nonce));
+				Ok(self.mesh.clone())
+			}
+		}
+	}
+
+	struct MockClient {
+		headers: HashMap<H256, Header>,
+		mesh: Vec<u8>,
+		replays: Replays,
+	}
+
+	impl ProvideRuntimeApi<Block> for MockClient {
+		type Api = MockApi;
+
+		fn runtime_api(&self) -> ApiRef<'_, Self::Api> {
+			MockApi { mesh: self.mesh.clone(), replays: self.replays.clone() }.into()
+		}
+	}
+
+	impl HeaderBackend<Block> for MockClient {
+		fn header(&self, hash: H256) -> sp_blockchain::Result<Option<Header>> {
+			Ok(self.headers.get(&hash).cloned())
+		}
+
+		fn info(&self) -> Info<Block> {
+			unimplemented!("not used by the export RPC")
+		}
+
+		fn status(&self, _hash: H256) -> sp_blockchain::Result<BlockStatus> {
+			unimplemented!("not used by the export RPC")
+		}
+
+		fn number(&self, _hash: H256) -> sp_blockchain::Result<Option<NumberFor<Block>>> {
+			unimplemented!("not used by the export RPC")
+		}
+
+		fn hash(&self, _number: NumberFor<Block>) -> sp_blockchain::Result<Option<H256>> {
+			unimplemented!("not used by the export RPC")
+		}
+	}
+
+	fn triangle() -> WireMesh {
+		WireMesh {
+			vertices: vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+			faces: vec![[0, 1, 2]],
+		}
+	}
+
+	/// A header carrying an author pre-runtime digest, the way mined blocks do.
+	/// The pre-hash is taken before the seal lands, exactly like block import.
+	fn mined_header(seal_bytes: Vec<u8>) -> (Header, H256, H256) {
+		let mut header = Header::new_from_number(5);
+		header.parent_hash = H256::repeat_byte(0x11);
+		header.digest.push(DigestItem::PreRuntime(POW_ENGINE_ID, vec![0xAB; 32]));
+		let pre_hash = header.hash();
+		header.digest.push(DigestItem::Seal(POW_ENGINE_ID, seal_bytes));
+		let sealed_hash = header.hash();
+		(header, sealed_hash, pre_hash)
+	}
+
+	fn export(headers: Vec<(H256, Header)>) -> (ObjectExport<MockClient, Block>, Replays) {
+		let replays = Replays::default();
+		let client = MockClient {
+			headers: headers.into_iter().collect(),
+			mesh: triangle().encode(),
+			replays: replays.clone(),
+		};
+		(ObjectExport::new(Arc::new(client)), replays)
+	}
 
 	#[test]
 	fn obj_shifts_faces_to_one_based() {
-		let mesh = WireMesh {
-			vertices: vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
-			faces: vec![[0, 1, 2]],
-		};
+		let mesh = triangle();
 		assert_eq!(write_obj(&mesh), "v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n");
+	}
+
+	#[test]
+	fn get_object_takes_every_replay_input_from_the_block() {
+		let nonce = U256::from(42);
+		let seal = Seal { nonce, work: H256::repeat_byte(0x09) };
+		let (header, sealed_hash, pre_hash) = mined_header(seal.encode());
+		let parent_hash = header.parent_hash;
+		let (export, replays) = export(vec![(sealed_hash, header)]);
+
+		let obj = export.get_object(sealed_hash).expect("export succeeds");
+
+		assert_eq!(obj, write_obj(&triangle()));
+		assert_eq!(
+			replays.lock().unwrap().as_slice(),
+			&[(parent_hash, pre_hash, nonce)],
+			"the mesh replays at the parent, on the seal-stripped hash, with the seal nonce",
+		);
+	}
+
+	#[test]
+	fn get_object_rejects_block_without_pow_seal() {
+		let mut header = Header::new_from_number(5);
+		header.digest.push(DigestItem::PreRuntime(POW_ENGINE_ID, vec![0xAB; 32]));
+		let hash = header.hash();
+		let (export, replays) = export(vec![(hash, header)]);
+
+		let err = export.get_object(hash).expect_err("sealless block must be rejected");
+
+		assert_eq!(err.code(), NO_SEAL);
+		assert!(replays.lock().unwrap().is_empty());
+	}
+
+	#[test]
+	fn get_object_rejects_malformed_seal_bytes() {
+		let (header, sealed_hash, _) = mined_header(vec![0xFF]);
+		let (export, replays) = export(vec![(sealed_hash, header)]);
+
+		let err = export.get_object(sealed_hash).expect_err("undecodable seal must be rejected");
+
+		assert_eq!(err.code(), REBUILD_FAILED);
+		assert!(err.message().contains("seal decode"), "unexpected message: {}", err.message());
+		assert!(replays.lock().unwrap().is_empty());
+	}
+
+	#[test]
+	fn get_object_rejects_unknown_block() {
+		let (export, _) = export(Vec::new());
+
+		let err = export
+			.get_object(H256::repeat_byte(0x77))
+			.expect_err("a hash outside the backend must be rejected");
+
+		assert_eq!(err.code(), UNKNOWN_BLOCK);
 	}
 }

--- a/runtime/tests/fees.rs
+++ b/runtime/tests/fees.rs
@@ -1,0 +1,176 @@
+//! Fee routing. Substrate fees and EVM base fee plus tip all land on the PoW
+//! author from the block digest, and burn when a block carries no author.
+
+mod common;
+
+use codec::Encode;
+use common::new_test_ext;
+use frame_support::traits::{
+	tokens::{
+		fungible::{Balanced, Mutate},
+		Fortitude, Precision, Preservation,
+	},
+	OnUnbalanced,
+};
+use numen_runtime::{
+	configs::DealWithFees, AccountId, Balance, Balances, Runtime, System, UNIT,
+};
+use pallet_evm::{AddressMapping, FeeCalculator, Runner};
+use sp_consensus_pow::POW_ENGINE_ID;
+use sp_core::{H160, U256};
+use sp_keyring::Sr25519Keyring;
+use sp_runtime::DigestItem;
+
+/// Two gwei, comfortably above the 1 gwei base fee plus the tip below.
+const MAX_FEE_PER_GAS: u64 = 2_000_000_000;
+const TIP_PER_GAS: u64 = 500_000_000;
+const GAS_LIMIT: u64 = 100_000;
+const CALLER_FUNDS: Balance = 1_000 * UNIT;
+
+fn miner() -> AccountId {
+	Sr25519Keyring::Eve.to_account_id()
+}
+
+/// Stamp the block digest with a PoW author, the way both miners do.
+fn set_pow_author(author: &AccountId) {
+	System::deposit_log(DigestItem::PreRuntime(POW_ENGINE_ID, author.encode()));
+}
+
+fn evm_account(addr: H160) -> AccountId {
+	<Runtime as pallet_evm::Config>::AddressMapping::into_account_id(addr)
+}
+
+/// Withdraw `fee` from the payer exactly like `FungibleAdapter` does before it
+/// hands the credit to the fee sink.
+fn fee_credit(
+	payer: &AccountId,
+	fee: Balance,
+) -> frame_support::traits::fungible::Credit<AccountId, Balances> {
+	<Balances as Balanced<AccountId>>::withdraw(
+		payer,
+		fee,
+		Precision::Exact,
+		Preservation::Expendable,
+		Fortitude::Polite,
+	)
+	.expect("payer covers the fee")
+}
+
+/// A transactional EVM call to a plain address, paying a tip on top of the
+/// base fee.
+fn evm_plain_call_with_tip(caller: H160) -> fp_evm::CallInfo {
+	<Runtime as pallet_evm::Config>::Runner::call(
+		caller,
+		H160::from_low_u64_be(0xD00D),
+		Vec::new(),
+		U256::zero(),
+		GAS_LIMIT,
+		Some(U256::from(MAX_FEE_PER_GAS)),
+		Some(U256::from(TIP_PER_GAS)),
+		None,
+		Vec::new(),
+		Vec::new(),
+		true,
+		true,
+		None,
+		None,
+		None,
+		<Runtime as pallet_evm::Config>::config(),
+	)
+	.expect("plain call must dispatch without runtime error")
+}
+
+#[test]
+fn substrate_fees_credit_the_block_author() {
+	new_test_ext().execute_with(|| {
+		let author = miner();
+		set_pow_author(&author);
+		let payer = Sr25519Keyring::Alice.to_account_id();
+		Balances::set_balance(&payer, CALLER_FUNDS);
+		let issuance_before = Balances::total_issuance();
+		let fee = UNIT;
+
+		DealWithFees::on_nonzero_unbalanced(fee_credit(&payer, fee));
+
+		assert_eq!(
+			Balances::free_balance(&author),
+			fee,
+			"the whole fee lands on the digest author",
+		);
+		assert_eq!(
+			Balances::total_issuance(),
+			issuance_before,
+			"nothing burns when the block has an author",
+		);
+	});
+}
+
+#[test]
+fn substrate_fees_burn_without_author_digest() {
+	new_test_ext().execute_with(|| {
+		let payer = Sr25519Keyring::Alice.to_account_id();
+		Balances::set_balance(&payer, CALLER_FUNDS);
+		let issuance_before = Balances::total_issuance();
+		let fee = UNIT;
+
+		DealWithFees::on_nonzero_unbalanced(fee_credit(&payer, fee));
+
+		assert_eq!(
+			Balances::total_issuance(),
+			issuance_before - fee,
+			"an authorless fee credit burns in full",
+		);
+	});
+}
+
+#[test]
+fn evm_base_fee_and_tip_credit_the_block_author() {
+	new_test_ext().execute_with(|| {
+		let author = miner();
+		set_pow_author(&author);
+		let caller = H160::from_low_u64_be(0xFEE1);
+		let caller_acc = evm_account(caller);
+		Balances::set_balance(&caller_acc, CALLER_FUNDS);
+		let issuance_before = Balances::total_issuance();
+		let (base_fee, _) = <Runtime as pallet_evm::Config>::FeeCalculator::min_gas_price();
+
+		let info = evm_plain_call_with_tip(caller);
+		assert!(info.exit_reason.is_succeed(), "unexpected exit: {:?}", info.exit_reason);
+
+		let caller_spent = CALLER_FUNDS - Balances::free_balance(&caller_acc);
+		let author_gain = Balances::free_balance(&author);
+		assert_eq!(
+			U256::from(author_gain),
+			info.used_gas.effective * (base_fee + U256::from(TIP_PER_GAS)),
+			"the author collects gas times base fee plus tip",
+		);
+		assert_eq!(author_gain, caller_spent, "every wei the caller pays reaches the author");
+		assert_eq!(
+			Balances::free_balance(&evm_account(H160::zero())),
+			0,
+			"the tip must bypass the zero coinbase the default handler pays",
+		);
+		assert_eq!(Balances::total_issuance(), issuance_before, "nothing burns");
+	});
+}
+
+#[test]
+fn evm_fees_burn_without_author_digest() {
+	new_test_ext().execute_with(|| {
+		let caller = H160::from_low_u64_be(0xFEE1);
+		let caller_acc = evm_account(caller);
+		Balances::set_balance(&caller_acc, CALLER_FUNDS);
+		let issuance_before = Balances::total_issuance();
+
+		let info = evm_plain_call_with_tip(caller);
+		assert!(info.exit_reason.is_succeed(), "unexpected exit: {:?}", info.exit_reason);
+
+		let caller_spent = CALLER_FUNDS - Balances::free_balance(&caller_acc);
+		assert!(caller_spent > 0);
+		assert_eq!(
+			Balances::total_issuance(),
+			issuance_before - caller_spent,
+			"base fee and tip both burn in an authorless block",
+		);
+	});
+}

--- a/runtime/tests/prime_brakes.rs
+++ b/runtime/tests/prime_brakes.rs
@@ -1,0 +1,219 @@
+//! Governance brakes wiring. Referenda cancel and kill plus the treasury
+//! reject origin answer only to the prime key, with root explicitly locked out.
+
+mod common;
+
+use common::new_test_ext;
+use frame_support::{
+	assert_noop, assert_ok,
+	traits::{schedule::DispatchTime, tokens::fungible::Mutate, OriginTrait, StorePreimage},
+};
+use numen_runtime::{
+	configs::{self, governance::pallet_custom_origins},
+	AccountId, Balance, Balances, Bounties, Preimage, Referenda, Runtime, RuntimeCall,
+	RuntimeOrigin, System, UNIT,
+};
+use pallet_referenda::{ReferendumInfo, ReferendumInfoFor};
+use sp_keyring::Sr25519Keyring;
+use sp_runtime::DispatchError;
+
+const FUNDS: Balance = 10_000 * UNIT;
+
+fn prime() -> AccountId {
+	Sr25519Keyring::Ferdie.to_account_id()
+}
+
+fn install_prime() -> AccountId {
+	let key = prime();
+	pallet_prime::Key::<Runtime>::put(&key);
+	key
+}
+
+fn assert_ongoing(index: u32) {
+	assert!(
+		matches!(ReferendumInfoFor::<Runtime>::get(index), Some(ReferendumInfo::Ongoing(_))),
+		"referendum {index} must stay ongoing",
+	);
+}
+
+/// Submit a small track referendum with its decision deposit placed, returning
+/// its index. Both deposits stay reserved on the submitter.
+fn ongoing_referendum(submitter: &AccountId) -> u32 {
+	Balances::set_balance(submitter, FUNDS);
+	let index = pallet_referenda::ReferendumCount::<Runtime>::get();
+	let proposal = <Preimage as StorePreimage>::bound(RuntimeCall::System(
+		frame_system::Call::remark { remark: b"spend".to_vec() },
+	))
+	.expect("a remark call bounds inline");
+	let track = RuntimeOrigin::from(pallet_custom_origins::Origin::SmallSpender);
+	assert_ok!(Referenda::submit(
+		RuntimeOrigin::signed(submitter.clone()),
+		Box::new(track.caller().clone()),
+		proposal,
+		DispatchTime::After(1),
+	));
+	assert_ok!(Referenda::place_decision_deposit(
+		RuntimeOrigin::signed(submitter.clone()),
+		index,
+	));
+	index
+}
+
+/// Place a bounty proposal, returning its id and the bond reserved for it.
+fn proposed_bounty(proposer: &AccountId) -> (u32, Balance) {
+	Balances::set_balance(proposer, FUNDS);
+	let id = pallet_bounties::BountyCount::<Runtime>::get();
+	assert_ok!(Bounties::propose_bounty(
+		RuntimeOrigin::signed(proposer.clone()),
+		1_000 * UNIT,
+		b"work".to_vec(),
+	));
+	(id, Balances::reserved_balance(proposer))
+}
+
+#[test]
+fn prime_cancels_referendum_and_deposits_stay_refundable() {
+	new_test_ext().execute_with(|| {
+		let key = install_prime();
+		let submitter = Sr25519Keyring::Alice.to_account_id();
+		let index = ongoing_referendum(&submitter);
+
+		assert_ok!(Referenda::cancel(RuntimeOrigin::signed(key), index));
+
+		assert!(matches!(
+			ReferendumInfoFor::<Runtime>::get(index),
+			Some(ReferendumInfo::Cancelled(..)),
+		));
+		assert_ok!(Referenda::refund_decision_deposit(
+			RuntimeOrigin::signed(submitter.clone()),
+			index,
+		));
+		assert_ok!(Referenda::refund_submission_deposit(
+			RuntimeOrigin::signed(submitter.clone()),
+			index,
+		));
+		assert_eq!(Balances::reserved_balance(&submitter), 0);
+		assert_eq!(
+			Balances::free_balance(&submitter),
+			FUNDS,
+			"a cancelled referendum returns both deposits in full",
+		);
+	});
+}
+
+#[test]
+fn prime_kills_referendum_and_slashes_both_deposits() {
+	new_test_ext().execute_with(|| {
+		let key = install_prime();
+		let submitter = Sr25519Keyring::Alice.to_account_id();
+		let treasury = configs::TreasuryAccount::get();
+		let index = ongoing_referendum(&submitter);
+		let deposits = Balances::reserved_balance(&submitter);
+		assert!(deposits > 0);
+
+		assert_ok!(Referenda::kill(RuntimeOrigin::signed(key), index));
+
+		assert!(matches!(
+			ReferendumInfoFor::<Runtime>::get(index),
+			Some(ReferendumInfo::Killed(_)),
+		));
+		assert_eq!(Balances::reserved_balance(&submitter), 0);
+		assert_eq!(
+			Balances::free_balance(&submitter),
+			FUNDS - deposits,
+			"a killed referendum forfeits both deposits",
+		);
+		assert_eq!(
+			Balances::free_balance(&treasury),
+			deposits,
+			"slashed deposits land in the treasury pot",
+		);
+	});
+}
+
+#[test]
+fn cancel_referendum_rejects_non_prime_origins() {
+	new_test_ext().execute_with(|| {
+		install_prime();
+		let submitter = Sr25519Keyring::Alice.to_account_id();
+		let index = ongoing_referendum(&submitter);
+		let outsider = Sr25519Keyring::Bob.to_account_id();
+
+		assert_noop!(
+			Referenda::cancel(RuntimeOrigin::signed(outsider), index),
+			DispatchError::BadOrigin,
+		);
+		assert_noop!(Referenda::cancel(RuntimeOrigin::root(), index), DispatchError::BadOrigin);
+
+		assert_ongoing(index);
+	});
+}
+
+#[test]
+fn kill_referendum_rejects_non_prime_origins() {
+	new_test_ext().execute_with(|| {
+		install_prime();
+		let submitter = Sr25519Keyring::Alice.to_account_id();
+		let index = ongoing_referendum(&submitter);
+		let outsider = Sr25519Keyring::Bob.to_account_id();
+
+		assert_noop!(
+			Referenda::kill(RuntimeOrigin::signed(outsider), index),
+			DispatchError::BadOrigin,
+		);
+		assert_noop!(Referenda::kill(RuntimeOrigin::root(), index), DispatchError::BadOrigin);
+
+		assert_ongoing(index);
+	});
+}
+
+#[test]
+fn prime_closes_proposed_bounty_and_slashes_bond() {
+	new_test_ext().execute_with(|| {
+		let key = install_prime();
+		let proposer = Sr25519Keyring::Alice.to_account_id();
+		let treasury = configs::TreasuryAccount::get();
+		let (id, bond) = proposed_bounty(&proposer);
+		assert!(bond > 0);
+
+		assert_ok!(Bounties::close_bounty(RuntimeOrigin::signed(key), id));
+
+		assert!(
+			pallet_bounties::Bounties::<Runtime>::get(id).is_none(),
+			"a rejected proposal is removed",
+		);
+		assert_eq!(Balances::reserved_balance(&proposer), 0);
+		assert_eq!(
+			Balances::free_balance(&proposer),
+			FUNDS - bond,
+			"the slashed bond is not returned",
+		);
+		assert_eq!(
+			Balances::free_balance(&treasury),
+			bond,
+			"the slashed bond lands in the treasury pot",
+		);
+		System::assert_has_event(pallet_bounties::Event::BountyRejected { index: id, bond }.into());
+	});
+}
+
+#[test]
+fn close_bounty_rejects_non_prime_origins() {
+	new_test_ext().execute_with(|| {
+		install_prime();
+		let proposer = Sr25519Keyring::Alice.to_account_id();
+		let (id, _) = proposed_bounty(&proposer);
+		let outsider = Sr25519Keyring::Bob.to_account_id();
+
+		assert_noop!(
+			Bounties::close_bounty(RuntimeOrigin::signed(outsider), id),
+			DispatchError::BadOrigin,
+		);
+		assert_noop!(Bounties::close_bounty(RuntimeOrigin::root(), id), DispatchError::BadOrigin);
+
+		assert!(
+			pallet_bounties::Bounties::<Runtime>::get(id).is_some(),
+			"the proposal survives rejected close attempts",
+		);
+	});
+}

--- a/runtime/tests/proxy.rs
+++ b/runtime/tests/proxy.rs
@@ -1,0 +1,182 @@
+//! ProxyType filter wiring. NonTransfer fences off every fund moving entry
+//! including the EVM ones, Governance admits only the governance pallets, and
+//! pallet-proxy enforces the filter at dispatch.
+
+mod common;
+
+use common::new_test_ext;
+use ethereum::{
+	legacy::TransactionSignature, LegacyTransaction, TransactionAction, TransactionV3,
+};
+use frame_support::{
+	assert_ok,
+	traits::{tokens::fungible::Mutate, InstanceFilter},
+};
+use numen_runtime::{
+	configs::ProxyType, AccountId, Balances, Proxy, Runtime, RuntimeCall, RuntimeOrigin, System,
+	UNIT,
+};
+use sp_core::{H160, H256, U256};
+use sp_keyring::Sr25519Keyring;
+use sp_runtime::traits::StaticLookup;
+
+fn src(who: &AccountId) -> <<Runtime as frame_system::Config>::Lookup as StaticLookup>::Source {
+	<Runtime as frame_system::Config>::Lookup::unlookup(who.clone())
+}
+
+fn transfer_call(dest: &AccountId) -> RuntimeCall {
+	RuntimeCall::Balances(pallet_balances::Call::transfer_keep_alive {
+		dest: src(dest),
+		value: UNIT,
+	})
+}
+
+fn evm_withdraw_call() -> RuntimeCall {
+	RuntimeCall::EVM(pallet_evm::Call::withdraw { address: H160::zero(), value: UNIT })
+}
+
+fn ethereum_transact_call() -> RuntimeCall {
+	let signature = TransactionSignature::new(27, H256::repeat_byte(0x01), H256::repeat_byte(0x01))
+		.expect("dummy legacy signature is within range");
+	RuntimeCall::Ethereum(pallet_ethereum::Call::transact {
+		transaction: TransactionV3::Legacy(LegacyTransaction {
+			nonce: U256::zero(),
+			gas_price: U256::zero(),
+			gas_limit: U256::from(21_000),
+			action: TransactionAction::Call(H160::zero()),
+			value: U256::zero(),
+			input: Vec::new(),
+			signature,
+		}),
+	})
+}
+
+fn remark_call() -> RuntimeCall {
+	RuntimeCall::System(frame_system::Call::remark { remark: Vec::new() })
+}
+
+fn governance_whitelist(voter: &AccountId) -> Vec<RuntimeCall> {
+	vec![
+		RuntimeCall::Treasury(pallet_treasury::Call::remove_approval { proposal_id: 0 }),
+		RuntimeCall::Bounties(pallet_bounties::Call::propose_bounty {
+			value: UNIT,
+			description: Vec::new(),
+		}),
+		RuntimeCall::ChildBounties(pallet_child_bounties::Call::add_child_bounty {
+			parent_bounty_id: 0,
+			value: UNIT,
+			description: Vec::new(),
+		}),
+		RuntimeCall::ConvictionVoting(pallet_conviction_voting::Call::unlock {
+			class: 0,
+			target: src(voter),
+		}),
+		RuntimeCall::Referenda(pallet_referenda::Call::place_decision_deposit { index: 0 }),
+		RuntimeCall::Utility(pallet_utility::Call::batch { calls: Vec::new() }),
+	]
+}
+
+#[test]
+fn non_transfer_blocks_every_fund_moving_entry() {
+	let dest = Sr25519Keyring::Bob.to_account_id();
+	for call in [transfer_call(&dest), evm_withdraw_call(), ethereum_transact_call()] {
+		assert!(
+			!ProxyType::NonTransfer.filter(&call),
+			"NonTransfer must block {call:?}",
+		);
+	}
+}
+
+#[test]
+fn non_transfer_admits_calls_that_leave_funds_alone() {
+	let voter = Sr25519Keyring::Bob.to_account_id();
+	for call in governance_whitelist(&voter).into_iter().chain([remark_call()]) {
+		assert!(
+			ProxyType::NonTransfer.filter(&call),
+			"NonTransfer must admit {call:?}",
+		);
+	}
+}
+
+#[test]
+fn governance_admits_only_the_governance_whitelist() {
+	let who = Sr25519Keyring::Bob.to_account_id();
+	for call in governance_whitelist(&who) {
+		assert!(ProxyType::Governance.filter(&call), "Governance must admit {call:?}");
+	}
+	for call in [transfer_call(&who), evm_withdraw_call(), remark_call()] {
+		assert!(!ProxyType::Governance.filter(&call), "Governance must block {call:?}");
+	}
+}
+
+#[test]
+fn proxy_type_lattice_orders_permissions() {
+	use ProxyType::{Any, Governance, NonTransfer};
+
+	assert!(Any.is_superset(&Any));
+	assert!(Any.is_superset(&NonTransfer));
+	assert!(Any.is_superset(&Governance));
+	assert!(NonTransfer.is_superset(&Governance));
+	assert!(!NonTransfer.is_superset(&Any));
+	assert!(!Governance.is_superset(&NonTransfer));
+	assert!(!Governance.is_superset(&Any));
+}
+
+#[test]
+fn non_transfer_proxy_cannot_move_funds_on_chain() {
+	new_test_ext().execute_with(|| {
+		let delegator = Sr25519Keyring::Alice.to_account_id();
+		let delegate = Sr25519Keyring::Bob.to_account_id();
+		let target = Sr25519Keyring::Charlie.to_account_id();
+		Balances::set_balance(&delegator, 100 * UNIT);
+		assert_ok!(Proxy::add_proxy(
+			RuntimeOrigin::signed(delegator.clone()),
+			src(&delegate),
+			ProxyType::NonTransfer,
+			0,
+		));
+		let delegator_free = Balances::free_balance(&delegator);
+
+		assert_ok!(Proxy::proxy(
+			RuntimeOrigin::signed(delegate),
+			src(&delegator),
+			None,
+			Box::new(transfer_call(&target)),
+		));
+
+		System::assert_last_event(
+			pallet_proxy::Event::ProxyExecuted {
+				result: Err(frame_system::Error::<Runtime>::CallFiltered.into()),
+			}
+			.into(),
+		);
+		assert_eq!(Balances::free_balance(&target), 0, "no funds may leave through the proxy");
+		assert_eq!(Balances::free_balance(&delegator), delegator_free);
+	});
+}
+
+#[test]
+fn non_transfer_proxy_still_dispatches_harmless_calls() {
+	new_test_ext().execute_with(|| {
+		let delegator = Sr25519Keyring::Alice.to_account_id();
+		let delegate = Sr25519Keyring::Bob.to_account_id();
+		Balances::set_balance(&delegator, 100 * UNIT);
+		assert_ok!(Proxy::add_proxy(
+			RuntimeOrigin::signed(delegator.clone()),
+			src(&delegate),
+			ProxyType::NonTransfer,
+			0,
+		));
+
+		assert_ok!(Proxy::proxy(
+			RuntimeOrigin::signed(delegate),
+			src(&delegator),
+			None,
+			Box::new(remark_call()),
+		));
+
+		System::assert_last_event(
+			pallet_proxy::Event::ProxyExecuted { result: Ok(()) }.into(),
+		);
+	});
+}


### PR DESCRIPTION
- prime cancels and kills referenda, closes bounties via reject origin
- substrate and evm fees credit the pow author and burn without one
- proxy type filter fences fund moving calls, checked end to end
- pow worker task queue cap eviction and stale head clearing
- object export rpc takes seal, pre hash and nonce from the block