### PR TITLE
Require a plaintext social channel to submit referenda

### DIFF
--- a/runtime/src/configs/governance.rs
+++ b/runtime/src/configs/governance.rs
@@ -9,10 +9,10 @@ use crate::{
 use alloc::borrow::Cow;
 use frame_support::{
 	parameter_types,
-	traits::{AsEnsureOriginWithArg, ConstU32, EitherOf, EnsureOrigin},
+	traits::{AsEnsureOriginWithArg, ConstU32, Contains, EitherOf, EnsureOrigin},
 };
 use frame_system::{EnsureSigned, RawOrigin};
-use pallet_identity::Judgement;
+use pallet_identity::{Data, Judgement};
 use pallet_referenda::{Curve, Track, TrackInfo};
 use sp_runtime::{str_array as s, FixedI64};
 
@@ -198,31 +198,57 @@ impl pallet_custom_origins::Config for Runtime {}
 /// amount.
 pub type TreasurySpender = EitherOf<SmallSpender, EitherOf<MediumSpender, BigSpender>>;
 
-/// Referendum submission is open to any account holding an identity judged
-/// Reasonable or KnownGood. A sub account qualifies through its parent since
-/// the SuperOf link keeps the owner traceable.
-pub struct EnsureJudgedIdentity;
+/// Qualified identity standard shared by every entry point that gates on
+/// identity. An account qualifies when a registrar judged its identity
+/// Reasonable or KnownGood and the identity carries at least one social
+/// channel among x, telegram and discord registered as plaintext. Hashed
+/// channel commitments do not count since the point is public attribution.
+/// A sub account qualifies through its parent since the SuperOf link keeps
+/// the owner traceable.
+pub struct QualifiedIdentity;
 
-impl EnsureJudgedIdentity {
-	fn is_judged(who: &AccountId) -> bool {
+/// Additional field keys that count as social channels next to the native
+/// twitter field.
+const SOCIAL_CHANNEL_KEYS: [&[u8]; 2] = [b"telegram", b"discord"];
+
+fn plaintext(data: &Data) -> bool {
+	matches!(data, Data::Raw(bytes) if !bytes.is_empty())
+}
+
+impl QualifiedIdentity {
+	fn account_qualifies(who: &AccountId) -> bool {
 		pallet_identity::IdentityOf::<Runtime>::get(who).is_some_and(|registration| {
-			registration
+			let judged = registration
 				.judgements
 				.iter()
-				.any(|(_, judgement)| matches!(judgement, Judgement::Reasonable | Judgement::KnownGood))
+				.any(|(_, judgement)| matches!(judgement, Judgement::Reasonable | Judgement::KnownGood));
+			let channel = plaintext(&registration.info.twitter)
+				|| registration.info.additional.iter().any(|(key, value)| {
+					matches!(key, Data::Raw(k) if SOCIAL_CHANNEL_KEYS.contains(&k.as_slice()))
+						&& plaintext(value)
+				});
+			judged && channel
 		})
 	}
 }
 
-impl EnsureOrigin<RuntimeOrigin> for EnsureJudgedIdentity {
+impl Contains<AccountId> for QualifiedIdentity {
+	fn contains(who: &AccountId) -> bool {
+		Self::account_qualifies(who)
+			|| pallet_identity::SuperOf::<Runtime>::get(who)
+				.is_some_and(|(parent, _)| Self::account_qualifies(&parent))
+	}
+}
+
+/// Referendum submission is open to any account passing [`QualifiedIdentity`].
+pub struct EnsureQualifiedIdentity;
+
+impl EnsureOrigin<RuntimeOrigin> for EnsureQualifiedIdentity {
 	type Success = AccountId;
 
 	fn try_origin(o: RuntimeOrigin) -> Result<Self::Success, RuntimeOrigin> {
 		let who = EnsureSigned::<AccountId>::try_origin(o)?;
-		let judged = Self::is_judged(&who)
-			|| pallet_identity::SuperOf::<Runtime>::get(&who)
-				.is_some_and(|(parent, _)| Self::is_judged(&parent));
-		if judged {
+		if QualifiedIdentity::contains(&who) {
 			Ok(who)
 		} else {
 			Err(RawOrigin::Signed(who).into())
@@ -232,12 +258,16 @@ impl EnsureOrigin<RuntimeOrigin> for EnsureJudgedIdentity {
 	#[cfg(feature = "runtime-benchmarks")]
 	fn try_successful_origin() -> Result<RuntimeOrigin, ()> {
 		let who: AccountId = frame_benchmarking::whitelisted_caller();
+		let info = pallet_identity::legacy::IdentityInfo {
+			twitter: Data::Raw(b"@bench".to_vec().try_into().map_err(|_| ())?),
+			..Default::default()
+		};
 		let registration = pallet_identity::Registration {
 			judgements: alloc::vec![(0, Judgement::Reasonable)]
 				.try_into()
 				.map_err(|_| ())?,
 			deposit: 0,
-			info: Default::default(),
+			info,
 		};
 		pallet_identity::IdentityOf::<Runtime>::insert(&who, registration);
 		Ok(RawOrigin::Signed(who).into())
@@ -250,7 +280,7 @@ impl pallet_referenda::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Scheduler = Scheduler;
 	type Currency = Balances;
-	type SubmitOrigin = AsEnsureOriginWithArg<EnsureJudgedIdentity>;
+	type SubmitOrigin = AsEnsureOriginWithArg<EnsureQualifiedIdentity>;
 	type CancelOrigin = pallet_prime::EnsurePrime<Runtime>;
 	type KillOrigin = pallet_prime::EnsurePrime<Runtime>;
 	type Slash = Treasury;

--- a/runtime/tests/opengov.rs
+++ b/runtime/tests/opengov.rs
@@ -153,8 +153,8 @@ fn run_to_block(n: BlockNumber) {
 /// small track bars at the first deciding block.
 fn backed_small_track_referendum(voter: &AccountId, call: RuntimeCall) -> u32 {
 	Balances::set_balance(voter, VOTER_FUNDS);
-	// Submission is gated on a judged identity, which has its own coverage, so
-	// place one straight into storage.
+	// Submission is gated on a qualified identity, which has its own coverage,
+	// so place a judged one carrying a plaintext channel straight into storage.
 	pallet_identity::IdentityOf::<Runtime>::insert(
 		voter,
 		pallet_identity::Registration {
@@ -162,7 +162,12 @@ fn backed_small_track_referendum(voter: &AccountId, call: RuntimeCall) -> u32 {
 				.try_into()
 				.expect("one judgement fits the bound"),
 			deposit: 0,
-			info: Default::default(),
+			info: pallet_identity::legacy::IdentityInfo {
+				twitter: pallet_identity::Data::Raw(
+					b"@voter".to_vec().try_into().expect("the handle fits the field bound"),
+				),
+				..Default::default()
+			},
 		},
 	);
 	let index = pallet_referenda::ReferendumCount::<Runtime>::get();

--- a/runtime/tests/prime_brakes.rs
+++ b/runtime/tests/prime_brakes.rs
@@ -37,9 +37,9 @@ fn assert_ongoing(index: u32) {
 }
 
 /// Submit a small track referendum with its decision deposit placed, returning
-/// its index. Both deposits stay reserved on the submitter. A judged identity
-/// goes straight into storage since submission is gated on one and the gate
-/// has its own coverage.
+/// its index. Both deposits stay reserved on the submitter. A qualified
+/// identity goes straight into storage since submission is gated on one and
+/// the gate has its own coverage.
 fn ongoing_referendum(submitter: &AccountId) -> u32 {
 	Balances::set_balance(submitter, FUNDS);
 	pallet_identity::IdentityOf::<Runtime>::insert(
@@ -49,7 +49,12 @@ fn ongoing_referendum(submitter: &AccountId) -> u32 {
 				.try_into()
 				.expect("one judgement fits the bound"),
 			deposit: 0,
-			info: Default::default(),
+			info: pallet_identity::legacy::IdentityInfo {
+				twitter: pallet_identity::Data::Raw(
+					b"@submitter".to_vec().try_into().expect("handle fits the raw bound"),
+				),
+				..Default::default()
+			},
 		},
 	);
 	let index = pallet_referenda::ReferendumCount::<Runtime>::get();

--- a/runtime/tests/referenda_submission.rs
+++ b/runtime/tests/referenda_submission.rs
@@ -1,6 +1,7 @@
-//! Referendum submission gate. Only accounts backed by an identity judged
-//! Reasonable or KnownGood may open referenda, and a sub account qualifies
-//! through its parent judgement.
+//! Referendum submission gate. Only accounts backed by a qualified identity
+//! may open referenda. Qualified means judged Reasonable or KnownGood while
+//! carrying at least one plaintext social channel among x, telegram and
+//! discord, and a sub account qualifies through its parent.
 
 mod common;
 
@@ -35,17 +36,21 @@ fn funded(keyring: Sr25519Keyring) -> AccountId {
 	who
 }
 
-fn identity_info() -> IdInfo {
+fn raw(bytes: &[u8]) -> Data {
+	Data::Raw(bytes.to_vec().try_into().expect("raw data fits the field bound"))
+}
+
+fn identity_info(twitter: Data, additional: Vec<(Data, Data)>) -> IdInfo {
 	IdentityInfo {
-		additional: Default::default(),
-		display: Data::Raw(b"proposer".to_vec().try_into().unwrap()),
+		additional: additional.try_into().expect("additional entries fit the field limit"),
+		display: raw(b"proposer"),
 		legal: Default::default(),
 		web: Default::default(),
 		riot: Default::default(),
 		email: Default::default(),
 		pgp_fingerprint: None,
 		image: Default::default(),
-		twitter: Default::default(),
+		twitter,
 	}
 }
 
@@ -61,19 +66,19 @@ fn install_registrar() -> AccountId {
 	registrar
 }
 
-/// Gives `who` an identity carrying `judgement` from registrar zero.
-fn judged_identity(who: &AccountId, judgement: Judgement<Balance>) {
+/// Registers `info` for `who` and judges it `judgement` through registrar zero.
+fn judged_identity(who: &AccountId, judgement: Judgement<Balance>, info: IdInfo) {
 	let registrar = install_registrar();
 	assert_ok!(Identity::set_identity(
 		RuntimeOrigin::signed(who.clone()),
-		Box::new(identity_info()),
+		Box::new(info.clone()),
 	));
 	assert_ok!(Identity::provide_judgement(
 		RuntimeOrigin::signed(registrar),
 		0,
 		src(who),
 		judgement,
-		<Runtime as frame_system::Config>::Hashing::hash_of(&identity_info()),
+		<Runtime as frame_system::Config>::Hashing::hash_of(&info),
 	));
 }
 
@@ -107,7 +112,7 @@ fn unjudged_identity_cannot_submit() {
 		let who = funded(Sr25519Keyring::Alice);
 		assert_ok!(Identity::set_identity(
 			RuntimeOrigin::signed(who.clone()),
-			Box::new(identity_info()),
+			Box::new(identity_info(raw(b"@proposer"), vec![])),
 		));
 
 		assert_noop!(submit(&who), DispatchError::BadOrigin);
@@ -119,7 +124,7 @@ fn unjudged_identity_cannot_submit() {
 fn negative_judgement_cannot_submit() {
 	new_test_ext().execute_with(|| {
 		let who = funded(Sr25519Keyring::Alice);
-		judged_identity(&who, Judgement::OutOfDate);
+		judged_identity(&who, Judgement::OutOfDate, identity_info(raw(b"@proposer"), vec![]));
 
 		assert_noop!(submit(&who), DispatchError::BadOrigin);
 		assert_eq!(referendum_count(), 0);
@@ -127,10 +132,40 @@ fn negative_judgement_cannot_submit() {
 }
 
 #[test]
+fn judged_identity_without_social_channel_cannot_submit() {
+	new_test_ext().execute_with(|| {
+		let who = funded(Sr25519Keyring::Alice);
+		let mut info = identity_info(Data::None, vec![(raw(b"matrix"), raw(b"@proposer"))]);
+		info.email = raw(b"proposer@example.com");
+		judged_identity(&who, Judgement::Reasonable, info);
+
+		assert_noop!(submit(&who), DispatchError::BadOrigin);
+		assert_eq!(referendum_count(), 0);
+	});
+}
+
+#[test]
+fn non_plaintext_social_channel_cannot_submit() {
+	let commitment = <Runtime as frame_system::Config>::Hashing::hash(b"@proposer").0;
+	let hashed_twitter = identity_info(Data::BlakeTwo256(commitment), vec![]);
+	let empty_telegram = identity_info(Data::None, vec![(raw(b"telegram"), raw(b""))]);
+
+	for info in [hashed_twitter, empty_telegram] {
+		new_test_ext().execute_with(|| {
+			let who = funded(Sr25519Keyring::Alice);
+			judged_identity(&who, Judgement::Reasonable, info.clone());
+
+			assert_noop!(submit(&who), DispatchError::BadOrigin);
+			assert_eq!(referendum_count(), 0);
+		});
+	}
+}
+
+#[test]
 fn reasonable_judgement_submits() {
 	new_test_ext().execute_with(|| {
 		let who = funded(Sr25519Keyring::Alice);
-		judged_identity(&who, Judgement::Reasonable);
+		judged_identity(&who, Judgement::Reasonable, identity_info(raw(b"@proposer"), vec![]));
 
 		assert_ok!(submit(&who));
 		assert_eq!(referendum_count(), 1);
@@ -141,7 +176,7 @@ fn reasonable_judgement_submits() {
 fn known_good_judgement_submits() {
 	new_test_ext().execute_with(|| {
 		let who = funded(Sr25519Keyring::Alice);
-		judged_identity(&who, Judgement::KnownGood);
+		judged_identity(&who, Judgement::KnownGood, identity_info(raw(b"@proposer"), vec![]));
 
 		assert_ok!(submit(&who));
 		assert_eq!(referendum_count(), 1);
@@ -149,10 +184,27 @@ fn known_good_judgement_submits() {
 }
 
 #[test]
-fn sub_of_judged_identity_submits() {
+fn telegram_and_discord_additional_channels_qualify() {
+	for key in [b"telegram".as_slice(), b"discord".as_slice()] {
+		new_test_ext().execute_with(|| {
+			let who = funded(Sr25519Keyring::Alice);
+			judged_identity(
+				&who,
+				Judgement::Reasonable,
+				identity_info(Data::None, vec![(raw(key), raw(b"@proposer"))]),
+			);
+
+			assert_ok!(submit(&who));
+			assert_eq!(referendum_count(), 1);
+		});
+	}
+}
+
+#[test]
+fn sub_of_qualified_identity_submits() {
 	new_test_ext().execute_with(|| {
 		let parent = funded(Sr25519Keyring::Alice);
-		judged_identity(&parent, Judgement::Reasonable);
+		judged_identity(&parent, Judgement::Reasonable, identity_info(raw(b"@proposer"), vec![]));
 		let sub = funded(Sr25519Keyring::Bob);
 		assert_ok!(Identity::set_subs(
 			RuntimeOrigin::signed(parent),
@@ -165,12 +217,12 @@ fn sub_of_judged_identity_submits() {
 }
 
 #[test]
-fn sub_of_unjudged_identity_cannot_submit() {
+fn sub_of_unqualified_identity_cannot_submit() {
 	new_test_ext().execute_with(|| {
 		let parent = funded(Sr25519Keyring::Alice);
 		assert_ok!(Identity::set_identity(
 			RuntimeOrigin::signed(parent.clone()),
-			Box::new(identity_info()),
+			Box::new(identity_info(raw(b"@proposer"), vec![])),
 		));
 		let sub = funded(Sr25519Keyring::Bob);
 		assert_ok!(Identity::set_subs(


### PR DESCRIPTION
A judgement alone proves a registrar looked at the identity but gives the public no handle to hold the proposer to. Require at least one social channel among x, telegram and discord registered as plaintext. Hashed commitments defeat attribution so they do not count. The standard lives in a Contains impl so other entry points can gate on the same predicate.