### PR TITLE
Harden poscan against mining shortcuts

### DIFF
--- a/consensus/obj-asteroid/src/lib.rs
+++ b/consensus/obj-asteroid/src/lib.rs
@@ -16,9 +16,13 @@ use crate::icosphere::icosphere;
 use crate::rng::Rng;
 use shape::{AsteroidParams, Lobe};
 
+pub const OCTAVES: usize = 5;
+pub const NUM_CRATERS: usize = 10;
+pub const NUM_LOBES: usize = 4;
+
 /// Grow one asteroid from a seed. Shape params derive from the seed, so the same
 /// seed always reproduces the same mesh.
-pub fn asteroid(seed: u64, subdivisions: u32) -> Mesh {
+pub fn asteroid(seed: [u8; 32], subdivisions: u32) -> Mesh {
     let base = icosphere(subdivisions);
 
     let mut rng = Rng::new(seed);
@@ -35,9 +39,8 @@ pub fn asteroid(seed: u64, subdivisions: u32) -> Mesh {
     // (lower reads rounder and chubbier), small amplitude, and a positive bias.
     // They build large-scale asymmetry without poking spikes, yielding a slightly
     // lopsided rock rather than a sea urchin growing spines.
-    let num_lobes = 2 + rng.range(0.0, 3.0) as usize; // 2..=4
-    let mut lobes = Vec::with_capacity(num_lobes);
-    for _ in 0..num_lobes {
+    let mut lobes = Vec::with_capacity(NUM_LOBES);
+    for _ in 0..NUM_LOBES {
         lobes.push(Lobe {
             dir: rng.unit_vector(),
             amp: rng.range(0.08, 0.20),
@@ -49,8 +52,8 @@ pub fn asteroid(seed: u64, subdivisions: u32) -> Mesh {
     let params = AsteroidParams {
         noise_amplitude: rng.range(0.16, 0.30),
         noise_frequency: rng.range(1.1, 2.4),
-        octaves: rng.range(4.0, 6.0) as usize,
-        num_craters: rng.range(4.0, 11.0) as usize,
+        octaves: OCTAVES,
+        num_craters: NUM_CRATERS,
         axis_scale: axes,
         lobes,
         ..AsteroidParams::default()

--- a/consensus/obj-asteroid/src/perlin.rs
+++ b/consensus/obj-asteroid/src/perlin.rs
@@ -16,10 +16,9 @@ pub struct Fbm {
 }
 
 impl Fbm {
-    /// Build from a 32-bit seed. The seed drives a Fisher-Yates shuffle of the
-    /// permutation table, so neighbouring seeds give decorrelated fields, not a
-    /// shifted copy of one.
-    pub fn new(seed: u32, octaves: usize, frequency: f64) -> Self {
+    /// The seed drives a Fisher-Yates shuffle of the permutation table, so
+    /// neighbouring seeds give decorrelated fields, not a shifted copy of one.
+    pub fn new(seed: [u8; 32], octaves: usize, frequency: f64) -> Self {
         Fbm {
             perm: shuffled_perm(seed),
             octaves,
@@ -97,8 +96,8 @@ impl Fbm {
 
 /// A seed-specific permutation of 0..256, mirrored into 512 so corner lookups never
 /// need a wrap-around mask.
-fn shuffled_perm(seed: u32) -> [u8; 512] {
-    let mut rng = Rng::new(seed as u64);
+fn shuffled_perm(seed: [u8; 32]) -> [u8; 512] {
+    let mut rng = Rng::new(seed);
     let mut p = [0u8; 256];
     for (i, slot) in p.iter_mut().enumerate() {
         *slot = i as u8;

--- a/consensus/obj-asteroid/src/rng.rs
+++ b/consensus/obj-asteroid/src/rng.rs
@@ -11,10 +11,12 @@ pub struct Rng {
 }
 
 impl Rng {
-    /// Seed a generator. The same seed reproduces on every target.
-    pub fn new(seed: u64) -> Self {
+    /// Seed a generator. The same seed reproduces on every target. Full hash width is
+    /// deliberate. A narrow seed caps the reachable stream space, and a capped space
+    /// can be enumerated offline.
+    pub fn new(seed: [u8; 32]) -> Self {
         Rng {
-            core: Pcg64::seed_from_u64(seed),
+            core: Pcg64::from_seed(seed),
         }
     }
 
@@ -38,8 +40,12 @@ impl Rng {
         [r * libm::cos(phi), r * libm::sin(phi), z]
     }
 
-    /// A fresh u32 seed, e.g. to hand the fBm noise its own stream.
-    pub fn next_seed(&mut self) -> u32 {
-        self.core.next_u32()
+    /// A fresh seed, e.g. to hand the fBm noise its own stream.
+    pub fn next_seed(&mut self) -> [u8; 32] {
+        let mut seed = [0u8; 32];
+        for word in seed.chunks_exact_mut(8) {
+            word.copy_from_slice(&self.core.next_u64().to_le_bytes());
+        }
+        seed
     }
 }

--- a/consensus/obj-asteroid/tests/determinism.rs
+++ b/consensus/obj-asteroid/tests/determinism.rs
@@ -8,6 +8,14 @@
 use obj_asteroid::asteroid;
 use obj_asteroid::Mesh;
 
+/// Widen a compact vector label to full seed width. Keeps the tables readable
+/// without 32 byte literals.
+fn seed(label: u64) -> [u8; 32] {
+    let mut bytes = [0u8; 32];
+    bytes[..8].copy_from_slice(&label.to_le_bytes());
+    bytes
+}
+
 /// FNV-1a over a byte stream, self-contained on purpose. A std hasher's output can
 /// drift across toolchains and move the goalposts under us.
 fn fnv1a(bytes: &[u8]) -> u64 {
@@ -36,25 +44,38 @@ fn mesh_fingerprint(mesh: &Mesh) -> u64 {
     fnv1a(&buf)
 }
 
-/// (seed, subdivisions, mesh fingerprint). Subdivision 4 is the on-chain mining
+/// (seed label, subdivisions, mesh fingerprint). Subdivision 4 is the on-chain mining
 /// resolution, frozen here beside the lighter level the seam tests exercise.
 const MESH_GOLDEN: [(u64, u32, u64); 8] = [
-    (0x0, 3, 0xb192d0954cf2ad83),
-    (0x1, 3, 0xf5c3672f25b02031),
-    (0x2a, 3, 0xa4f06fe37253ce42),
-    (0xdead_beef, 3, 0xa0b0d08c5deafe5c),
-    (0x0, 4, 0x8291dee3ea07baa0),
-    (0x1, 4, 0x56c2a257a4f6cb55),
-    (0x2a, 4, 0x0c78e63b5245717d),
-    (0xdead_beef, 4, 0x2547477c49d8ea72),
+    (0x0, 3, 0x60eece03403261ce),
+    (0x1, 3, 0x63f00c5d8eea8791),
+    (0x2a, 3, 0xbfc876e62d6cef68),
+    (0xdead_beef, 3, 0x1ceba8fc054c6bb8),
+    (0x0, 4, 0x25dd32a1cc684937),
+    (0x1, 4, 0x0f6892f5698f0014),
+    (0x2a, 4, 0xcdccf22dc20a0aa8),
+    (0xdead_beef, 4, 0x5cf92daacd522599),
 ];
 
 #[test]
 fn mesh_golden_vectors() {
-    for (seed, sub, want) in MESH_GOLDEN {
-        let got = mesh_fingerprint(&asteroid(seed, sub));
-        assert_eq!(got, want, "seed={seed:#x} sub={sub}: mesh drifted, got 0x{got:016x}");
+    for (label, sub, want) in MESH_GOLDEN {
+        let got = mesh_fingerprint(&asteroid(seed(label), sub));
+        assert_eq!(got, want, "seed={label:#x} sub={sub}: mesh drifted, got 0x{got:016x}");
     }
+}
+
+/// Two seeds differing only outside the low 8 bytes must grow different bodies. A
+/// generator that folds the seed down to a narrow word collapses them onto one mesh.
+/// That caps the work domain at the narrow width, which puts it in reach of an
+/// offline scan.
+#[test]
+fn the_whole_seed_reaches_the_mesh() {
+    let mut low = [0u8; 32];
+    low[0] = 1;
+    let mut high = low;
+    high[31] = 1;
+    assert_ne!(mesh_fingerprint(&asteroid(low, 3)), mesh_fingerprint(&asteroid(high, 3)));
 }
 
 /// A seed must land on the same mesh every call. Guards against nondeterminism a
@@ -62,8 +83,8 @@ fn mesh_golden_vectors() {
 /// hashed one.
 #[test]
 fn reproducible() {
-    let a = asteroid(7, 3);
-    let b = asteroid(7, 3);
+    let a = asteroid(seed(7), 3);
+    let b = asteroid(seed(7), 3);
     assert_eq!(mesh_fingerprint(&a), mesh_fingerprint(&b));
 }
 
@@ -74,7 +95,7 @@ fn reproducible() {
 #[test]
 #[ignore]
 fn regenerate() {
-    for (seed, sub, _) in MESH_GOLDEN {
-        println!("({seed:#x}, {sub}, 0x{:016x}),", mesh_fingerprint(&asteroid(seed, sub)));
+    for (label, sub, _) in MESH_GOLDEN {
+        println!("({label:#x}, {sub}, 0x{:016x}),", mesh_fingerprint(&asteroid(seed(label), sub)));
     }
 }

--- a/consensus/obj-asteroid/tests/spectral.rs
+++ b/consensus/obj-asteroid/tests/spectral.rs
@@ -12,6 +12,14 @@ use spectral3d::{register, scan, verify, SpectralParams};
 const SUBDIVISIONS: u32 = 3;
 const SEEDS: u64 = 128;
 
+/// Widen a compact vector label to full seed width. Keeps the tables readable
+/// without 32 byte literals.
+fn seed(label: u64) -> [u8; 32] {
+    let mut bytes = [0u8; 32];
+    bytes[..8].copy_from_slice(&label.to_le_bytes());
+    bytes
+}
+
 /// Every seeded body clears the structural gates (closed, consistently wound,
 /// non-degenerate volume and covariance) and then registers, so it sits inside
 /// the well-conditioned band the generator's axis and relief ranges aim for. A
@@ -20,12 +28,12 @@ const SEEDS: u64 = 128;
 #[test]
 fn every_seed_registers() {
     let p = SpectralParams::default();
-    for seed in 0..SEEDS {
-        if let Err(e) = scan(asteroid(seed, SUBDIVISIONS), p.target_samples) {
-            panic!("seed {seed:#x}: spectral3d rejected the mesh structurally: {e}");
+    for label in 0..SEEDS {
+        if let Err(e) = scan(asteroid(seed(label), SUBDIVISIONS), p.target_samples) {
+            panic!("seed {label:#x}: spectral3d rejected the mesh structurally: {e}");
         }
-        if let Err(e) = register(asteroid(seed, SUBDIVISIONS), &p) {
-            panic!("seed {seed:#x}: outside the well-conditioned band: {e}");
+        if let Err(e) = register(asteroid(seed(label), SUBDIVISIONS), &p) {
+            panic!("seed {label:#x}: outside the well-conditioned band: {e}");
         }
     }
 }
@@ -36,14 +44,14 @@ fn every_seed_registers() {
 #[test]
 fn identity_is_reproducible() {
     let p = SpectralParams::default();
-    for seed in [0u64, 1, 0x2a, 0xdead_beef] {
-        let (id, helper) = register(asteroid(seed, SUBDIVISIONS), &p)
-            .unwrap_or_else(|e| panic!("seed {seed:#x}: register failed: {e}"));
-        let (again, _) = register(asteroid(seed, SUBDIVISIONS), &p).unwrap();
-        assert_eq!(id, again, "seed {seed:#x}: identity not reproducible");
+    for label in [0u64, 1, 0x2a, 0xdead_beef] {
+        let (id, helper) = register(asteroid(seed(label), SUBDIVISIONS), &p)
+            .unwrap_or_else(|e| panic!("seed {label:#x}: register failed: {e}"));
+        let (again, _) = register(asteroid(seed(label), SUBDIVISIONS), &p).unwrap();
+        assert_eq!(id, again, "seed {label:#x}: identity not reproducible");
 
-        let scanned = verify(asteroid(seed, SUBDIVISIONS), &helper, &p).unwrap();
-        assert_eq!(scanned, id, "seed {seed:#x}: fresh scan did not verify to its identity");
+        let scanned = verify(asteroid(seed(label), SUBDIVISIONS), &helper, &p).unwrap();
+        assert_eq!(scanned, id, "seed {label:#x}: fresh scan did not verify to its identity");
     }
 }
 
@@ -56,11 +64,11 @@ fn identity_is_reproducible() {
 fn the_seam_carries_shape_variation() {
     let p = SpectralParams::default();
     let mut seen = HashSet::new();
-    for seed in 0..SEEDS {
-        let f = scan(asteroid(seed, SUBDIVISIONS), p.target_samples)
-            .unwrap_or_else(|e| panic!("seed {seed:#x}: scan failed: {e}"));
+    for label in 0..SEEDS {
+        let f = scan(asteroid(seed(label), SUBDIVISIONS), p.target_samples)
+            .unwrap_or_else(|e| panic!("seed {label:#x}: scan failed: {e}"));
         let bits: Vec<u64> = f.iter().map(|x| x.to_bits()).collect();
-        assert!(seen.insert(bits), "seed {seed:#x}: identical raw features to an earlier seed");
+        assert!(seen.insert(bits), "seed {label:#x}: identical raw features to an earlier seed");
     }
 }
 
@@ -91,12 +99,12 @@ fn scan_fingerprint(features: &[f64]) -> u64 {
     fnv1a(&buf)
 }
 
-/// (seed, scan feature fingerprint). The full-entropy mining path.
+/// (seed label, scan feature fingerprint). The full-entropy mining path.
 const SCAN_GOLDEN: [(u64, u64); 4] = [
-    (0x0, 0xd273571a63c4048b),
-    (0x1, 0xb658101f364623e9),
-    (0x2a, 0xa1187161662d5331),
-    (0xdead_beef, 0x37e165355dfcda75),
+    (0x0, 0x0d26821ca134f8ff),
+    (0x1, 0xf619359cccd929fa),
+    (0x2a, 0x0e72613078377d67),
+    (0xdead_beef, 0xf3ca413897081200),
 ];
 
 /// On-chain mining resolution. The protocol scans a subdivision 4 body at this many
@@ -105,50 +113,50 @@ const SCAN_GOLDEN: [(u64, u64); 4] = [
 const MINING_SUBDIVISIONS: u32 = 4;
 const MINING_SAMPLES: usize = 4096;
 
-/// (seed, scan feature fingerprint) at the on-chain mining resolution.
+/// (seed label, scan feature fingerprint) at the on-chain mining resolution.
 const SCAN_GOLDEN_MINING: [(u64, u64); 4] = [
-    (0x0, 0x6da1b2a0b181616c),
-    (0x1, 0xd3e887809042186c),
-    (0x2a, 0x88be365da70385d6),
-    (0xdead_beef, 0xbbb64605ce4c62cc),
+    (0x0, 0xb21b2b6986a53da6),
+    (0x1, 0xf0d87a7ea9a98f4c),
+    (0x2a, 0xf7351ba847a5c29c),
+    (0xdead_beef, 0x99e2620e026ad041),
 ];
 
-/// (seed, registered identity hash). The coarse on-chain tag.
+/// (seed label, registered identity hash). The coarse on-chain tag.
 const IDENTITY_GOLDEN: [(u64, &str); 4] = [
-    (0x0, "1f8e42839dbd9894eca3c17c1140d85c6513eee5b14c4e7e3e766b29b9310f63"),
-    (0x1, "5e814cb3706b947ff65a461d8df0c6463275067ab9624b0fd799c302c227210f"),
-    (0x2a, "d28b296abd9bccb34c954373a154aff5f8c2cf1b0784f6d160ae5ba4060718f5"),
-    (0xdead_beef, "e6c741b0da6ee895054ea0daa59243a097bd3e41767f494a90dfb68b2e57096d"),
+    (0x0, "5a4cff8722d3a2db39090f46f9db2509e5ec3d22a3b4833986b14cd1239996d5"),
+    (0x1, "ee01f81ad9bcc11569a8a2a21a10d670114c14aaa670456725f499f66a00b11c"),
+    (0x2a, "60f37ddf1f662ecaeb72a0c6b2e4122ab146ff8f996447ea1d30253116383269"),
+    (0xdead_beef, "87f04183be78b25602d9e30f5d973499bb2ee9e507aab2fe2ff59c2c5761bd6f"),
 ];
 
 #[test]
 fn scan_golden_vectors() {
     let p = SpectralParams::default();
-    for (seed, want) in SCAN_GOLDEN {
-        let f = scan(asteroid(seed, SUBDIVISIONS), p.target_samples)
-            .unwrap_or_else(|e| panic!("seed {seed:#x}: scan failed: {e}"));
+    for (label, want) in SCAN_GOLDEN {
+        let f = scan(asteroid(seed(label), SUBDIVISIONS), p.target_samples)
+            .unwrap_or_else(|e| panic!("seed {label:#x}: scan failed: {e}"));
         let got = scan_fingerprint(&f);
-        assert_eq!(got, want, "seed={seed:#x}: scan features drifted, got 0x{got:016x}");
+        assert_eq!(got, want, "seed={label:#x}: scan features drifted, got 0x{got:016x}");
     }
 }
 
 #[test]
 fn scan_golden_vectors_mining() {
-    for (seed, want) in SCAN_GOLDEN_MINING {
-        let f = scan(asteroid(seed, MINING_SUBDIVISIONS), MINING_SAMPLES)
-            .unwrap_or_else(|e| panic!("seed {seed:#x}: scan failed: {e}"));
+    for (label, want) in SCAN_GOLDEN_MINING {
+        let f = scan(asteroid(seed(label), MINING_SUBDIVISIONS), MINING_SAMPLES)
+            .unwrap_or_else(|e| panic!("seed {label:#x}: scan failed: {e}"));
         let got = scan_fingerprint(&f);
-        assert_eq!(got, want, "seed={seed:#x}: mining-resolution scan drifted, got 0x{got:016x}");
+        assert_eq!(got, want, "seed={label:#x}: mining-resolution scan drifted, got 0x{got:016x}");
     }
 }
 
 #[test]
 fn identity_golden_vectors() {
     let p = SpectralParams::default();
-    for (seed, want) in IDENTITY_GOLDEN {
-        let (id, _) = register(asteroid(seed, SUBDIVISIONS), &p)
-            .unwrap_or_else(|e| panic!("seed {seed:#x}: register failed: {e}"));
-        assert_eq!(id, want, "seed={seed:#x}: identity drifted, got {id}");
+    for (label, want) in IDENTITY_GOLDEN {
+        let (id, _) = register(asteroid(seed(label), SUBDIVISIONS), &p)
+            .unwrap_or_else(|e| panic!("seed {label:#x}: register failed: {e}"));
+        assert_eq!(id, want, "seed={label:#x}: identity drifted, got {id}");
     }
 }
 
@@ -160,16 +168,16 @@ fn identity_golden_vectors() {
 #[ignore]
 fn regenerate_golden() {
     let p = SpectralParams::default();
-    for (seed, _) in SCAN_GOLDEN {
-        let f = scan(asteroid(seed, SUBDIVISIONS), p.target_samples).unwrap();
-        println!("scan  ({seed:#x}, 0x{:016x}),", scan_fingerprint(&f));
+    for (label, _) in SCAN_GOLDEN {
+        let f = scan(asteroid(seed(label), SUBDIVISIONS), p.target_samples).unwrap();
+        println!("scan  ({label:#x}, 0x{:016x}),", scan_fingerprint(&f));
     }
-    for (seed, _) in SCAN_GOLDEN_MINING {
-        let f = scan(asteroid(seed, MINING_SUBDIVISIONS), MINING_SAMPLES).unwrap();
-        println!("mine  ({seed:#x}, 0x{:016x}),", scan_fingerprint(&f));
+    for (label, _) in SCAN_GOLDEN_MINING {
+        let f = scan(asteroid(seed(label), MINING_SUBDIVISIONS), MINING_SAMPLES).unwrap();
+        println!("mine  ({label:#x}, 0x{:016x}),", scan_fingerprint(&f));
     }
-    for (seed, _) in IDENTITY_GOLDEN {
-        let (id, _) = register(asteroid(seed, SUBDIVISIONS), &p).unwrap();
-        println!("ident ({seed:#x}, {id:?}),");
+    for (label, _) in IDENTITY_GOLDEN {
+        let (id, _) = register(asteroid(seed(label), SUBDIVISIONS), &p).unwrap();
+        println!("ident ({label:#x}, {id:?}),");
     }
 }

--- a/consensus/poscan/src/lib.rs
+++ b/consensus/poscan/src/lib.rs
@@ -34,9 +34,10 @@ pub const TARGET_SAMPLES: usize = 4096;
 /// shortcuts.
 pub const EPS_SCALE: f64 = 1e-5;
 
-/// Domain separation prefix hashed into every work value. Any parameter change
-/// must bump it so old and new work land in disjoint spaces.
-pub const POSCAN_PROTOCOL: &[u8] = b"poscan-v1|gen=asteroid|sd=4|samp=4096|eps_scale=1e-5";
+/// Domain separation prefix. 
+/// 
+/// Any parameter change must bump it so old and new work land in disjoint spaces.
+pub const POSCAN_PROTOCOL: &[u8] = b"poscan-v2";
 
 // ── Core types (no_std) ─────────────────────────────────────────────
 
@@ -73,7 +74,7 @@ impl Compute {
 	/// generated mesh is structurally unscannable, which a valid seal never is.
 	pub fn work(&self) -> Option<H256> {
 		let features = spectral3d::scan(self.mesh(), TARGET_SAMPLES).ok()?;
-		Some(hash_buckets(&quantize(&features)))
+		Some(hash_buckets(&quantize(&features), &self.pre_hash))
 	}
 
 	/// Run the scan and bundle the resulting work into a [`Seal`].
@@ -102,15 +103,27 @@ impl From<Mesh> for WireMesh {
 	}
 }
 
-/// Derive the 64-bit generator seed from the pre-hash and nonce.
-fn derive_seed(pre_hash: &H256, nonce: &U256) -> u64 {
-	let mut buf = Vec::with_capacity(64);
-	buf.extend_from_slice(pre_hash.as_bytes());
-	buf.extend_from_slice(&nonce.encode());
-	let digest = Sha256::digest(&buf);
-	let mut head = [0u8; 8];
-	head.copy_from_slice(&digest[..8]);
-	u64::from_le_bytes(head)
+/// Derive the generator seed from the full digest, never a truncation.
+///
+/// Truncating caps the work domain at the truncated width, and a capped domain is
+/// enumerable. A miner scans it offline once, keeps the seeds whose work clears
+/// difficulty, then reaches them by hashing nonces instead of scanning. The edge
+/// follows table size and holds at every difficulty. Retargeting cannot correct
+/// for it.
+///
+/// The protocol tag goes in for the same reason it goes into the work value.
+/// Two protocol revisions sharing one seed space would share their asteroids,
+/// letting the generate and scan labour spent under one revision replay under
+/// the other for the price of one bucket hash.
+fn derive_seed(pre_hash: &H256, nonce: &U256) -> [u8; 32] {
+	let mut hasher = Sha256::new();
+	hasher.update(POSCAN_PROTOCOL);
+	hasher.update([0u8]);
+	hasher.update(pre_hash.as_bytes());
+	hasher.update(nonce.encode());
+	let mut seed = [0u8; 32];
+	seed.copy_from_slice(&hasher.finalize());
+	seed
 }
 
 /// Fine quantize the raw spectral features into the integer bucket vector.
@@ -123,10 +136,15 @@ fn quantize(features: &[f64; N_FEATURES]) -> [i64; N_FEATURES] {
 }
 
 /// Hash the bucket vector into the work value, prefixed for domain separation.
-fn hash_buckets(buckets: &[i64; N_FEATURES]) -> H256 {
+///
+/// The pre-hash goes in directly, not only through the seed. Work stays
+/// block-specific even if a later generator narrows its state, so a scanned seed
+/// table never outlives one block.
+fn hash_buckets(buckets: &[i64; N_FEATURES], pre_hash: &H256) -> H256 {
 	let mut hasher = Sha256::new();
 	hasher.update(POSCAN_PROTOCOL);
 	hasher.update([0u8]);
+	hasher.update(pre_hash.as_bytes());
 	for &bucket in buckets {
 		hasher.update(bucket.to_le_bytes());
 	}

--- a/consensus/poscan/tests/golden.rs
+++ b/consensus/poscan/tests/golden.rs
@@ -16,10 +16,10 @@ use primitive_types::{H256, U256};
 
 /// (pre_hash low u64, nonce, lowercase hex of `s`). The value that goes on chain.
 const WORK_GOLDEN: [(u64, u64, &str); 4] = [
-	(0x0, 0x0, "5cea70c24b6ff7d7761e8817f63e1068baeeabb132fb08c918159127243bac8d"),
-	(0x1, 0x1, "864d75aa5b4599aa6cf29a8c76681c800d8177efd0a209c492324b4a84eb6961"),
-	(0x2a, 0x2a, "0f155bccfa1c57143c04e47f9affec27a84a828e75da5fd4ff8422919c6649b6"),
-	(0xdead_beef, 0xdead_beef, "55657c14aefeb8dffd90838e78dbc059f152cdff13ba3d280acccaaf44fcba2c"),
+	(0x0, 0x0, "c851199f0acde97f70b6403352528bad1cff470a6a2ab7d2623f035a8e2f4e43"),
+	(0x1, 0x1, "e659f06f2083dae275d31cb5f4bc46c0941bf508e3a45a835dc3d46f9c89fa0c"),
+	(0x2a, 0x2a, "0fb71e69fd2b6404247453ea052dc8466e94593bf5d052fe3639cc8fa7278f11"),
+	(0xdead_beef, 0xdead_beef, "a9aed2df79ebb3816bc9efa047eadba5e7f5c8a8c9e3db3961fe154b12412f51"),
 ];
 
 fn work_of(pre: u64, nonce: u64) -> H256 {


### PR DESCRIPTION
- feed the whole 32 byte digest to the generator. a truncated seed caps the work domain at its width, and a bounded domain turns scanning into an offline table that honest mining builds for free, degrading chain security to sha256 hashrate
- pin octaves, craters and lobes as protocol constants. seed-drawn counts only shape per nonce cost, never the work distribution, so a miner peeks them in nanoseconds and mines only the cheapest draws, a measured +5.6% free edge
- hash the protocol tag into seed derivation. revisions sharing one seed space share their asteroids, so scan labour done under one revision would replay under the other for the price of one bucket hash

also shrink the protocol string to a bare version token since the version alone separates hash universes, and rebake all golden vectors.