### PR TITLE
Remove treasury root spend origin left over from sudo removal

### DIFF
--- a/runtime/src/configs/governance.rs
+++ b/runtime/src/configs/governance.rs
@@ -11,7 +11,7 @@ use frame_support::{
 	parameter_types,
 	traits::{ConstU32, EitherOf},
 };
-use frame_system::{EnsureRootWithSuccess, EnsureSigned};
+use frame_system::EnsureSigned;
 use pallet_referenda::{Curve, Track, TrackInfo};
 use sp_runtime::{str_array as s, FixedI64};
 
@@ -193,12 +193,9 @@ impl pallet_conviction_voting::Config for Runtime {
 
 impl pallet_custom_origins::Config for Runtime {}
 
-/// Treasury and bounty spends accept root or any spender tier, each capped at
-/// its tier amount.
-pub type TreasurySpender = EitherOf<
-	EnsureRootWithSuccess<AccountId, super::MaxBalance>,
-	EitherOf<SmallSpender, EitherOf<MediumSpender, BigSpender>>,
->;
+/// Treasury and bounty spends accept any spender tier, each capped at its tier
+/// amount.
+pub type TreasurySpender = EitherOf<SmallSpender, EitherOf<MediumSpender, BigSpender>>;
 
 impl pallet_referenda::Config for Runtime {
 	type WeightInfo = pallet_referenda::weights::SubstrateWeight<Runtime>;

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -604,7 +604,6 @@ parameter_types! {
 	pub const Burn: Permill = Permill::zero();
 	pub const PayoutPeriod: BlockNumber = 30 * DAYS;
 	pub const MaxApprovals: u32 = 100;
-	pub const MaxBalance: Balance = Balance::MAX;
 	pub TreasuryAccount: AccountId = TreasuryPalletId::get().into_account_truncating();
 }
 

--- a/runtime/tests/governance.rs
+++ b/runtime/tests/governance.rs
@@ -1,5 +1,5 @@
 //! Governance wiring. Bounty and child-bounty lifecycles run end to end under a
-//! root approval origin.
+//! spender approval origin.
 
 mod common;
 
@@ -10,8 +10,9 @@ use frame_support::{
 };
 use pallet_bounties::BountyStatus;
 use numen_runtime::{
-	configs, AccountId, Balance, Balances, BlockNumber, Bounties, ChildBounties, Runtime,
-	RuntimeOrigin, System, Treasury, UNIT,
+	configs::{self, governance::pallet_custom_origins},
+	AccountId, Balance, Balances, BlockNumber, Bounties, ChildBounties, Runtime, RuntimeOrigin,
+	System, Treasury, UNIT,
 };
 use sp_keyring::Sr25519Keyring;
 use sp_runtime::traits::StaticLookup;
@@ -56,20 +57,21 @@ fn fund_approved_bounties() {
 /// Take a parent bounty from proposal to an accepted curator, returning its id.
 fn active_parent_bounty(proposer: &AccountId, curator: &AccountId, value: Balance, fee: Balance) -> u32 {
 	let id = pallet_bounties::BountyCount::<Runtime>::get();
+	let approve = RuntimeOrigin::from(pallet_custom_origins::Origin::SmallSpender);
 	assert_ok!(Bounties::propose_bounty(
 		RuntimeOrigin::signed(proposer.clone()),
 		value,
 		b"parent bounty".to_vec(),
 	));
-	assert_ok!(Bounties::approve_bounty(RuntimeOrigin::root(), id));
+	assert_ok!(Bounties::approve_bounty(approve.clone(), id));
 	fund_approved_bounties();
-	assert_ok!(Bounties::propose_curator(RuntimeOrigin::root(), id, src(curator), fee));
+	assert_ok!(Bounties::propose_curator(approve, id, src(curator), fee));
 	assert_ok!(Bounties::accept_curator(RuntimeOrigin::signed(curator.clone()), id));
 	id
 }
 
 #[test]
-fn bounty_pays_beneficiary_and_curator_after_root_approval() {
+fn bounty_pays_beneficiary_and_curator_after_spender_approval() {
 	let proposer = acc(Sr25519Keyring::Alice);
 	let curator = acc(Sr25519Keyring::Bob);
 	let beneficiary = acc(Sr25519Keyring::Charlie);

--- a/runtime/tests/opengov.rs
+++ b/runtime/tests/opengov.rs
@@ -87,13 +87,16 @@ fn higher_tier_approves_what_lower_tier_cannot() {
 }
 
 #[test]
-fn root_origin_still_approves_bounty() {
+fn root_origin_cannot_approve_bounty() {
 	new_test_ext().execute_with(|| {
 		let id = proposed_bounty(SMALL_CAP + 1);
 
-		assert_ok!(Bounties::approve_bounty(RuntimeOrigin::root(), id));
+		assert_noop!(
+			Bounties::approve_bounty(RuntimeOrigin::root(), id),
+			DispatchError::BadOrigin,
+		);
 
-		assert_queued_for_funding(id);
+		assert_still_proposed(id);
 	});
 }
 


### PR DESCRIPTION
The root spend arm of `TreasurySpender` and its dead `MaxBalance` const were left behind when sudo was removed.