### PR TITLE
Harden validator entry

### DIFF
--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -17,7 +17,7 @@ extern crate alloc;
 
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::{
-    traits::{Contains, Currency, Get, LockableCurrency},
+    traits::{Currency, Get, LockableCurrency},
     BoundedVec,
 };
 use scale_info::TypeInfo;
@@ -101,8 +101,8 @@ pub mod pallet {
         #[pallet::constant]
         type LockAmount: Get<BalanceOf<Self>>;
 
-        /// Accounts that validate without locking stake.
-        type StakeExempt: Contains<Self::AccountId>;
+        /// Origin allowed to manage [`StakeExemptAccounts`].
+        type ExemptOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
         /// Lock duration applied at registration and on each renewal.
         #[pallet::constant]
@@ -147,6 +147,12 @@ pub mod pallet {
     #[pallet::storage]
 	pub type DesiredValidators<T: Config> = StorageValue<_, BoundedVec<T::AccountId, T::MaxValidators>, ValueQuery>;
 
+    /// Accounts allowed to join the validator set without locking stake.
+    /// Consulted only when a candidate joins via `lock`; validators already
+    /// in the set keep the amount recorded at join time.
+    #[pallet::storage]
+	pub type StakeExemptAccounts<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, (), OptionQuery>;
+
     /// Rejoin cooldown deadline per account (block number).
     #[pallet::storage]
 	pub type RejoinCooldown<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, BlockNumberFor<T>, OptionQuery>;
@@ -169,6 +175,8 @@ pub mod pallet {
     /// active validator set at block 0. They are appointed by the chain spec
     /// and stake nothing. Each account still gets a lock record with a zero
     /// amount so auto-renewal, exit, and kick logic operates on real records.
+    /// Each account is also seeded into [`StakeExemptAccounts`] so it can
+    /// rejoin without stake until the exempt origin removes it.
     /// The accounts are pushed directly into `DesiredValidators` (not
     /// `PendingValidators`) so that the very first session already has a
     /// non-empty authority set for `pallet-session` and downstream consumers
@@ -202,6 +210,7 @@ pub mod pallet {
                         status: ValidatorStatus::Active,
                     },
                 );
+                StakeExemptAccounts::<T>::insert(who, ());
                 active
                     .try_push(who.clone())
                     .expect("Genesis validators exceed MaxValidators");
@@ -229,6 +238,8 @@ pub mod pallet {
         EquivocationReported { who: T::AccountId },
         /// A pending validator was dropped.
         PendingValidatorDropped { who: T::AccountId },
+        /// An account's stake exemption was granted or revoked.
+        StakeExemptSet { who: T::AccountId, exempt: bool },
     }
 
     /// Reason a validator was removed from the active set.
@@ -440,6 +451,28 @@ pub mod pallet {
             Self::deposit_event(Event::ValidatorExitRequested { who });
             Ok(())
         }
+
+        /// Grant or revoke stake exemption for `who`.
+        ///
+        /// Idempotent so the managing origin never has to read state first.
+        /// Revoking does not touch validators already in the set; their lock
+        /// amount was fixed when they joined.
+        #[pallet::call_index(2)]
+        #[pallet::weight(Weight::from_parts(30_000_000, 0))]
+        pub fn set_stake_exempt(
+            origin: OriginFor<T>,
+            who: T::AccountId,
+            exempt: bool,
+        ) -> DispatchResult {
+            T::ExemptOrigin::ensure_origin(origin)?;
+            if exempt {
+                StakeExemptAccounts::<T>::insert(&who, ());
+            } else {
+                StakeExemptAccounts::<T>::remove(&who);
+            }
+            Self::deposit_event(Event::StakeExemptSet { who, exempt });
+            Ok(())
+        }
     }
 }
 
