### PR TITLE
Keep validator stake locked until expiry

### DIFF
--- a/pallets/validator/src/lib.rs
+++ b/pallets/validator/src/lib.rs
@@ -47,7 +47,8 @@ pub type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system:
 pub enum ValidatorStatus {
     /// Active in the validator set; eligible for auto-renewal.
     Active,
-    /// Voluntary exit requested; auto-renewal stopped, awaiting expiry.
+    /// On the way out of the set, either by voluntary exit or by being
+    /// dropped before promotion. Auto-renewal stopped, awaiting expiry.
     ExitRequested,
     /// Removed from the active set due to offline or equivocation.
     /// The specific reason is conveyed by the [`pallet::KickReason`] event.
@@ -240,7 +241,8 @@ pub mod pallet {
 		LockReleased { who: T::AccountId, amount: BalanceOf<T> },
         /// A GRANDPA equivocation report was processed for an active validator.
         EquivocationReported { who: T::AccountId },
-        /// A pending validator was dropped.
+        /// A pending validator was dropped before promotion. Its stake stays
+        /// locked until expiry.
         PendingValidatorDropped { who: T::AccountId },
         /// An account's stake exemption was granted or revoked.
         StakeExemptSet { who: T::AccountId, exempt: bool },
@@ -352,6 +354,10 @@ pub mod pallet {
         ///
         /// The locked amount and duration are taken from `Config::LockAmount`
         /// and `Config::LockDuration` respectively; callers do not choose them.
+        ///
+        /// A caller whose previous lock has not expired yet may rejoin, which
+        /// refreshes that lock instead of placing a second one. The refresh
+        /// only ever tightens it, so rejoining never returns stake early.
         #[pallet::call_index(0)]
         #[pallet::weight(Weight::from_parts(50_000_000, 0))]
         pub fn lock(origin: OriginFor<T>) -> DispatchResult {
@@ -389,15 +395,25 @@ pub mod pallet {
                 RejoinCooldown::<T>::remove(&who);
             }
 
-            let amount = Self::required_lock(&who);
-            let duration = T::LockDuration::get();
+            let required = Self::required_lock(&who);
+            let fresh_expiry = now.saturating_add(T::LockDuration::get());
+
+            // Relocking refreshes an existing commitment and a refresh must
+            // never weaken it, so both fields keep whichever value binds
+            // harder. Without this, a zero required amount frees the stake
+            // outright, because `set_lock` treats zero as removal.
+            let (amount, expiry_block) = match ValidatorLocks::<T>::get(&who) {
+                Some(previous) => (
+                    previous.amount.max(required),
+                    previous.expiry_block.max(fresh_expiry),
+                ),
+                None => (required, fresh_expiry),
+            };
 
             ensure!(
                 T::Currency::free_balance(&who) >= amount,
                 Error::<T>::InsufficientBalance,
             );
-
-            let expiry_block = now.saturating_add(duration);
 
             PendingValidators::<T>::mutate(|queue| {
                 let _ = queue
@@ -491,9 +507,10 @@ pub mod pallet {
 const LOG_TARGET: &str = "runtime::validator";
 
 impl<T: Config> Pallet<T> {
-    /// Stake required from `who` when joining the validator set. A zero
-    /// amount never places a currency lock because `set_lock` treats zero
-    /// as removal.
+    /// Fresh stake `who` must put up to join the validator set. Zero for an
+    /// exempt account, which places no currency lock at all because `set_lock`
+    /// treats zero as removal. It is a floor, not the final amount, since a
+    /// rejoining account keeps whatever its unexpired lock already holds.
     fn required_lock(who: &T::AccountId) -> BalanceOf<T> {
         if StakeExemptAccounts::<T>::contains_key(who) {
             Zero::zero()
@@ -685,9 +702,16 @@ impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
                 .unwrap_or(false)
         };
         
-        let cancel_pending_candidate = |who: &T::AccountId| {
-            T::Currency::remove_lock(T::LockId::get(), who);
-            ValidatorLocks::<T>::remove(who);
+        // A dropped candidate keeps its stake until `expiry_block`, like every
+        // other way out of the set. Only the status has to leave `Active`,
+        // otherwise auto-renewal would keep extending a lock that no longer
+        // belongs to anyone in the set.
+        let drop_pending_candidate = |who: &T::AccountId| {
+            ValidatorLocks::<T>::mutate(who, |maybe_info| {
+                if let Some(info) = maybe_info {
+                    info.status = ValidatorStatus::ExitRequested;
+                }
+            });
             OfflineSessionCount::<T>::remove(who);
             OfflineThisSession::<T>::remove(who);
             Self::deposit_event(Event::PendingValidatorDropped { who: who.clone() });
@@ -708,7 +732,7 @@ impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
             }
             if !T::SessionInterface::has_keys(&who)
             || next.is_full() {
-                cancel_pending_candidate(&who);
+                drop_pending_candidate(&who);
                 continue;
             }
             let _ = next.try_push(who);

--- a/pallets/validator/src/tests.rs
+++ b/pallets/validator/src/tests.rs
@@ -564,6 +564,36 @@ fn new_session_drops_pending_when_without_session_keys() {
 }
 
 #[test]
+fn dropped_pending_candidate_keeps_lock_and_stops_renewal() {
+    let lock_amount: Balance = <Test as crate::Config>::LockAmount::get();
+
+    new_test_ext(vec![(ALICE, lock_amount)]).execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        let expiry = ValidatorLocks::<Test>::get(ALICE).expect("locked").expiry_block;
+
+        // ALICE purges her session keys before the boundary can promote her.
+        MissingSessionKeys::mutate(|set| {
+            set.insert(ALICE);
+        });
+        new_session(1);
+
+        // Dropped without ever being seated, yet the stake is not handed back.
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("stake still committed");
+        assert_eq!(lock.status, ValidatorStatus::ExitRequested);
+        assert!(!pallet_balances::Locks::<Test>::get(ALICE).is_empty());
+        System::assert_last_event(Event::PendingValidatorDropped { who: ALICE }.into());
+
+        // Leaving `Active` stops auto-renewal, so the lock reaches its original
+        // expiry and clears there instead of rolling forward forever.
+        run_to_block(expiry - 1);
+        assert_eq!(ValidatorLocks::<Test>::get(ALICE).unwrap().expiry_block, expiry);
+        run_to_block(expiry);
+        assert!(ValidatorLocks::<Test>::get(ALICE).is_none());
+        assert!(pallet_balances::Locks::<Test>::get(ALICE).is_empty());
+    });
+}
+
+#[test]
 fn new_session_drops_pending_when_capacity_full() {
     let lock_amount: Balance = <Test as crate::Config>::LockAmount::get();
     let max_validators: u32 = <Test as crate::Config>::MaxValidators::get();
@@ -930,6 +960,41 @@ fn rejoin_after_exit_next_session_succeeds() {
     });
 }
 
+/// Rejoining on top of an unexpired lock must not become a way out of the
+/// time lock, however the fresh candidacy ends.
+#[test]
+fn relock_then_key_purge_keeps_lock_until_expiry() {
+    let lock_amount: Balance = <Test as crate::Config>::LockAmount::get();
+    let lock_duration: u64 = <Test as crate::Config>::LockDuration::get();
+
+    // ALICE holds exactly the stake, so recovering it needs no fresh funds.
+    new_test_ext(vec![(ALICE, lock_amount)]).execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        new_session(1);
+        assert_eq!(DesiredValidators::<Test>::get().to_vec(), vec![ALICE]);
+
+        // Exit, then a boundary drops ALICE from the active set.
+        assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+        new_session(2);
+        assert!(DesiredValidators::<Test>::get().is_empty());
+
+        // Rejoin over the unexpired lock, then purge the session keys so the
+        // next boundary drops the fresh candidacy.
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        MissingSessionKeys::mutate(|set| {
+            set.insert(ALICE);
+        });
+        new_session(3);
+
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("stake still committed");
+        assert_eq!(lock.amount, lock_amount);
+        assert_eq!(lock.expiry_block, 1 + lock_duration);
+        assert_eq!(lock.status, ValidatorStatus::ExitRequested);
+        assert!(System::block_number() < lock.expiry_block);
+        assert!(!pallet_balances::Locks::<Test>::get(ALICE).is_empty());
+    });
+}
+
 #[test]
 fn rejoin_after_offline_immediate_relock_rejected() {
     let lock_amount: Balance = <Test as crate::Config>::LockAmount::get();
@@ -1132,6 +1197,28 @@ fn exempt_account_locks_with_zero_balance() {
             Event::ValidatorLocked { who: EXEMPT, amount: 0, expiry_block: 1 + lock_duration }
                 .into(),
         );
+    });
+}
+
+#[test]
+fn relock_with_exemption_keeps_existing_stake_locked() {
+    let lock_amount: Balance = <Test as crate::Config>::LockAmount::get();
+
+    new_test_ext(vec![(ALICE, lock_amount)]).execute_with(|| {
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+        new_session(1);
+        assert_ok!(Validator::request_exit(RuntimeOrigin::signed(ALICE)));
+        new_session(2);
+
+        // The exemption lands while the old stake is still committed. It
+        // waives fresh stake, it does not cancel a running lock.
+        assert_ok!(Validator::set_stake_exempt(RuntimeOrigin::root(), ALICE, true));
+        assert_ok!(Validator::lock(RuntimeOrigin::signed(ALICE)));
+
+        let lock = ValidatorLocks::<Test>::get(ALICE).expect("stake still committed");
+        assert_eq!(lock.amount, lock_amount);
+        assert_eq!(lock.status, ValidatorStatus::Active);
+        assert!(!pallet_balances::Locks::<Test>::get(ALICE).is_empty());
     });
 }
 


### PR DESCRIPTION
Two paths handed a validator its stake back before expiry.

- Dropping a pending candidate called remove_lock unconditionally. It now only moves the status out of Active, which stops auto renewal and leaves the expiry sweep to release the stake, the same way voluntary exit and kick already work.
- Relocking recomputed the amount from scratch, so an exempt account with a running lock refreshed it down to zero, and set_lock treats zero as removal. A refresh now keeps whichever amount and expiry binds harder.

Chained together the two cut a 180 day commitment down to roughly 20 minutes at mainnet parameters. There is no slashing on this chain, so that lock is the entire economic cost of being a validator.

Rejoining on top of an unexpired lock stays allowed and still refreshes it, it just cannot shrink it. Every existing test passes unchanged.