### PR TITLE
build releases with production flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
       - uses: ./.github/actions/free-disk-space
       - uses: ./.github/actions/ubuntu-dependencies
       - name: Build runtime wasm (no_std)
-        run: cargo check -p numen-runtime --locked
-        timeout-minutes: 30
+        run: cargo check -p numen-runtime --locked --features metadata-hash
+        timeout-minutes: 45
 
   determinism:
     name: determinism (${{ matrix.arch }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,13 +122,13 @@ jobs:
         uses: ./.github/actions/macos-dependencies
 
       - name: Build node
-        run: cargo build --release
-        timeout-minutes: 30
+        run: cargo build --profile production --locked -p numen --features metadata-hash
+        timeout-minutes: 90
 
       - name: Bundle release archive
         run: |
           mkdir -p ${{ matrix.asset }}
-          cp target/release/numen ${{ matrix.asset }}/
+          cp target/production/numen ${{ matrix.asset }}/
           cp testnet-raw.json ${{ matrix.asset }}/
           tar -czf ${{ matrix.asset }}.tar.gz ${{ matrix.asset }}
 

--- a/docs/how-to-build.md
+++ b/docs/how-to-build.md
@@ -148,3 +148,21 @@ The first build compiles all dependencies and may take 20–60 minutes.
 |-----------|---------|
 | RAM       |    6 GB |
 | Disk      |   12 GB |
+
+### Release Build
+
+The published binaries are built differently. Use this if you want to reproduce one.
+
+```bash
+cargo build --profile production --locked -p numen --features metadata-hash
+```
+
+The binary lands in `target/production/numen`.
+
+Two things set it apart from a plain `cargo build`.
+
+The `production` profile turns on fat LTO and a single codegen unit. Faster node, slower build, more memory.
+
+The `metadata-hash` feature bakes the runtime metadata hash into the wasm. Hardware wallets like Ledger and Polkadot Vault need it to verify what they sign. Costs a second wasm build.
+
+Expect well over an hour on a cold cache.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -120,6 +120,9 @@ substrate-build-script-utils.workspace = true
 [features]
 default = ["std"]
 std = ["numen-runtime/std"]
+# Bake the metadata hash into the runtime so hardware wallets can verify
+# what they sign. Off by default because it builds the wasm twice.
+metadata-hash = ["numen-runtime/metadata-hash"]
 # Dependencies that are only required if runtime benchmarking should be build.
 runtime-benchmarks = [
 	"frame-benchmarking-cli/runtime-benchmarks",


### PR DESCRIPTION
Plain `cargo build --release` meant neither flag ever took effect.

`[profile.production]` had been sitting unused in the workspace manifest, so every released node shipped without LTO.

`CheckMetadataHash` has been in `TxExtension` all along, but nothing ever baked `RUNTIME_METADATA_HASH`, leaving it `None`. Hardware wallets that ask for metadata verification get refused, so Ledger and Polkadot Vault cannot sign for this chain.

CI builds the wasm with `metadata-hash` now as well. That branch of build.rs had never once been compiled, and a break in it would only show up at tag time.
