### PR TITLE
Stop the vesting lock from advertising a fee exemption

### DIFF
--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -324,10 +324,12 @@ parameter_types! {
 	/// A grant small enough to fall under this is not worth the storage a
 	/// schedule costs. One NUMN is a million times the existential deposit.
 	pub const MinVestedTransfer: Balance = UNIT;
-	/// Unvested funds still pay fees and back governance deposits. Only moving
-	/// them out of the account is fenced off.
-	pub UnvestedFundsAllowedWithdrawReasons: WithdrawReasons =
-		WithdrawReasons::except(WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE);
+	/// `pallet-balances` folds every lock into one frozen figure and drops the
+	/// reasons each carries, so this set buys no exemption whatever it holds.
+	/// Empty spells out what actually happens, which is that unvested funds are
+	/// fenced off from every use. A grant needs free balance beside it or the
+	/// account cannot even afford to vest.
+	pub UnvestedFundsAllowedWithdrawReasons: WithdrawReasons = WithdrawReasons::empty();
 }
 
 impl pallet_vesting::Config for Runtime {

--- a/runtime/tests/vesting.rs
+++ b/runtime/tests/vesting.rs
@@ -1,14 +1,14 @@
 //! pallet-vesting wired for the airdrop. A vested transfer locks the grant and
 //! releases it linearly per block. These pin the release curve, the completion
-//! that clears the lock, and that the lock also binds the Frontier EVM view so
-//! locked funds cannot leave through an EVM entry.
+//! that clears the lock, and the two ways funds might slip out early, through
+//! fees or through the Frontier EVM view.
 
 mod common;
 
 use common::new_test_ext;
 use frame_support::{
 	assert_noop, assert_ok,
-	traits::tokens::fungible::Mutate,
+	traits::{tokens::fungible::Mutate, Currency, ExistenceRequirement, WithdrawReasons},
 };
 use numen_runtime::{AccountId, Balances, Runtime, RuntimeOrigin, System, Vesting, EVM, UNIT};
 use pallet_evm::AddressMapping;
@@ -96,6 +96,36 @@ fn vest_completes_and_clears_schedule_after_full_term() {
 			GRANT,
 		));
 		assert_eq!(Balances::free_balance(&sink), GRANT);
+	});
+}
+
+/// The reason set on the vesting lock reads as though fees might slip through.
+/// They cannot. Pinned so a future edit to that set does not quietly turn into
+/// a real exemption.
+#[test]
+fn fees_cannot_draw_on_the_locked_grant() {
+	new_test_ext().execute_with(|| {
+		let alice = Sr25519Keyring::Alice.to_account_id();
+		let bob = Sr25519Keyring::Bob.to_account_id();
+		airdrop_to(&alice, &bob);
+
+		let fee = |amount: u128| {
+			<Balances as Currency<AccountId>>::withdraw(
+				&bob,
+				amount,
+				WithdrawReasons::TRANSACTION_PAYMENT,
+				ExistenceRequirement::KeepAlive,
+			)
+		};
+
+		assert_noop!(fee(1), pallet_balances::Error::<Runtime>::LiquidityRestrictions);
+
+		// The elapsed share is the whole fee budget, down to the last planck.
+		System::set_block_number(START + 50);
+		assert_ok!(Vesting::vest(RuntimeOrigin::signed(bob.clone())));
+		let released = 50 * PER_BLOCK;
+		assert_noop!(fee(released + 1), pallet_balances::Error::<Runtime>::LiquidityRestrictions);
+		assert_ok!(fee(released));
 	});
 }
 


### PR DESCRIPTION
`pallet-balances` drops the reasons a lock carries and folds every lock into a single frozen figure, so `except(TRANSFER | RESERVE)` never granted anything. It only read as though unvested funds could pay fees, which is the opposite of what the chain does.

Behavior is unchanged. The empty set states what already happens and the new test pins it, so the next edit to that set cannot quietly turn into a real exemption.