### PR TITLE
Reject delegatecall into the balances-erc20 precompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6884,6 +6884,7 @@ dependencies = [
  "parity-scale-codec",
  "poscan",
  "poscan-pow",
+ "precompile-utils",
  "sc-executor",
  "scale-info",
  "serde",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -56,6 +56,7 @@ pallet-evm-precompile-modexp.workspace = true
 pallet-evm-precompile-sha3fips.workspace = true
 pallet-evm-precompile-simple.workspace = true
 pallet-evm-precompile-balances-erc20.workspace = true
+precompile-utils.workspace = true
 fp-evm.workspace = true
 fp-rpc.workspace = true
 fp-self-contained = { workspace = true, features = ["serde"] }
@@ -141,6 +142,7 @@ std = [
 	"pallet-evm-precompile-sha3fips/std",
 	"pallet-evm-precompile-simple/std",
 	"pallet-evm-precompile-balances-erc20/std",
+	"precompile-utils/std",
 	"fp-evm/std",
 	"fp-rpc/std",
 	"fp-self-contained/std",

--- a/runtime/src/configs/evm.rs
+++ b/runtime/src/configs/evm.rs
@@ -7,8 +7,6 @@
 //! the EVM `COINBASE` (`FindAuthor<H160>`) is pinned to the zero address; EVM
 //! fees are still routed to the substrate-side miner by [`EvmDealWithFees`].
 
-use core::marker::PhantomData;
-
 use frame_support::{
 	parameter_types,
 	traits::{
@@ -20,13 +18,16 @@ use frame_support::{
 use pallet_ethereum::PostLogContent;
 use pallet_evm::{
 	EnsureAddressNever, EnsureAddressRoot, EVMFungibleAdapter, HashedAddressMapping,
-	IsPrecompileResult, OnChargeEVMTransaction, Precompile, PrecompileHandle, PrecompileResult,
-	PrecompileSet,
+	OnChargeEVMTransaction,
 };
 use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
 use pallet_evm_precompile_balances_erc20::{Erc20BalancesPrecompile, Erc20Metadata};
 use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_simple::{ECRecover, Identity, Ripemd160, Sha256};
+use precompile_utils::precompile_set::{
+	AcceptDelegateCall, AddressU64, CallableByContract, CallableByPrecompile, PrecompileAt,
+	PrecompileSetBuilder,
+};
 use sp_core::{H160, U256};
 use sp_runtime::{
 	traits::BlakeTwo256,
@@ -64,7 +65,7 @@ parameter_types! {
 		weight_per_gas(BLOCK_GAS_LIMIT, NORMAL_DISPATCH_RATIO, WEIGHT_MILLIS_PER_BLOCK),
 		0,
 	);
-	pub PrecompilesValue: FrontierPrecompiles<Runtime> = FrontierPrecompiles::<_>::new();
+	pub PrecompilesValue: FrontierPrecompiles<Runtime> = FrontierPrecompiles::<Runtime>::new();
 }
 
 /// Local copy of [`fp_evm::weight_per_gas`] used here in `const`-friendly form.
@@ -95,6 +96,20 @@ impl Erc20Metadata for NativeErc20Metadata {
 	const DECIMALS: u8 = 18;
 }
 
+/// Call context policy for the stock Ethereum precompiles. They are pure
+/// functions of their input and mainnet lets every caller reach them, including
+/// through DELEGATECALL, so all three doors stay open to keep bytecode compiled
+/// for Ethereum working unchanged.
+pub type EthereumPrecompileChecks = (AcceptDelegateCall, CallableByContract, CallableByPrecompile);
+
+/// Call context policy for the ERC20 facade. It reads the funds owner from
+/// `context().caller`, which DELEGATECALL and CALLCODE rebind to the outer
+/// caller, so borrowed code could spend a third party balance. Omitting
+/// [`AcceptDelegateCall`] makes `PrecompileAt` reject those two opcodes. Plain
+/// CALL stays open to contracts and precompiles, where the caller really is the
+/// account being debited.
+pub type Erc20PrecompileChecks = (CallableByContract, CallableByPrecompile);
+
 /// Precompile set covering the standard Ethereum precompiles 1-8 plus the
 /// chain-specific `balances-erc20` precompile at `0x0000…0802`, which
 /// exposes the native balance pallet through an ERC20 interface and adds a
@@ -105,73 +120,29 @@ impl Erc20Metadata for NativeErc20Metadata {
 /// [`pallet_evm_precompile_modexp`]; the bn128 curve precompiles use
 /// [`pallet_evm_precompile_bn128`]; the chain-specific ERC20 facade comes
 /// from [`pallet_evm_precompile_balances_erc20`].
-pub struct FrontierPrecompiles<R>(PhantomData<R>);
-
-impl<R> FrontierPrecompiles<R>
-where
-	R: pallet_evm::Config,
-{
-	pub fn new() -> Self {
-		Self(PhantomData)
-	}
-	pub fn used_addresses() -> [H160; 9] {
-		[
-			hash(1),
-			hash(2),
-			hash(3),
-			hash(4),
-			hash(5),
-			hash(6),
-			hash(7),
-			hash(8),
-			hash(0x0802),
-		]
-	}
-}
-
-impl<R> Default for FrontierPrecompiles<R>
-where
-	R: pallet_evm::Config,
-{
-	fn default() -> Self {
-		Self::new()
-	}
-}
-
-impl<R> PrecompileSet for FrontierPrecompiles<R>
-where
-	R: pallet_evm::Config + pallet_timestamp::Config<Moment = u64>,
-	pallet_evm::AccountIdOf<R>: From<[u8; 32]>,
-	<<R as pallet_evm::Config>::Currency as frame_support::traits::Currency<
-		pallet_evm::AccountIdOf<R>,
-	>>::Balance: TryFrom<U256> + Into<U256>,
-{
-	fn execute(&self, handle: &mut impl PrecompileHandle) -> Option<PrecompileResult> {
-		match handle.code_address() {
-			a if a == hash(1) => Some(ECRecover::execute(handle)),
-			a if a == hash(2) => Some(Sha256::execute(handle)),
-			a if a == hash(3) => Some(Ripemd160::execute(handle)),
-			a if a == hash(4) => Some(Identity::execute(handle)),
-			a if a == hash(5) => Some(Modexp::execute(handle)),
-			a if a == hash(6) => Some(Bn128Add::execute(handle)),
-			a if a == hash(7) => Some(Bn128Mul::execute(handle)),
-			a if a == hash(8) => Some(Bn128Pairing::execute(handle)),
-			a if a == hash(0x0802) => Some(Erc20BalancesPrecompile::<R, NativeErc20Metadata>::execute(handle)),
-			_ => None,
-		}
-	}
-
-	fn is_precompile(&self, address: H160, _gas: u64) -> IsPrecompileResult {
-		IsPrecompileResult::Answer {
-			is_precompile: Self::used_addresses().contains(&address),
-			extra_cost: 0,
-		}
-	}
-}
-
-fn hash(a: u64) -> H160 {
-	H160::from_low_u64_be(a)
-}
+///
+/// Built with [`PrecompileSetBuilder`] rather than a hand written dispatcher so
+/// that every member goes through the upstream call context checks. A dispatcher
+/// that only matches on the code address silently accepts DELEGATECALL, which
+/// forges `msg.sender` for any precompile that trusts it.
+pub type FrontierPrecompiles<R> = PrecompileSetBuilder<
+	R,
+	(
+		PrecompileAt<AddressU64<1>, ECRecover, EthereumPrecompileChecks>,
+		PrecompileAt<AddressU64<2>, Sha256, EthereumPrecompileChecks>,
+		PrecompileAt<AddressU64<3>, Ripemd160, EthereumPrecompileChecks>,
+		PrecompileAt<AddressU64<4>, Identity, EthereumPrecompileChecks>,
+		PrecompileAt<AddressU64<5>, Modexp, EthereumPrecompileChecks>,
+		PrecompileAt<AddressU64<6>, Bn128Add, EthereumPrecompileChecks>,
+		PrecompileAt<AddressU64<7>, Bn128Mul, EthereumPrecompileChecks>,
+		PrecompileAt<AddressU64<8>, Bn128Pairing, EthereumPrecompileChecks>,
+		PrecompileAt<
+			AddressU64<0x802>,
+			Erc20BalancesPrecompile<R, NativeErc20Metadata>,
+			Erc20PrecompileChecks,
+		>,
+	),
+>;
 
 /// EVM fee handler routing both the base fee and the priority tip to the PoW
 /// miner. Base fee goes through [`DealWithFees`]; the tip is deposited to the

--- a/runtime/tests/attack_delegatecall_erc20.rs
+++ b/runtime/tests/attack_delegatecall_erc20.rs
@@ -1,0 +1,239 @@
+// Call context gate on the balances-erc20 precompile at `0x802`, driven through
+// a real `pallet_evm::runner::stack::Runner`.
+//
+// The precompile reads the funds owner from `context().caller`. DELEGATECALL
+// rebinds that field to the outer caller, so a dispatcher that only matches on
+// the code address lets any contract move a third party's native balance with
+// no approval. The set is built with `PrecompileSetBuilder`, whose checks reject
+// borrowed code while leaving plain CALL open to contracts.
+
+mod common;
+
+use common::new_test_ext;
+use frame_support::traits::tokens::fungible::Mutate;
+use numen_runtime::{AccountId, Balances, Runtime, UNIT};
+use pallet_evm::{AddressMapping, Runner};
+use sp_core::{H160, U256};
+
+const MAX_FEE_PER_GAS: u64 = 2_000_000_000;
+const GAS_LIMIT: u64 = 1_000_000;
+const ERC20_PRECOMPILE: u64 = 0x0802;
+
+fn evm_account(addr: H160) -> AccountId {
+    <Runtime as pallet_evm::Config>::AddressMapping::into_account_id(addr)
+}
+
+// Runtime bytecode that forwards its calldata verbatim into `0x802` via
+// DELEGATECALL, so the precompile sees the *outer* caller as `msg.sender`, then
+// returns the inner output so the test can read the revert reason.
+//
+//   CALLDATACOPY(0, 0, cds)                    copy calldata into memory
+//   DELEGATECALL(gas, 0x0802, 0, cds, 0, 0)    forward it
+//   POP                                        drop the success flag
+//   RETURNDATACOPY(0, 0, rds)                  keep whatever came back
+//   RETURN(0, rds)                             hand it to the caller
+//
+// A 12 byte constructor returns the 29 byte runtime code that follows it.
+const DELEGATECALL_FORWARDER_INIT: [u8; 41] = [
+    // constructor CODECOPYs the 29 byte runtime to memory 0 then RETURNs it
+    0x60, 0x1d, 0x60, 0x0c, 0x60, 0x00, 0x39, 0x60, 0x1d, 0x60, 0x00, 0xf3,
+    // forwarder body, CALLDATACOPY(dest=0, off=0, len=CALLDATASIZE)
+    0x36, 0x60, 0x00, 0x60, 0x00, 0x37,
+    // DELEGATECALL(gas=GAS, addr=0x0802, argsOff=0, argsLen=CALLDATASIZE, retOff=0, retLen=0)
+    0x60, 0x00, 0x60, 0x00, 0x36, 0x60, 0x00, 0x61, 0x08, 0x02, 0x5a, 0xf4,
+    // POP the success flag
+    0x50,
+    // RETURNDATACOPY(dest=0, off=0, len=RETURNDATASIZE)
+    0x3d, 0x60, 0x00, 0x60, 0x00, 0x3e,
+    // RETURN(off=0, len=RETURNDATASIZE)
+    0x3d, 0x60, 0x00, 0xf3,
+];
+
+// Same forwarder with CALL in place of DELEGATECALL. The precompile then sees
+// the contract itself as `msg.sender`, which is how a contract spends its own
+// balance.
+//
+//   CALLDATACOPY(0, 0, cds)                       copy calldata into memory
+//   CALL(gas, 0x0802, 0, 0, cds, 0, 0)            forward it
+//   POP                                           drop the success flag
+//   RETURNDATACOPY(0, 0, rds)                     keep whatever came back
+//   RETURN(0, rds)                                hand it to the caller
+const CALL_FORWARDER_INIT: [u8; 43] = [
+    // constructor CODECOPYs the 31 byte runtime to memory 0 then RETURNs it
+    0x60, 0x1f, 0x60, 0x0c, 0x60, 0x00, 0x39, 0x60, 0x1f, 0x60, 0x00, 0xf3,
+    // forwarder body, CALLDATACOPY(dest=0, off=0, len=CALLDATASIZE)
+    0x36, 0x60, 0x00, 0x60, 0x00, 0x37,
+    // CALL(gas=GAS, addr=0x0802, value=0, argsOff=0, argsLen=CALLDATASIZE, retOff=0, retLen=0)
+    0x60, 0x00, 0x60, 0x00, 0x36, 0x60, 0x00, 0x60, 0x00, 0x61, 0x08, 0x02, 0x5a, 0xf1,
+    // POP the success flag
+    0x50,
+    // RETURNDATACOPY(dest=0, off=0, len=RETURNDATASIZE)
+    0x3d, 0x60, 0x00, 0x60, 0x00, 0x3e,
+    // RETURN(off=0, len=RETURNDATASIZE)
+    0x3d, 0x60, 0x00, 0xf3,
+];
+
+/// `transfer(address,uint256)`.
+fn encode_transfer(to: H160, amount: u128) -> Vec<u8> {
+    let mut data = vec![0xa9, 0x05, 0x9c, 0xbb];
+    data.extend_from_slice(&[0u8; 12]);
+    data.extend_from_slice(to.as_bytes());
+    data.extend_from_slice(&U256::from(amount).to_big_endian());
+    data
+}
+
+fn deploy_forwarder(deployer: H160, init_code: &[u8]) -> H160 {
+    let info = <Runtime as pallet_evm::Config>::Runner::create(
+        deployer,
+        init_code.to_vec(),
+        U256::zero(),
+        GAS_LIMIT,
+        Some(U256::from(MAX_FEE_PER_GAS)),
+        None,
+        None,
+        Vec::new(),
+        Vec::new(),
+        true,
+        true,
+        None,
+        None,
+        <Runtime as pallet_evm::Config>::config(),
+    )
+    .map_err(|e| e.error)
+    .expect("create dispatches without runtime error");
+    assert!(info.exit_reason.is_succeed(), "deploy failed: {:?}", info.exit_reason);
+    info.value
+}
+
+fn call_contract(caller: H160, target: H160, data: Vec<u8>) -> fp_evm::CallInfo {
+    <Runtime as pallet_evm::Config>::Runner::call(
+        caller,
+        target,
+        data,
+        U256::zero(),
+        GAS_LIMIT,
+        Some(U256::from(MAX_FEE_PER_GAS)),
+        None,
+        None,
+        Vec::new(),
+        Vec::new(),
+        true,
+        true,
+        None,
+        None,
+        None,
+        <Runtime as pallet_evm::Config>::config(),
+    )
+    .map_err(|e| e.error)
+    .expect("call dispatches without runtime error")
+}
+
+/// A victim who calls an attacker's ordinary-looking contract keeps their native
+/// balance. The contract DELEGATECALLs the ERC-20 precompile, which would read
+/// the victim as `msg.sender`, so the precompile refuses to run at all.
+#[test]
+fn delegatecall_into_erc20_precompile_is_rejected() {
+    new_test_ext().execute_with(|| {
+        let deployer = H160::from_low_u64_be(0xDEAD_BEEF);
+        let victim = H160::from_low_u64_be(0x0000_1C71); // "victim"
+        let attacker = H160::from_low_u64_be(0x0000_0BAD);
+
+        // Deployer pays gas; victim holds the loot; attacker starts empty.
+        Balances::set_balance(&evm_account(deployer), 100 * UNIT);
+        let victim_start = 7_500 * UNIT;
+        Balances::set_balance(&evm_account(victim), victim_start);
+        assert_eq!(Balances::free_balance(evm_account(attacker)), 0);
+
+        let forwarder = deploy_forwarder(deployer, &DELEGATECALL_FORWARDER_INIT);
+
+        // Victim calls the forwarder. No `approve` was ever issued. The steal
+        // amount is baked into the calldata the victim unwittingly forwards.
+        let steal = 1_000 * UNIT;
+        let info = call_contract(victim, forwarder, encode_transfer(attacker, steal));
+        assert!(
+            info.exit_reason.is_succeed(),
+            "the forwarder itself must not fail: {:?}",
+            info.exit_reason
+        );
+
+        // The forwarder bubbles up whatever the precompile returned.
+        let returned = String::from_utf8_lossy(&info.value).into_owned();
+        assert!(
+            returned.contains("Cannot be called with DELEGATECALL or CALLCODE"),
+            "expected the delegate call gate to fire, got {returned:?}",
+        );
+
+        assert_eq!(
+            Balances::free_balance(evm_account(attacker)),
+            0,
+            "attacker must not receive anything",
+        );
+        let victim_end = Balances::free_balance(evm_account(victim));
+        assert!(
+            victim_end > victim_start - steal,
+            "victim must only pay gas, never the steal amount: {victim_start} -> {victim_end}",
+        );
+    });
+}
+
+/// Sanity contrast. A direct (non-delegate) call to the precompile debits the
+/// caller's own account, as intended.
+#[test]
+fn direct_call_to_erc20_precompile_debits_the_real_caller() {
+    new_test_ext().execute_with(|| {
+        let caller = H160::from_low_u64_be(0x0000_C1A1);
+        let recipient = H160::from_low_u64_be(0x0000_0BAD);
+        Balances::set_balance(&evm_account(caller), 7_500 * UNIT);
+        assert_eq!(Balances::free_balance(evm_account(recipient)), 0);
+
+        let amount = 1_000 * UNIT;
+        let precompile = H160::from_low_u64_be(ERC20_PRECOMPILE);
+        let info = call_contract(caller, precompile, encode_transfer(recipient, amount));
+        assert!(info.exit_reason.is_succeed(), "{:?}", info.exit_reason);
+
+        // Funds come out of the caller, never a third party.
+        assert_eq!(Balances::free_balance(evm_account(recipient)), amount);
+    });
+}
+
+/// Contracts must keep reaching the precompile through a plain CALL and spend
+/// their own balance. This is the half of the call context policy that a missing
+/// `CallableByContract` would silently break, and no other test covers it
+/// because every other caller here is an EOA.
+#[test]
+fn contract_call_to_erc20_precompile_debits_the_calling_contract() {
+    new_test_ext().execute_with(|| {
+        let deployer = H160::from_low_u64_be(0xDEAD_BEEF);
+        let recipient = H160::from_low_u64_be(0x0000_B0B0);
+        Balances::set_balance(&evm_account(deployer), 100 * UNIT);
+
+        let forwarder = deploy_forwarder(deployer, &CALL_FORWARDER_INIT);
+        let forwarder_start = 5_000 * UNIT;
+        Balances::set_balance(&evm_account(forwarder), forwarder_start);
+        assert_eq!(Balances::free_balance(evm_account(recipient)), 0);
+
+        let amount = 1_000 * UNIT;
+        let info = call_contract(deployer, forwarder, encode_transfer(recipient, amount));
+        assert!(
+            info.exit_reason.is_succeed(),
+            "contract call reverted: {:?}",
+            info.exit_reason
+        );
+        // Length first, so a rejected contract call reports the revert reason
+        // instead of panicking inside `from_big_endian`.
+        assert_eq!(
+            info.value.len(),
+            32,
+            "expected a single ABI word, got {:?}",
+            String::from_utf8_lossy(&info.value),
+        );
+        assert_eq!(U256::from_big_endian(&info.value), U256::one(), "transfer returns bool true");
+
+        assert_eq!(Balances::free_balance(evm_account(recipient)), amount);
+        assert_eq!(
+            Balances::free_balance(evm_account(forwarder)),
+            forwarder_start - amount,
+            "the contract is the spender, gas stays on the deployer",
+        );
+    });
+}


### PR DESCRIPTION
The hand written PrecompileSet matched on the code address and nothing else, so DELEGATECALL and CALLCODE reached the balances-erc20 precompile at 0x802 with context().caller still naming the outer caller. The precompile reads the funds owner from that field, so any contract could move a third party's native balance with no approval. transferFrom was no defence either, since a forged caller makes from == spender and skips the allowance check. Two paths were live, a victim calling an attacker's contract, and any contract that calls out to an attacker controlled address.

Upstream ships the gate for this in common_checks, but it only runs from PrecompileAt and PrecompileSetStartingWith, so the hand written set never reached it. The dispatcher is gone and the set is now built with PrecompileSetBuilder, where every member declares its own call policy.

Ethereum precompiles 1 through 8 keep AcceptDelegateCall so bytecode compiled for mainnet keeps working. 0x802 declares CallableByContract and CallableByPrecompile only, which closes the hole while leaving plain CALL open to contracts.

The checks cost one db read per precompile call for the caller address type lookup, roughly 1250 gas at the current WeightPerGas. That lands on the cheap Ethereum precompiles too, identity goes from 15 to 1265. Worth paying before launch, not after.

Three tests drive a real stack Runner with hand written forwarder contracts. Delegatecall is rejected and the victim keeps the funds, an EOA call still debits the caller, and a contract making a plain CALL still spends its own balance. That last one is the sentinel for CallableByContract, since every other EVM test in the tree calls from an EOA. Both halves were mutation checked, dropping CallableByContract turns the contract test red and adding AcceptDelegateCall turns the delegatecall test red.
