### PR TITLE
Harden pr ci gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: ./.github/actions/free-disk-space
       - uses: ./.github/actions/ubuntu-dependencies
       - name: Run clippy
-        run: SKIP_WASM_BUILD=1 cargo clippy --all-targets --locked --workspace --quiet
+        run: SKIP_WASM_BUILD=1 cargo clippy --all-targets --locked --workspace --quiet -- -D warnings
         timeout-minutes: 30
 
   test:
@@ -30,6 +30,17 @@ jobs:
       - uses: ./.github/actions/ubuntu-dependencies
       - name: Run tests
         run: SKIP_WASM_BUILD=1 cargo test --workspace --locked
+        timeout-minutes: 30
+
+  runtime-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/free-disk-space
+      - uses: ./.github/actions/ubuntu-dependencies
+      - name: Build runtime wasm (no_std)
+        run: cargo check -p numen-runtime --locked
         timeout-minutes: 30
 
   determinism:


### PR DESCRIPTION
- build the runtime wasm on pr. no_std breakage in the in-house crates surfaced only at tag time. a bare `--target wasm32v1-none` check will not do. frontier pulls a cumulus hostfunction that fails to compile that way, so only the full wasm builder mirrors the release build.

- fail clippy on warnings.