### PR TITLE
Verify difficulty from the block timestamp instead of the local clock

### DIFF
--- a/consensus/poscan-pow/src/lib.rs
+++ b/consensus/poscan-pow/src/lib.rs
@@ -75,20 +75,16 @@ where
 {
 	type Difficulty = U256;
 
-	fn difficulty(&self, parent: B::Hash) -> Result<U256, PowError<B>> {
-		// Use wall-clock time so difficulty naturally decays even when no
-		// blocks are being produced.
-		let now_secs = std::time::SystemTime::now()
-			.duration_since(std::time::UNIX_EPOCH)
-			.unwrap_or_default()
-			.as_secs();
-
+	fn difficulty(&self, parent: B::Hash, timestamp_inherent: &[u8]) -> Result<U256, PowError<B>> {
 		self.client
 			.runtime_api()
-			.realtime_difficulty(parent, now_secs)
+			.difficulty_for_block(parent, timestamp_inherent.to_vec())
 			.map_err(|err| PowError::Environment(format!(
-				"Fetching realtime difficulty from runtime failed: {err:?}"
-			)))
+				"Fetching difficulty from runtime failed: {err:?}"
+			)))?
+			.ok_or_else(|| {
+				PowError::Runtime("Block carries no valid timestamp inherent".into())
+			})
 	}
 
 	fn verify(

--- a/consensus/sc-consensus-pow/src/lib.rs
+++ b/consensus/sc-consensus-pow/src/lib.rs
@@ -86,6 +86,8 @@ pub enum Error<B: BlockT> {
 	CheckInherentsUnknownError(sp_inherents::InherentIdentifier),
 	#[error("Multiple pre-runtime digests")]
 	MultiplePreRuntimeDigests,
+	#[error("Block carries no timestamp inherent to derive difficulty from")]
+	MissingTimestampInherent,
 	#[error(transparent)]
 	Client(sp_blockchain::Error),
 	#[error(transparent)]
@@ -209,11 +211,14 @@ pub trait PowAlgorithm<B: BlockT> {
 	/// Difficulty for the algorithm.
 	type Difficulty: TotalDifficulty + Default + Encode + Decode + Ord + Clone + Copy;
 
-	/// Get the next block's difficulty.
+	/// Returns the difficulty the given block must satisfy.
 	///
-	/// This function will be called twice during the import process, so the implementation
-	/// should be properly cached.
-	fn difficulty(&self, parent: B::Hash) -> Result<Self::Difficulty, Error<B>>;
+	/// The clock is the block's own, so verdicts match across nodes and replays.
+	fn difficulty(
+		&self,
+		parent: B::Hash,
+		timestamp_inherent: &[u8],
+	) -> Result<Self::Difficulty, Error<B>>;
 	/// Verify that the seal is valid against given pre hash when parent block is not yet imported.
 	///
 	/// None means that preliminary verify is not available for this algorithm.
@@ -384,8 +389,13 @@ where
 
 		let inner_seal = fetch_seal::<B>(block.post_digests.last(), block.header.hash())?;
 
-		// Recompute difficulty from the parent at import, not from the block or submitter.
-		let difficulty = self.algorithm.difficulty(parent_hash)?;
+		let timestamp_inherent = block
+			.body
+			.as_ref()
+			.and_then(|body| body.first())
+			.ok_or(Error::<B>::MissingTimestampInherent)?
+			.encode();
+		let difficulty = self.algorithm.difficulty(parent_hash, &timestamp_inherent)?;
 
 		let pre_hash = block.header.hash();
 		let pre_digest = find_pre_digest::<B>(&block.header)?;
@@ -591,19 +601,6 @@ where
 			// miners keep getting a recent timestamp. on_build stacks it next to
 			// the head's earlier tasks instead of replacing them.
 
-			let difficulty = match algorithm.difficulty(best_hash) {
-				Ok(x) => x,
-				Err(err) => {
-					warn!(
-						target: LOG_TARGET,
-						"Unable to propose new block for authoring. \
-						 Fetch difficulty failed: {}",
-						err,
-					);
-					continue;
-				},
-			};
-
 			let inherent_data_providers = match create_inherent_data_providers
 				.create_inherent_data_providers(best_hash, ())
 				.await
@@ -669,6 +666,31 @@ where
 						target: LOG_TARGET,
 						"Unable to propose new block for authoring. \
 						 Creating proposal failed: {}",
+						err,
+					);
+					continue;
+				},
+			};
+
+			let timestamp_inherent = match proposal.block.extrinsics().first() {
+				Some(extrinsic) => extrinsic.encode(),
+				None => {
+					warn!(
+						target: LOG_TARGET,
+						"Unable to propose new block for authoring. \
+						 Proposal carries no timestamp inherent",
+					);
+					continue;
+				},
+			};
+
+			let difficulty = match algorithm.difficulty(best_hash, &timestamp_inherent) {
+				Ok(x) => x,
+				Err(err) => {
+					warn!(
+						target: LOG_TARGET,
+						"Unable to propose new block for authoring. \
+						 Fetch difficulty failed: {}",
 						err,
 					);
 					continue;

--- a/consensus/sc-consensus-pow/src/worker.rs
+++ b/consensus/sc-consensus-pow/src/worker.rs
@@ -160,21 +160,12 @@ where
 			},
 		};
 
