### PR TITLE
Calibrate transaction fees against the EVM gas price

### DIFF
--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -10,7 +10,7 @@ use frame_support::{
 	},
 	weights::{
 		constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND},
-		IdentityFee, Weight,
+		ConstantMultiplier, Weight,
 	},
 	PalletId,
 };
@@ -148,8 +148,14 @@ impl pallet_reward::Config for Runtime {
 
 parameter_types! {
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
-	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(3, 100_000);
-	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000u128);
+	/// Upstream's 7.5e-5 assumes 6 second blocks, so the step scales with the
+	/// 10 second block time to hold the same wall clock response. Sustained
+	/// full blocks then reach `MaximumMultiplier` in under three days.
+	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(125, 1_000_000);
+	/// Floor kept symmetric with `MaximumMultiplier`. The stock 1e-6 lets an
+	/// idle chain erode the fee anchor by six orders of magnitude, far looser
+	/// than the 2x floor `pallet-base-fee` holds on the EVM side.
+	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 10u128);
 	pub MaximumMultiplier: Multiplier = Multiplier::saturating_from_integer(10);
 }
 
@@ -176,12 +182,23 @@ impl OnUnbalanced<Credit<AccountId, Balances>> for DealWithFees {
 	}
 }
 
+/// Price of one weight unit in smallest units, pinned to what the EVM path
+/// charges for the same compute. `WeightPerGas` is 20,000 and the base fee is
+/// 1 gwei, so a gas unit costs 1e9 and a weight unit is worth 1e9 / 20,000.
+/// Any other value makes one path a cheap bypass around the other.
+pub const WEIGHT_FEE: Balance = 50_000;
+
+/// Price of one encoded byte, mirroring Ethereum's 16 gas per non-zero calldata
+/// byte at the same 1 gwei base fee. Keeps a length-full block within the same
+/// order as a weight-full one so neither dimension is the cheap one to abuse.
+pub const LENGTH_FEE: Balance = 16_000_000_000;
+
 impl pallet_transaction_payment::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type OnChargeTransaction = FungibleAdapter<Balances, DealWithFees>;
 	type OperationalFeeMultiplier = ConstU8<5>;
-	type WeightToFee = IdentityFee<Balance>;
-	type LengthToFee = IdentityFee<Balance>;
+	type WeightToFee = ConstantMultiplier<Balance, ConstU128<WEIGHT_FEE>>;
+	type LengthToFee = ConstantMultiplier<Balance, ConstU128<LENGTH_FEE>>;
 	type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Runtime>;
 	type WeightInfo = pallet_transaction_payment::weights::SubstrateWeight<Runtime>;
 }

--- a/runtime/tests/fees.rs
+++ b/runtime/tests/fees.rs
@@ -1,19 +1,28 @@
-//! Fee routing. Substrate fees and EVM base fee plus tip all land on the PoW
-//! author from the block digest, and burn when a block carries no author.
+//! Fee routing and calibration. Substrate fees and EVM base fee plus tip all
+//! land on the PoW author from the block digest, and burn when a block carries
+//! no author. The substrate fee constants stay pinned to the EVM gas price so
+//! neither path undercuts the other.
 
 mod common;
 
 use codec::Encode;
 use common::new_test_ext;
-use frame_support::traits::{
-	tokens::{
-		fungible::{Balanced, Mutate},
-		Fortitude, Precision, Preservation,
+use frame_support::{
+	dispatch::DispatchClass,
+	traits::{
+		tokens::{
+			fungible::{Balanced, Mutate},
+			Fortitude, Precision, Preservation,
+		},
+		OnUnbalanced,
 	},
-	OnUnbalanced,
 };
 use numen_runtime::{
-	configs::DealWithFees, AccountId, Balance, Balances, Runtime, System, UNIT,
+	configs::{
+		evm::DefaultBaseFeePerGas, DealWithFees, RuntimeBlockLength, RuntimeBlockWeights,
+		LENGTH_FEE, WEIGHT_FEE,
+	},
+	AccountId, Balance, Balances, Runtime, System, UNIT,
 };
 use pallet_evm::{AddressMapping, FeeCalculator, Runner};
 use sp_consensus_pow::POW_ENGINE_ID;
@@ -173,4 +182,40 @@ fn evm_fees_burn_without_author_digest() {
 			"base fee and tip both burn in an authorless block",
 		);
 	});
+}
+
+/// `WeightPerGas` derives from the block gas limit and the block weight budget,
+/// so retuning either one silently reprices substrate compute against EVM
+/// compute.
+#[test]
+fn weight_fee_tracks_the_evm_gas_price() {
+	let weight_per_gas =
+		Balance::from(<Runtime as pallet_evm::Config>::WeightPerGas::get().ref_time());
+
+	assert_eq!(
+		WEIGHT_FEE * weight_per_gas,
+		DefaultBaseFeePerGas::get().as_u128(),
+		"one gas unit of work must cost the same through either path",
+	);
+}
+
+/// A block fills on whichever of weight or length runs out first, so the two
+/// have to cost about the same. Otherwise the cheaper dimension carries the
+/// spam.
+#[test]
+fn weight_and_length_price_a_full_block_alike() {
+	let normal_weight = RuntimeBlockWeights::get()
+		.get(DispatchClass::Normal)
+		.max_total
+		.expect("normal class is bounded")
+		.ref_time();
+	let normal_length = *RuntimeBlockLength::get().max.get(DispatchClass::Normal);
+
+	let weight_cost = WEIGHT_FEE * Balance::from(normal_weight);
+	let length_cost = LENGTH_FEE * Balance::from(normal_length);
+
+	assert!(
+		weight_cost <= 2 * length_cost && length_cost <= 2 * weight_cost,
+		"full block costs drifted apart, weight {weight_cost} vs length {length_cost}",
+	);
 }


### PR DESCRIPTION
IdentityFee priced a weight unit at one smallest unit, so a weight-full block cost 0.000002 NUMN while the same compute routed through the EVM cost 50,000 times more. Any call reachable through both paths was free on one of them, and the substrate side carried no spam cost at all.

WeightPerGas and the 1 gwei base fee already pin what a gas unit of work is worth, so the weight price is not a free choice. The byte price follows Ethereum's 16 gas per non-zero calldata byte, which also lands a length-full block within the same order as a weight-full one.

The multiplier bounds move with it. A 1e-6 floor would erode the new anchor by six orders of magnitude on an idle chain, and the old step needed twelve days of sustained full blocks to reach the 10x cap.