@@ -451,7 +484,7 @@ impl<T: Config> Pallet<T> {
     /// amount never places a currency lock because `set_lock` treats zero
     /// as removal.
     fn required_lock(who: &T::AccountId) -> BalanceOf<T> {
-        if T::StakeExempt::contains(who) {
+        if StakeExemptAccounts::<T>::contains_key(who) {
             Zero::zero()
         } else {
             T::LockAmount::get()

--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -1,8 +1,7 @@
 //! # Pallet Validator
 //!
 //! Manages the full lifecycle of validators: lock, auto-renewal, exit,
-//! and kick. This crate currently provides the storage, event, and error
-//! skeleton.
+//! and kick.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -71,7 +70,7 @@ pub mod pallet {
     use super::*;
     use frame_support::{
         pallet_prelude::*,
-        traits::{Defensive, LockIdentifier, WithdrawReasons},
+        traits::{Contains, Defensive, LockIdentifier, WithdrawReasons},
     };
     use frame_system::pallet_prelude::*;
 
@@ -103,6 +102,11 @@ pub mod pallet {
 
         /// Origin allowed to manage [`StakeExemptAccounts`].
         type ExemptOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+
+        /// Identity requirement every candidate must pass to join via `lock`.
+        /// Stake exemption does not bypass it. Genesis appointment does, along
+        /// with every other join condition.
+        type IdentityGate: Contains<Self::AccountId>;
 
         /// Lock duration applied at registration and on each renewal.
         #[pallet::constant]
@@ -280,6 +284,8 @@ pub mod pallet {
         TooManyValidators,
         /// Caller has not registered session keys.
         SessionKeysNotRegistered,
+        /// Caller does not pass the configured identity gate.
+        IdentityNotQualified,
     }
 
     #[pallet::hooks]
@@ -368,6 +374,11 @@ pub mod pallet {
             ensure!(
                 T::SessionInterface::has_keys(&who),
                 Error::<T>::SessionKeysNotRegistered,
+            );
+
+            ensure!(
+                T::IdentityGate::contains(&who),
+                Error::<T>::IdentityNotQualified,
             );
 
             let now = frame_system::Pallet::<T>::block_number();

--- a/pallets/validator/src/mock.rs
+++ b/pallets/validator/src/mock.rs
@@ -2,7 +2,7 @@ use crate as pallet_validator;
 use crate::SessionInterface;
 use frame_support::{
 	derive_impl, parameter_types,
-	traits::{ConstU128, ConstU32, ConstU64, LockIdentifier, VariantCountOf, Hooks},
+	traits::{ConstU128, ConstU32, ConstU64, Contains, LockIdentifier, VariantCountOf, Hooks},
 };
 use sp_runtime::BuildStorage;
 
@@ -76,11 +76,26 @@ impl SessionInterface<AccountId> for MockSession {
 	}
 }
 
+parameter_types! {
+	pub static UnqualifiedIdentities: alloc::collections::BTreeSet<AccountId> =
+		alloc::collections::BTreeSet::new();
+}
+
+/// Mock identity gate whose verdict is driven by the `UnqualifiedIdentities`
+/// static, allowing tests to flip the response per case.
+pub struct MockIdentityGate;
+impl Contains<AccountId> for MockIdentityGate {
+	fn contains(who: &AccountId) -> bool {
+		!UnqualifiedIdentities::get().contains(who)
+	}
+}
+
 impl pallet_validator::Config for Test {
 	type Currency = Balances;
 	type SessionInterface = MockSession;
 	type LockAmount = ConstU128<1_000>;
 	type ExemptOrigin = frame_system::EnsureRoot<AccountId>;
+	type IdentityGate = MockIdentityGate;
 	type LockDuration = ConstU64<10>;
 	type SessionPeriod = ConstU64<5>;
 	type SessionOffset = ConstU64<0>;

--- a/pallets/validator/src/mock.rs
+++ b/pallets/validator/src/mock.rs
@@ -2,7 +2,7 @@ use crate as pallet_validator;
 use crate::SessionInterface;
 use frame_support::{
 	derive_impl, parameter_types,
-	traits::{ConstU128, ConstU32, ConstU64, Contains, LockIdentifier, VariantCountOf, Hooks},
+	traits::{ConstU128, ConstU32, ConstU64, LockIdentifier, VariantCountOf, Hooks},
 };
 use sp_runtime::BuildStorage;
 
@@ -76,18 +76,11 @@ impl SessionInterface<AccountId> for MockSession {
 	}
 }
 
-pub struct MockStakeExempt;
-impl Contains<AccountId> for MockStakeExempt {
-	fn contains(who: &AccountId) -> bool {
-		*who == EXEMPT
-	}
-}
-
 impl pallet_validator::Config for Test {
 	type Currency = Balances;
 	type SessionInterface = MockSession;
 	type LockAmount = ConstU128<1_000>;
-	type StakeExempt = MockStakeExempt;
+	type ExemptOrigin = frame_system::EnsureRoot<AccountId>;
 	type LockDuration = ConstU64<10>;
 	type SessionPeriod = ConstU64<5>;
 	type SessionOffset = ConstU64<0>;

--- a/pallets/validator/src/tests.rs
+++ b/pallets/validator/src/tests.rs
@@ -1,6 +1,7 @@
 use crate::{
-    mock::*, DesiredValidators, PendingValidators, Error, Event, KickReason, LockInfo, OfflineSessionCount, 
-    OfflineThisSession, EquivocationThisSession, RejoinCooldown, ValidatorLocks, ValidatorStatus,
+    mock::*, DesiredValidators, PendingValidators, Error, Event, KickReason, LockInfo, OfflineSessionCount,
+    OfflineThisSession, EquivocationThisSession, RejoinCooldown, StakeExemptAccounts, ValidatorLocks,
+    ValidatorStatus,
 };
 use frame_support::{assert_noop, assert_ok, traits::Get};
 use sp_runtime::{traits::Dispatchable, BuildStorage, DispatchError, TokenError};
@@ -1023,10 +1024,78 @@ fn rejoin_after_equivocation_cooldown_expired_succeeds() {
 // region: stake exemption
 
 #[test]
+fn set_stake_exempt_rejects_unauthorized_origin() {
+    new_test_ext(vec![]).execute_with(|| {
+        assert_noop!(
+            Validator::set_stake_exempt(RuntimeOrigin::signed(ALICE), EXEMPT, true),
+            DispatchError::BadOrigin
+        );
+        assert!(!StakeExemptAccounts::<Test>::contains_key(EXEMPT));
+    });
+}
+
+#[test]
+fn set_stake_exempt_updates_list_and_emits_event() {
+    new_test_ext(vec![]).execute_with(|| {
+        assert_ok!(Validator::set_stake_exempt(RuntimeOrigin::root(), EXEMPT, true));
+        assert!(StakeExemptAccounts::<Test>::contains_key(EXEMPT));
+        System::assert_last_event(Event::StakeExemptSet { who: EXEMPT, exempt: true }.into());
+
+        assert_ok!(Validator::set_stake_exempt(RuntimeOrigin::root(), EXEMPT, false));
+        assert!(!StakeExemptAccounts::<Test>::contains_key(EXEMPT));
+        System::assert_last_event(Event::StakeExemptSet { who: EXEMPT, exempt: false }.into());
+    });
+}
+
+#[test]
+fn set_stake_exempt_is_idempotent() {
+    new_test_ext(vec![]).execute_with(|| {
+        assert_ok!(Validator::set_stake_exempt(RuntimeOrigin::root(), EXEMPT, true));
+        assert_ok!(Validator::set_stake_exempt(RuntimeOrigin::root(), EXEMPT, true));
+        assert!(StakeExemptAccounts::<Test>::contains_key(EXEMPT));
+
+        assert_ok!(Validator::set_stake_exempt(RuntimeOrigin::root(), EXEMPT, false));
+        assert_ok!(Validator::set_stake_exempt(RuntimeOrigin::root(), EXEMPT, false));
+        assert!(!StakeExemptAccounts::<Test>::contains_key(EXEMPT));
+    });
+}
+
+#[test]
+fn revoked_exemption_restores_full_stake_requirement() {
+    new_test_ext(vec![]).execute_with(|| {
+        assert_ok!(Validator::set_stake_exempt(RuntimeOrigin::root(), EXEMPT, true));
+        assert_ok!(Validator::set_stake_exempt(RuntimeOrigin::root(), EXEMPT, false));
+
+        // Without exemption a zero balance no longer covers the lock.
+        assert_noop!(
+            Validator::lock(RuntimeOrigin::signed(EXEMPT)),
+            Error::<Test>::InsufficientBalance
+        );
+    });
+}
+
+#[test]
+fn revoking_exemption_leaves_active_validator_untouched() {
+    new_test_ext(vec![]).execute_with(|| {
+        assert_ok!(Validator::set_stake_exempt(RuntimeOrigin::root(), EXEMPT, true));
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(EXEMPT)));
+
+        assert_ok!(Validator::set_stake_exempt(RuntimeOrigin::root(), EXEMPT, false));
+
+        // The zero amount was fixed at join time; revocation only affects future joins.
+        let lock = ValidatorLocks::<Test>::get(EXEMPT).expect("lock recorded");
+        assert_eq!(lock.amount, 0);
+        assert_eq!(lock.status, ValidatorStatus::Active);
+        assert_eq!(PendingValidators::<Test>::get().to_vec(), vec![EXEMPT]);
+    });
+}
+
+#[test]
 fn exempt_account_locks_with_zero_balance() {
     let lock_duration: u64 = <Test as crate::Config>::LockDuration::get();
 
     new_test_ext(vec![]).execute_with(|| {
+        assert_ok!(Validator::set_stake_exempt(RuntimeOrigin::root(), EXEMPT, true));
         assert_ok!(Validator::lock(RuntimeOrigin::signed(EXEMPT)));
 
         let lock = ValidatorLocks::<Test>::get(EXEMPT).expect("lock recorded");
@@ -1054,6 +1123,7 @@ fn exempt_account_rejoin_checks_cooldown_but_not_stake() {
     let rejoin_cooldown: u64 = <Test as crate::Config>::RejoinCooldownPeriod::get();
 
     new_test_ext(vec![]).execute_with(|| {
+        assert_ok!(Validator::set_stake_exempt(RuntimeOrigin::root(), EXEMPT, true));
         RejoinCooldown::<Test>::insert(EXEMPT, rejoin_cooldown);
 
         // Exemption skips the stake but not the cooldown.
@@ -1102,6 +1172,25 @@ fn genesis_validator_needs_no_endowment() {
             }
         );
         assert!(pallet_balances::Locks::<Test>::get(ALICE).is_empty());
+    });
+}
+
+#[test]
+fn genesis_validators_are_seeded_exempt() {
+    let mut t = frame_system::GenesisConfig::<Test>::default()
+        .build_storage()
+        .unwrap();
+    crate::GenesisConfig::<Test> {
+        initial_validators: vec![ALICE, BOB],
+        ..Default::default()
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+    let mut ext: sp_io::TestExternalities = t.into();
+    ext.execute_with(|| {
+        assert!(StakeExemptAccounts::<Test>::contains_key(ALICE));
+        assert!(StakeExemptAccounts::<Test>::contains_key(BOB));
+        assert!(!StakeExemptAccounts::<Test>::contains_key(CHARLIE));
     });
 }
 

--- a/pallets/validator/src/tests.rs
+++ b/pallets/validator/src/tests.rs
@@ -51,6 +51,23 @@ fn lock_fails_without_session_keys() {
 }
 
 #[test]
+fn lock_fails_without_qualified_identity() {
+    let lock_amount: Balance = <Test as crate::Config>::LockAmount::get();
+
+    new_test_ext(vec![(ALICE, lock_amount)]).execute_with(|| {
+        UnqualifiedIdentities::mutate(|set| {
+            set.insert(ALICE);
+        });
+        assert_noop!(
+            Validator::lock(RuntimeOrigin::signed(ALICE)),
+            Error::<Test>::IdentityNotQualified,
+        );
+        assert!(ValidatorLocks::<Test>::get(ALICE).is_none());
+        assert!(PendingValidators::<Test>::get().is_empty());
+    });
+}
+
+#[test]
 fn lock_fails_when_balance_insufficient() {
     let lock_amount: Balance = <Test as crate::Config>::LockAmount::get();
 
@@ -1119,6 +1136,21 @@ fn exempt_account_locks_with_zero_balance() {
 }
 
 #[test]
+fn exemption_does_not_bypass_identity_gate() {
+    new_test_ext(vec![]).execute_with(|| {
+        assert_ok!(Validator::set_stake_exempt(RuntimeOrigin::root(), EXEMPT, true));
+        UnqualifiedIdentities::mutate(|set| {
+            set.insert(EXEMPT);
+        });
+        assert_noop!(
+            Validator::lock(RuntimeOrigin::signed(EXEMPT)),
+            Error::<Test>::IdentityNotQualified,
+        );
+        assert!(ValidatorLocks::<Test>::get(EXEMPT).is_none());
+    });
+}
+
+#[test]
 fn exempt_account_rejoin_checks_cooldown_but_not_stake() {
     let rejoin_cooldown: u64 = <Test as crate::Config>::RejoinCooldownPeriod::get();
 
@@ -1172,6 +1204,27 @@ fn genesis_validator_needs_no_endowment() {
             }
         );
         assert!(pallet_balances::Locks::<Test>::get(ALICE).is_empty());
+    });
+}
+
+#[test]
+fn genesis_seeding_bypasses_identity_gate() {
+    UnqualifiedIdentities::mutate(|set| {
+        set.insert(ALICE);
+    });
+    let mut t = frame_system::GenesisConfig::<Test>::default()
+        .build_storage()
+        .unwrap();
+    crate::GenesisConfig::<Test> {
+        initial_validators: vec![ALICE],
+        ..Default::default()
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+    let mut ext: sp_io::TestExternalities = t.into();
+    ext.execute_with(|| {
+        assert!(ValidatorLocks::<Test>::get(ALICE).is_some());
+        assert!(DesiredValidators::<Test>::get().contains(&ALICE));
     });
 }
 

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -443,6 +443,7 @@ impl pallet_validator::Config for Runtime {
 	type SessionOffset = SessionOffset;
 	type LockAmount = ConstU128<{ 100_000_000 * UNIT }>;
 	type ExemptOrigin = pallet_prime::EnsurePrime<Runtime>;
+	type IdentityGate = governance::QualifiedIdentity;
 	type LockDuration = ConstU32<{ 180 * DAYS }>;
 	type LockId = ValidatorLockId;
 	type MaxValidators = ConstU32<1_000>;
@@ -467,6 +468,7 @@ impl pallet_validator::Config for Runtime {
 	type SessionOffset = SessionOffset;
 	type LockAmount = ConstU128<{ 1 * UNIT }>;
 	type ExemptOrigin = pallet_prime::EnsurePrime<Runtime>;
+	type IdentityGate = governance::QualifiedIdentity;
 	type LockDuration = ConstU32<{ SessionPeriod::get() + 2 * MINUTES }>;
 	type LockId = ValidatorLockId;
 	type MaxValidators = ConstU32<4>;

--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -5,7 +5,7 @@ use frame_support::{
 	traits::{
 		fungible::{Balanced, Credit, HoldConsideration},
 		tokens::{PayFromAccount, UnityAssetBalanceConversion},
-		ConstU128, ConstU32, ConstU64, ConstU8, Contains, EqualPrivilegeOnly, InstanceFilter,
+		ConstU128, ConstU32, ConstU64, ConstU8, EqualPrivilegeOnly, InstanceFilter,
 		LinearStoragePrice, OnUnbalanced, VariantCountOf, WithdrawReasons,
 	},
 	weights::{
@@ -18,7 +18,6 @@ use frame_system::{
 	limits::{BlockLength, BlockWeights},
 	EnsureRoot,
 };
-use hex_literal::hex;
 use pallet_session::PeriodicSessions;
 use pallet_transaction_payment::{FungibleAdapter, Multiplier, TargetedFeeAdjustment};
 use scale_info::TypeInfo;
@@ -430,42 +429,6 @@ parameter_types! {
 	pub const ValidatorLockId: frame_support::traits::LockIdentifier = *b"validatr";
 }
 
-/// Validator accounts allowed to join without locking stake.
-pub struct StakeExemptAccounts;
-
-impl Contains<AccountId> for StakeExemptAccounts {
-	fn contains(who: &AccountId) -> bool {
-		STAKE_EXEMPT_ACCOUNTS.iter().any(|k| who == &AccountId::from(*k))
-	}
-}
-
-const STAKE_EXEMPT_ACCOUNTS: [[u8; 32]; 12] = [
-	// nu5WR2b5yFx6zUPudqfJtfnmDpg45PFafTFp5iwxH2bdKiqnW
-	hex!("7ebc23de675cd320952153f65eed8636ede3ee914d38d86a03b8690c5ef87745"),
-	// nu8FjWHe9eBn1oR9N7xADxKKTSpDMkYwocg9sPNBzXFxN1NoZ
-	hex!("f83e5c47238ae444ef3165741b0c2a26a15bfb910655376680dc86d47032ee71"),
-	// nu6Gk7pfM9Sxp19o64d5tP1pvGfkWELvk4t9C6d7AWaLjc1gN
-	hex!("a08b338e366fdd4d7a4e66cd6ff1c8fe3f8d8b58f72ea980938612df2a12cb2f"),
-	// nu6davM837qycpvwZ5WxDFn3U9NWxHYLLWwkT3DzsyGMv6nyk
-	hex!("b0706466389590c5e85c2536368db64510bea6def16ac1ac096e754342476f63"),
-	// nu6DhnACdsRfJXMBMG1VDZzTWYPCGvZhy6T6oo8LK1iZsjj9p
-	hex!("9e399761be3d62aff2f2496882f35e719a7d26e6e34964a8691507b7be44e436"),
-	// nu5jPGTWz3LigxmaYgxhnWDc4QEHCC3HMT661gB8ofHvAEPWs
-	hex!("88a0671aa30b1b6199ff5ac847d7ec059ec7bf7baf57b7c47aced431704a5333"),
-	// nu6GtAuvYCiCUy7PmqsLycXdRBdP63aeehug8EFkY9aE2Kj7y
-	hex!("a0a64fa9165f3f5115cd4c2e056f06531d9d9411aaaacf452625bd0623cc0d79"),
-	// nu2noBaVTbqQ4qxh3Smb8z77LsYaTRfQhgK9tsQqfv7tHm2VF
-	hex!("0685f2537b8dd8efa5eef6c2d7d95484b7e804559e0c2308708bfbd4c1ae0723"),
-	// nu8KAW3iGL6ATT4Zc4pWtXXpAhr1FoRUQ3mP1d6QfN9NZfaDD
-	hex!("fadc3d802a278f17424a98cf2ed40c359d41a80a6cdfe16f20530adf3cc98006"),
-	// nu2v7qUMJ8CdTVGHWprxDcoVsrxpFE813aB1LZk5uZnCYdbRH
-	hex!("0c1b7509c3728c1c3ca068448d742c71ac656401f308aef5883311e153eddb4c"),
-	// nu4zngCeKZmRT9kxEVh8Uv6vTHw2WxrRcvkAsRs5TBnWQPMSa
-	hex!("6823a740cbaa7316bc810058581f9d0b0223226b4291ab894cdd5bd0ea3b4976"),
-	// nu3R1jsSHf5ZSJ8G6yYaFtVakPEEutA3qZgKkB8JCFaY3e1ep
-	hex!("22250d0c61bc635742f2c9f14b3630e41574d2ea8e3e4e3a5b8526ff2148566a"),
-];
-
 #[cfg(not(feature = "zombienet-runtime"))]
 parameter_types! {
 	pub const SessionPeriod: BlockNumber = 10 * MINUTES;
@@ -478,8 +441,8 @@ impl pallet_validator::Config for Runtime {
 	type SessionInterface = ValidatorSessionAdapter;
 	type SessionPeriod = SessionPeriod;
 	type SessionOffset = SessionOffset;
-	type LockAmount = ConstU128<{ 1_000_000 * UNIT }>;
-	type StakeExempt = StakeExemptAccounts;
+	type LockAmount = ConstU128<{ 100_000_000 * UNIT }>;
+	type ExemptOrigin = pallet_prime::EnsurePrime<Runtime>;
 	type LockDuration = ConstU32<{ 180 * DAYS }>;
 	type LockId = ValidatorLockId;
 	type MaxValidators = ConstU32<1_000>;
@@ -503,7 +466,7 @@ impl pallet_validator::Config for Runtime {
 	type SessionPeriod = SessionPeriod;
 	type SessionOffset = SessionOffset;
 	type LockAmount = ConstU128<{ 1 * UNIT }>;
-	type StakeExempt = StakeExemptAccounts;
+	type ExemptOrigin = pallet_prime::EnsurePrime<Runtime>;
 	type LockDuration = ConstU32<{ SessionPeriod::get() + 2 * MINUTES }>;
 	type LockId = ValidatorLockId;
 	type MaxValidators = ConstU32<4>;

--- a/runtime/tests/validator_identity_gate.rs
+++ b/runtime/tests/validator_identity_gate.rs
@@ -1,0 +1,86 @@
+//! Validator entry identity gate wiring. Candidates joining the validator
+//! set are held to the same qualified identity standard as referenda
+//! submission, so a judgement without a social channel is not enough.
+
+mod common;
+
+use common::new_test_ext;
+use frame_support::{
+	assert_ok,
+	traits::{tokens::fungible::Mutate, Contains},
+};
+use numen_runtime::{AccountId, Balance, Balances, Identity, Runtime, RuntimeOrigin, UNIT};
+use pallet_identity::{legacy::IdentityInfo, Data, Judgement};
+use sp_keyring::Sr25519Keyring;
+use sp_runtime::traits::{Hash, StaticLookup};
+
+const FUNDS: Balance = 10_000 * UNIT;
+
+type Gate = <Runtime as pallet_validator::Config>::IdentityGate;
+type IdInfo = <Runtime as pallet_identity::Config>::IdentityInformation;
+
+fn src(who: &AccountId) -> <<Runtime as frame_system::Config>::Lookup as StaticLookup>::Source {
+	<Runtime as frame_system::Config>::Lookup::unlookup(who.clone())
+}
+
+fn raw(bytes: &[u8]) -> Data {
+	Data::Raw(bytes.to_vec().try_into().expect("raw data fits the field bound"))
+}
+
+fn identity_info(twitter: Data) -> IdInfo {
+	IdentityInfo {
+		additional: Default::default(),
+		display: raw(b"candidate"),
+		legal: Default::default(),
+		web: Default::default(),
+		riot: Default::default(),
+		email: Default::default(),
+		pgp_fingerprint: None,
+		image: Default::default(),
+		twitter,
+	}
+}
+
+/// Registers `info` for `who` and judges it Reasonable through a registrar
+/// installed via the prime key.
+fn judged_identity(who: &AccountId, info: IdInfo) {
+	let prime = Sr25519Keyring::Ferdie.to_account_id();
+	pallet_prime::Key::<Runtime>::put(&prime);
+	let registrar = Sr25519Keyring::Eve.to_account_id();
+	assert_ok!(Identity::add_registrar(
+		RuntimeOrigin::signed(prime),
+		src(&registrar),
+	));
+	Balances::set_balance(who, FUNDS);
+	assert_ok!(Identity::set_identity(
+		RuntimeOrigin::signed(who.clone()),
+		Box::new(info.clone()),
+	));
+	assert_ok!(Identity::provide_judgement(
+		RuntimeOrigin::signed(registrar),
+		0,
+		src(who),
+		Judgement::Reasonable,
+		<Runtime as frame_system::Config>::Hashing::hash_of(&info),
+	));
+}
+
+#[test]
+fn judged_identity_without_channel_fails_the_gate() {
+	new_test_ext().execute_with(|| {
+		let who = Sr25519Keyring::Alice.to_account_id();
+		judged_identity(&who, identity_info(Data::None));
+
+		assert!(!Gate::contains(&who));
+	});
+}
+
+#[test]
+fn qualified_identity_passes_the_gate() {
+	new_test_ext().execute_with(|| {
+		let who = Sr25519Keyring::Alice.to_account_id();
+		judged_identity(&who, identity_info(raw(b"@candidate")));
+
+		assert!(Gate::contains(&who));
+	});
+}


### PR DESCRIPTION
Validator entry gets a real stake bar, a prime managed exemption list and an identity gate.

- Stake bar raised to 100M NUMN. The old 1M bar let an attacker buy over 2/3 of GRANDPA for about 1.2% of genesis issuance and finalize an arbitrary fork. The raise is the smallest change that shuts entry through the open stake path.
- The fixed exemption list becomes storage managed by prime via set_stake_exempt. Genesis validators are seeded in and rejoin without stake until prime revokes them.
- Entry requires the qualified identity standard from #156, so every entrant including stake exempt invitees has a publicly attributable owner. Genesis appointment stays ungated since the chain spec names those validators directly.