-		// Pre-check against the same realtime difficulty import recomputes.
-		let difficulty = match self.algorithm.difficulty(metadata.best_hash) {
-			Ok(difficulty) => difficulty,
-			Err(err) => {
-				warn!(target: LOG_TARGET, "Unable to import mined block: {}", err,);
-				return false;
-			},
-		};
-
 		match self.algorithm.verify(
 			&BlockId::Hash(metadata.best_hash),
 			&metadata.pre_hash,
 			metadata.pre_runtime.as_ref().map(|v| &v[..]),
 			&seal,
-			difficulty,
+			metadata.difficulty,
 		) {
 			Ok(true) => (),
 			Ok(false) => {
@@ -325,7 +316,11 @@ mod tests {
 	impl PowAlgorithm<Block> for AcceptAll {
 		type Difficulty = U256;
 
-		fn difficulty(&self, _parent: H256) -> Result<U256, Error<Block>> {
+		fn difficulty(
+			&self,
+			_parent: H256,
+			_timestamp_inherent: &[u8],
+		) -> Result<U256, Error<Block>> {
 			Ok(U256::zero())
 		}
 

--- a/pallets/difficulty/src/lib.rs
+++ b/pallets/difficulty/src/lib.rs
@@ -9,6 +9,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
 pub use pallet::*;
 
 pub mod asert;
@@ -26,11 +28,17 @@ sp_api::decl_runtime_apis! {
 		/// target_block_time, halflife).
 		fn anchor_params() -> (sp_core::U256, u64, u64, u64, u64);
 
-		/// Compute difficulty given an external timestamp (seconds since
-		/// Unix epoch).  This allows the caller to supply the current
-		/// wall-clock time so that difficulty decays in real time even
-		/// when no blocks are being produced.
-		fn realtime_difficulty(now_secs: u64) -> sp_core::U256;
+		/// Computes the difficulty a block with the given timestamp must satisfy.
+		///
+		/// Recomputed from the ASERT anchor rather than read off `CurrentDifficulty`,
+		/// which only holds what the last block settled on. Pass the current time to get
+		/// the difficulty right now.
+		fn realtime_difficulty(block_timestamp_secs: u64) -> sp_core::U256;
+
+		/// Computes a block's difficulty from its timestamp inherent.
+		///
+		/// `None` on a malformed inherent leaves the block unverifiable, so invalid.
+		fn difficulty_for_block(timestamp_inherent: alloc::vec::Vec<u8>) -> Option<sp_core::U256>;
 	}
 }
 
@@ -210,11 +218,12 @@ use frame_support::pallet_prelude::Get;
 use sp_core::U256;
 
 impl<T: pallet::Config> Pallet<T> {
-	/// Compute difficulty given an external wall-clock timestamp (seconds).
+	/// Computes the difficulty a block with the given timestamp must satisfy.
 	///
-	/// When `now_secs` is the current system time, this returns the
-	/// difficulty that naturally decays even if no blocks are produced.
-	pub fn realtime_difficulty(now_secs: u64) -> U256 {
+	/// Recomputed from the ASERT anchor rather than read off `CurrentDifficulty`,
+	/// which only holds what the last block settled on. Pass the current time to get
+	/// the difficulty right now.
+	pub fn realtime_difficulty(block_timestamp_secs: u64) -> U256 {
 		let current_height: u64 = frame_system::Pallet::<T>::block_number()
 			.try_into()
 			.unwrap_or(u64::MAX);
@@ -224,7 +233,7 @@ impl<T: pallet::Config> Pallet<T> {
 		let anchor_target = AnchorTarget::<T>::get();
 
 		let height_delta = next_height.saturating_sub(anchor_height);
-		let time_delta = (now_secs as i128) - (anchor_ts as i128);
+		let time_delta = (block_timestamp_secs as i128) - (anchor_ts as i128);
 
 		let next_target = crate::asert::compute_next_target(
 			anchor_target,

--- a/runtime/src/apis.rs
+++ b/runtime/src/apis.rs
@@ -23,7 +23,7 @@ use super::{
 	AccountId, Balance, Block, Ethereum, Executive, Grandpa, Historical,
 	InherentDataExt, Nonce, Runtime, RuntimeCall, RuntimeGenesisConfig, SessionKeys, System,
 	TransactionPayment, UncheckedExtrinsic, VERSION,
-	inherent_checks::check_timestamp_drift,
+	inherent_checks::{check_timestamp_drift, timestamp_from_inherent},
 };
 
 impl_runtime_apis! {
@@ -270,8 +270,13 @@ impl_runtime_apis! {
 			)
 		}
 
-		fn realtime_difficulty(now_secs: u64) -> U256 {
-			pallet_difficulty::Pallet::<Runtime>::realtime_difficulty(now_secs)
+		fn realtime_difficulty(block_timestamp_secs: u64) -> U256 {
+			pallet_difficulty::Pallet::<Runtime>::realtime_difficulty(block_timestamp_secs)
+		}
+
+		fn difficulty_for_block(timestamp_inherent: Vec<u8>) -> Option<U256> {
+			let now_ms = timestamp_from_inherent(&timestamp_inherent)?;
+			Some(pallet_difficulty::Pallet::<Runtime>::realtime_difficulty(now_ms / 1000))
 		}
 	}
 

--- a/runtime/src/inherent_checks.rs
+++ b/runtime/src/inherent_checks.rs
@@ -1,6 +1,21 @@
+use codec::Decode;
+use crate::{RuntimeCall, UncheckedExtrinsic};
 
 /// Maximum allowed timestamp drift from the node's local clock (milliseconds).
 pub const MAX_TIMESTAMP_DRIFT_MS: u64 = 2_000;
+
+/// Reads the timestamp out of an encoded timestamp inherent, in milliseconds.
+///
+/// Anything else yields `None`, leaving the block with no clock for its difficulty.
+pub fn timestamp_from_inherent(encoded: &[u8]) -> Option<u64> {
+	// `fp_self_contained::UncheckedExtrinsic` wraps `generic::UncheckedExtrinsic`,
+	// hence the `.0`.
+	let extrinsic = UncheckedExtrinsic::decode(&mut &encoded[..]).ok()?;
+	match extrinsic.0.function {
+		RuntimeCall::Timestamp(pallet_timestamp::Call::set { now }) => Some(now),
+		_ => None,
+	}
+}
 
 /// Validate block timestamp against drift limits.
 ///
@@ -30,7 +45,27 @@ pub fn check_timestamp_drift(
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use codec::Encode;
 	use sp_inherents::CheckInherentsResult;
+
+	#[test]
+	fn reads_a_timestamp_inherent() {
+		let call = RuntimeCall::Timestamp(pallet_timestamp::Call::set { now: 123_000 });
+		let extrinsic = UncheckedExtrinsic::new_bare(call);
+		assert_eq!(timestamp_from_inherent(&extrinsic.encode()), Some(123_000));
+	}
+
+	#[test]
+	fn rejects_a_call_that_is_not_the_timestamp() {
+		let call = RuntimeCall::System(frame_system::Call::remark { remark: Default::default() });
+		let extrinsic = UncheckedExtrinsic::new_bare(call);
+		assert_eq!(timestamp_from_inherent(&extrinsic.encode()), None);
+	}
+
+	#[test]
+	fn rejects_bytes_that_are_not_an_extrinsic() {
+		assert_eq!(timestamp_from_inherent(&[0xff, 0xff, 0xff]), None);
+	}
 
 	fn run(block_ts_ms: u64, node_ts_ms: u64, parent_ts_ms: u64) -> CheckInherentsResult {
 		let mut result = CheckInherentsResult::new();


### PR DESCRIPTION
Import took the difficulty from SystemTime::now(), so the same block resolved to a different number depending on when a node got to it. On a node replaying old history the number collapsed to the floor and every seal cleared the work check.